### PR TITLE
feat: Line Bot Agent 整合與對話重置功能

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2025 擎添工業 Ching Tech Industrial Co., Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@ ChingTech OS 是擎添工業打造的整合式智慧工作空間，以 Web 技�
 | 檔案管理 | 完成 | NAS 檔案瀏覽、上傳、下載、刪除、搜尋、預覽 |
 | 終端機 | 完成 | PTY shell session、WebSocket 即時通訊、多終端機 |
 | AI 助手 | 完成 | 對話介面、多對話管理、歷史持久化、Markdown 渲染 |
+| AI 管理 | 完成 | Agent 設定、Prompt 管理、AI Log 查詢 |
 | 知識庫 | 完成 | Markdown 知識管理、全文搜尋、版本歷史、附件管理 |
 | 程式編輯器 | 完成 | code-server 整合（VS Code 體驗） |
 | 文字檢視器 | 完成 | Markdown/JSON/YAML/XML 格式化顯示、語法色彩 |
 | 專案管理 | 完成 | 專案、成員、會議、附件、連結、里程碑管理 |
+| Line Bot | 完成 | 群組管理、訊息記錄、用戶綁定、AI 對話整合 |
 | 訊息中心 | 完成 | 系統訊息、登入記錄追蹤、未讀狀態管理 |
+| 使用者管理 | 完成 | 使用者列表、功能權限設定（管理員） |
 | 系統設定 | 完成 | 亮色/暗色主題切換 |
 
 ## 快速開始
@@ -43,7 +46,7 @@ uv sync
 uv run alembic upgrade head
 
 # 3. 啟動後端服務
-uv run uvicorn ching_tech_os.main:socket_app --host 0.0.0.0 --port 8089
+uv run uvicorn ching_tech_os.main:socket_app --host 0.0.0.0 --port 8088
 
 # 4. 啟動前端（另開終端）
 cd frontend
@@ -70,6 +73,9 @@ python3 -m http.server 8080
 - Socket.IO (終端機、AI 即時通訊)
 - SMB/CIFS (NAS 檔案存取)
 - Alembic (資料庫 migration)
+- Line Bot SDK v3 (Line Messaging API)
+- Claude CLI (AI 對話處理)
+- MCP Server (AI 工具整合)
 
 ### 基礎設施
 - PostgreSQL (Docker 容器)
@@ -121,9 +127,12 @@ ching-tech-os/
 |------|------|
 | [docs/database-design.md](docs/database-design.md) | 資料庫設計、Alembic Migration |
 | [docs/ai-agent-design.md](docs/ai-agent-design.md) | AI Agent 架構設計 |
+| [docs/ai-management.md](docs/ai-management.md) | AI 管理系統（Agent、Prompt、Log） |
 | [docs/realtime.md](docs/realtime.md) | Socket.IO 即時通訊、終端機 PTY |
 | [docs/smb-nas-architecture.md](docs/smb-nas-architecture.md) | SMB/NAS 檔案系統架構 |
 | [docs/file-manager.md](docs/file-manager.md) | 檔案管理器設計 |
+| [docs/linebot.md](docs/linebot.md) | Line Bot 整合設計 |
+| [docs/mcp-server.md](docs/mcp-server.md) | MCP Server（AI 工具） |
 
 ### 部署與安全
 
@@ -142,9 +151,11 @@ ching-tech-os/
 ## API 文件
 
 啟動後端後，訪問：
-- Swagger UI: http://localhost:8089/docs
-- ReDoc: http://localhost:8089/redoc
+- Swagger UI: http://localhost:8088/docs
+- ReDoc: http://localhost:8088/redoc
 
 ## 授權
 
-&copy; 2024-2025 擎添工業 Ching Tech Industrial Co., Ltd.
+MIT License
+
+Copyright (c) 2024-2025 擎添工業 Ching Tech Industrial Co., Ltd.

--- a/backend/migrations/versions/013_update_linebot_prompts.py
+++ b/backend/migrations/versions/013_update_linebot_prompts.py
@@ -1,0 +1,104 @@
+"""update linebot prompts with MCP tools
+
+Revision ID: 013
+Revises: 012
+Create Date: 2025-12-31
+
+更新 linebot-personal 和 linebot-group 的 prompt 內容，
+加入完整的 MCP 工具說明。
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "013"
+down_revision: str | None = "012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# 完整的 linebot-personal prompt
+LINEBOT_PERSONAL_PROMPT = """你是擎添工業的 AI 助理，透過 Line 與用戶進行個人對話。
+
+你可以使用以下工具：
+
+【專案查詢】
+- query_project: 查詢專案（可用關鍵字搜尋，取得專案 ID）
+- get_project_milestones: 取得專案里程碑（需要 project_id）
+- get_project_meetings: 取得專案會議記錄（需要 project_id）
+- get_project_members: 取得專案成員與聯絡人（需要 project_id）
+
+【知識庫】
+- search_knowledge: 搜尋知識庫（輸入關鍵字，回傳標題列表）
+- get_knowledge_item: 取得知識庫文件完整內容（輸入 kb_id，如 kb-001）
+- update_knowledge_item: 更新知識庫文件（可更新標題、內容、分類、標籤）
+- delete_knowledge_item: 刪除知識庫文件
+- add_note: 新增筆記到知識庫（輸入標題和內容）
+
+使用工具的流程：
+1. 先用 query_project 搜尋專案名稱取得 ID
+2. 查詢知識庫時，先用 search_knowledge 找到文件 ID，再用 get_knowledge_item 取得完整內容
+3. 用戶要求「記住」或「記錄」某事時，使用 add_note 新增筆記
+4. 用戶要求修改或更新知識時，使用 update_knowledge_item
+5. 用戶要求刪除知識時，使用 delete_knowledge_item
+
+回應原則：
+- 使用繁體中文
+- 語氣親切專業
+- 善用工具查詢資訊，主動提供有用的資料
+- 回覆用戶時不要顯示 UUID，只顯示名稱"""
+
+# 精簡的 linebot-group prompt
+LINEBOT_GROUP_PROMPT = """你是擎添工業的 AI 助理，在 Line 群組中協助回答問題。
+
+可用工具：
+- query_project / get_project_milestones / get_project_meetings / get_project_members: 專案相關查詢
+- search_knowledge / get_knowledge_item: 知識庫查詢
+- add_note: 新增筆記
+- summarize_chat: 取得群組聊天記錄摘要
+
+回應原則：
+- 使用繁體中文
+- 回覆簡潔（不超過 200 字）
+- 善用工具查詢資訊
+- 不顯示 UUID，只顯示名稱"""
+
+
+def upgrade() -> None:
+    # 更新 linebot-personal prompt
+    op.execute(f"""
+        UPDATE ai_prompts
+        SET content = $prompt${LINEBOT_PERSONAL_PROMPT}$prompt$,
+            description = 'Line Bot 個人對話使用，包含完整 MCP 工具說明',
+            updated_at = NOW()
+        WHERE name = 'linebot-personal'
+    """)
+
+    # 更新 linebot-group prompt
+    op.execute(f"""
+        UPDATE ai_prompts
+        SET content = $prompt${LINEBOT_GROUP_PROMPT}$prompt$,
+            description = 'Line Bot 群組對話使用，精簡版包含 MCP 工具說明',
+            updated_at = NOW()
+        WHERE name = 'linebot-group'
+    """)
+
+
+def downgrade() -> None:
+    # 還原為簡單版本
+    op.execute("""
+        UPDATE ai_prompts
+        SET content = '你是使用者的個人 AI 助理。可以幫助查詢資訊、管理筆記、回答問題。使用繁體中文，語氣親切專業。',
+            description = 'Line Bot 個人對話使用',
+            updated_at = NOW()
+        WHERE name = 'linebot-personal'
+    """)
+
+    op.execute("""
+        UPDATE ai_prompts
+        SET content = '你是群組中的 AI 助手。回答要簡短（不超過 200 字），使用繁體中文。只在被 @ 或直接詢問時回應。',
+            description = 'Line Bot 群組對話使用',
+            updated_at = NOW()
+        WHERE name = 'linebot-group'
+    """)

--- a/backend/migrations/versions/014_add_conversation_reset.py
+++ b/backend/migrations/versions/014_add_conversation_reset.py
@@ -1,0 +1,38 @@
+"""add conversation_reset_at to line_users
+
+Revision ID: 014
+Revises: 013
+Create Date: 2025-12-31
+
+新增對話重置時間欄位，用於「忘記對話」功能。
+查詢對話歷史時，只取這個時間之後的訊息。
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "014"
+down_revision: str | None = "013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 新增對話重置時間欄位
+    op.execute("""
+        ALTER TABLE line_users
+        ADD COLUMN IF NOT EXISTS conversation_reset_at TIMESTAMPTZ
+    """)
+    op.execute("""
+        COMMENT ON COLUMN line_users.conversation_reset_at IS
+        '對話重置時間，查詢歷史時只取這個時間之後的訊息'
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        ALTER TABLE line_users
+        DROP COLUMN IF EXISTS conversation_reset_at
+    """)

--- a/backend/src/ching_tech_os/main.py
+++ b/backend/src/ching_tech_os/main.py
@@ -13,6 +13,7 @@ from .database import init_db_pool, close_db_pool
 from .services.session import session_manager
 from .services.terminal import terminal_service
 from .services.scheduler import start_scheduler, stop_scheduler
+from .services.linebot_agents import ensure_default_linebot_agents
 from .api import auth, knowledge, login_records, messages, nas, user, ai_router, ai_management, project, linebot_router
 
 # 建立 Socket.IO 伺服器
@@ -24,6 +25,7 @@ async def lifespan(app: FastAPI):
     """應用程式生命週期管理"""
     # 啟動時
     await init_db_pool()
+    await ensure_default_linebot_agents()  # 確保 Line Bot Agent 存在
     await session_manager.start_cleanup_task()
     await terminal_service.start_cleanup_task()
     start_scheduler()

--- a/backend/src/ching_tech_os/services/linebot_agents.py
+++ b/backend/src/ching_tech_os/services/linebot_agents.py
@@ -1,0 +1,159 @@
+"""Line Bot Agent 初始化與管理
+
+在應用程式啟動時確保預設的 Line Bot Agent 存在。
+"""
+
+import logging
+
+from . import ai_manager
+from ..models.ai import AiPromptCreate, AiAgentCreate
+
+logger = logging.getLogger("linebot_agents")
+
+# Agent 名稱常數
+AGENT_LINEBOT_PERSONAL = "linebot-personal"
+AGENT_LINEBOT_GROUP = "linebot-group"
+
+# 完整的 linebot-personal prompt
+LINEBOT_PERSONAL_PROMPT = """你是擎添工業的 AI 助理，透過 Line 與用戶進行個人對話。
+
+你可以使用以下工具：
+
+【專案查詢】
+- query_project: 查詢專案（可用關鍵字搜尋，取得專案 ID）
+- get_project_milestones: 取得專案里程碑（需要 project_id）
+- get_project_meetings: 取得專案會議記錄（需要 project_id）
+- get_project_members: 取得專案成員與聯絡人（需要 project_id）
+
+【知識庫】
+- search_knowledge: 搜尋知識庫（輸入關鍵字，回傳標題列表）
+- get_knowledge_item: 取得知識庫文件完整內容（輸入 kb_id，如 kb-001）
+- update_knowledge_item: 更新知識庫文件（可更新標題、內容、分類、標籤）
+- delete_knowledge_item: 刪除知識庫文件
+- add_note: 新增筆記到知識庫（輸入標題和內容）
+
+使用工具的流程：
+1. 先用 query_project 搜尋專案名稱取得 ID
+2. 查詢知識庫時，先用 search_knowledge 找到文件 ID，再用 get_knowledge_item 取得完整內容
+3. 用戶要求「記住」或「記錄」某事時，使用 add_note 新增筆記
+4. 用戶要求修改或更新知識時，使用 update_knowledge_item
+5. 用戶要求刪除知識時，使用 delete_knowledge_item
+
+對話管理：
+- 用戶可以發送 /新對話 或 /reset 來清除對話歷史，開始新對話
+- 當用戶說「忘記之前的對話」或類似內容時，建議他們使用 /新對話 指令
+
+回應原則：
+- 使用繁體中文
+- 語氣親切專業
+- 善用工具查詢資訊，主動提供有用的資料
+- 回覆用戶時不要顯示 UUID，只顯示名稱"""
+
+# 精簡的 linebot-group prompt
+LINEBOT_GROUP_PROMPT = """你是擎添工業的 AI 助理，在 Line 群組中協助回答問題。
+
+可用工具：
+- query_project / get_project_milestones / get_project_meetings / get_project_members: 專案相關查詢
+- search_knowledge / get_knowledge_item: 知識庫查詢
+- add_note: 新增筆記
+- summarize_chat: 取得群組聊天記錄摘要
+
+回應原則：
+- 使用繁體中文
+- 回覆簡潔（不超過 200 字）
+- 善用工具查詢資訊
+- 不顯示 UUID，只顯示名稱"""
+
+# 預設 Agent 設定
+DEFAULT_LINEBOT_AGENTS = [
+    {
+        "name": AGENT_LINEBOT_PERSONAL,
+        "display_name": "Line 個人助理",
+        "description": "Line Bot 個人對話 Agent",
+        "model": "claude-sonnet",
+        "prompt": {
+            "name": AGENT_LINEBOT_PERSONAL,
+            "display_name": "Line 個人助理 Prompt",
+            "category": "linebot",
+            "content": LINEBOT_PERSONAL_PROMPT,
+            "description": "Line Bot 個人對話使用，包含完整 MCP 工具說明",
+        },
+    },
+    {
+        "name": AGENT_LINEBOT_GROUP,
+        "display_name": "Line 群組助理",
+        "description": "Line Bot 群組對話 Agent",
+        "model": "claude-haiku",
+        "prompt": {
+            "name": AGENT_LINEBOT_GROUP,
+            "display_name": "Line 群組助理 Prompt",
+            "category": "linebot",
+            "content": LINEBOT_GROUP_PROMPT,
+            "description": "Line Bot 群組對話使用，精簡版包含 MCP 工具說明",
+        },
+    },
+]
+
+
+async def ensure_default_linebot_agents() -> None:
+    """
+    確保預設的 Line Bot Agent 存在。
+
+    如果 Agent 已存在則跳過（保留使用者修改）。
+    如果不存在則建立 Agent 和對應的 Prompt。
+    """
+    for agent_config in DEFAULT_LINEBOT_AGENTS:
+        agent_name = agent_config["name"]
+
+        # 檢查 Agent 是否存在
+        existing_agent = await ai_manager.get_agent_by_name(agent_name)
+        if existing_agent:
+            logger.debug(f"Agent '{agent_name}' 已存在，跳過建立")
+            continue
+
+        # 檢查 Prompt 是否存在
+        prompt_config = agent_config["prompt"]
+        existing_prompt = await ai_manager.get_prompt_by_name(prompt_config["name"])
+
+        if existing_prompt:
+            prompt_id = existing_prompt["id"]
+            logger.debug(f"Prompt '{prompt_config['name']}' 已存在，使用現有 Prompt")
+        else:
+            # 建立 Prompt
+            prompt_data = AiPromptCreate(
+                name=prompt_config["name"],
+                display_name=prompt_config["display_name"],
+                category=prompt_config["category"],
+                content=prompt_config["content"],
+                description=prompt_config["description"],
+            )
+            new_prompt = await ai_manager.create_prompt(prompt_data)
+            prompt_id = new_prompt["id"]
+            logger.info(f"已建立 Prompt: {prompt_config['name']}")
+
+        # 建立 Agent
+        agent_data = AiAgentCreate(
+            name=agent_config["name"],
+            display_name=agent_config["display_name"],
+            description=agent_config["description"],
+            model=agent_config["model"],
+            system_prompt_id=prompt_id,
+            is_active=True,
+        )
+        await ai_manager.create_agent(agent_data)
+        logger.info(f"已建立 Agent: {agent_name}")
+
+
+async def get_linebot_agent(is_group: bool) -> dict | None:
+    """
+    取得 Line Bot Agent 設定。
+
+    Args:
+        is_group: 是否為群組對話
+
+    Returns:
+        Agent 設定字典，包含 model 和 system_prompt
+        如果找不到則回傳 None
+    """
+    agent_name = AGENT_LINEBOT_GROUP if is_group else AGENT_LINEBOT_PERSONAL
+    return await ai_manager.get_agent_by_name(agent_name)

--- a/openspec/changes/archive/2025-12-31-2025-12-31-linebot-agent-integration/design.md
+++ b/openspec/changes/archive/2025-12-31-2025-12-31-linebot-agent-integration/design.md
@@ -1,0 +1,139 @@
+## Context
+
+Line Bot 的 AI 功能目前使用硬編碼的 System Prompt，未整合 ai-management 系統。需要修改為使用資料庫中的 Agent 設定，以符合原始設計。
+
+### 現狀
+
+```python
+# linebot_ai.py - 硬編碼
+system_prompt = await build_system_prompt(line_group_id)  # 硬編碼 prompt
+response = await call_claude(
+    prompt=user_message,
+    model="sonnet",  # 硬編碼 model
+    ...
+)
+
+# log 記錄時
+agent = await ai_manager.get_agent_by_name("linebot")  # 找不到
+agent_id = agent["id"] if agent else None  # 變成 None
+```
+
+### 目標
+
+```python
+# 改為從 Agent 取得設定
+agent_name = "linebot-group" if is_group else "linebot-personal"
+agent = await ai_manager.get_agent_by_name(agent_name)
+system_prompt = agent["system_prompt"]["content"]
+model = agent["model"]  # claude-haiku 或 claude-sonnet
+
+response = await call_claude(
+    prompt=user_message,
+    model=model,
+    system_prompt=system_prompt,
+    ...
+)
+```
+
+## Goals / Non-Goals
+
+### Goals
+- Line Bot 使用資料庫中的 Agent/Prompt 設定
+- 區分 `linebot-personal` 和 `linebot-group` 兩種情境
+- AI Log 正確關聯到 Agent
+- 應用程式啟動時自動建立預設 Agent（如不存在）
+
+### Non-Goals
+- 不修改前端 UI
+- 不提供 API 動態切換 Agent
+
+## Decisions
+
+### 1. Agent 選擇邏輯
+
+根據對話類型選擇 Agent：
+- 個人對話（`line_group_id is None`）→ `linebot-personal`
+- 群組對話（`line_group_id is not None`）→ `linebot-group`
+
+### 2. 預設 Agent 初始化
+
+在 FastAPI 啟動時（lifespan event）檢查並建立預設 Agent：
+
+```python
+DEFAULT_LINEBOT_AGENTS = [
+    {
+        "name": "linebot-personal",
+        "display_name": "Line Bot 個人助理",
+        "model": "claude-sonnet",
+        "prompt": {
+            "name": "linebot-personal",
+            "content": "...",  # 包含 MCP 工具說明
+            "category": "linebot",
+        }
+    },
+    {
+        "name": "linebot-group",
+        "display_name": "Line Bot 群組助理",
+        "model": "claude-haiku",
+        "prompt": {
+            "name": "linebot-group",
+            "content": "...",  # 簡短版本
+            "category": "linebot",
+        }
+    },
+]
+```
+
+### 3. Prompt 內容設計
+
+**linebot-personal**（完整版）：
+- 包含 MCP 工具說明（專案查詢、知識庫）
+- 語氣親切專業
+- 不限制回覆長度
+
+**linebot-group**（精簡版）：
+- 包含 MCP 工具說明
+- 限制回覆長度（不超過 200 字）
+- 語氣簡潔
+
+### 4. 群組綁定專案的處理
+
+保留現有的動態注入邏輯，在 Agent 的 Prompt 基礎上附加群組資訊：
+
+```python
+# 從 Agent 取得基礎 prompt
+base_prompt = agent["system_prompt"]["content"]
+
+# 如果是群組且有綁定專案，附加資訊
+if line_group_id and group_info:
+    base_prompt += f"\n\n目前群組：{group_info['name']}"
+    if group_info["project_name"]:
+        base_prompt += f"\n綁定專案：{group_info['project_name']}"
+        base_prompt += f"\n專案 ID：{group_info['project_id']}"
+```
+
+### 5. Fallback 機制
+
+如果 Agent 不存在（理論上不會發生，因為啟動時會建立）：
+- 使用硬編碼的預設 Prompt 作為 fallback
+- 記錄警告日誌
+
+## Risks / Trade-offs
+
+### Risks
+1. **啟動時間增加** - 需要檢查/建立 Agent
+   - 緩解：僅在 Agent 不存在時才 INSERT
+
+2. **Prompt 被誤刪** - 使用者可能刪除預設 Prompt
+   - 緩解：下次啟動時會重新建立
+
+### Trade-offs
+- **簡單 vs 靈活**：不提供前端切換 Agent 功能，保持簡單
+- **預設 vs 自訂**：保留現有 Agent 設定，不覆蓋使用者修改
+
+## Migration Plan
+
+1. 建立 `ensure_default_linebot_agents()` 函數
+2. 在 `main.py` 的 lifespan 中調用
+3. 修改 `linebot_ai.py` 使用 Agent 設定
+4. 更新現有資料庫中的 Prompt 內容（加入 MCP 工具說明）

--- a/openspec/changes/archive/2025-12-31-2025-12-31-linebot-agent-integration/proposal.md
+++ b/openspec/changes/archive/2025-12-31-2025-12-31-linebot-agent-integration/proposal.md
@@ -1,0 +1,37 @@
+# Proposal: linebot-agent-integration
+
+## Summary
+Line Bot 整合 AI Agent 系統，使用資料庫中的 Agent/Prompt 設定而非硬編碼，實現原始設計中的 Agent 整合目標。
+
+## Motivation
+原始設計文件（add-line-bot/design.md）明確指出：
+> 使用 `linebot-personal` AI Agent 處理訊息（來自 ai-management）
+
+但目前實作偏離了設計：
+- System Prompt 硬編碼在 `linebot_ai.py` 中
+- Model 設定硬編碼為 `"sonnet"`
+- AI Log 記錄時 Agent 顯示為 `-`（因為找不到名為 `"linebot"` 的 Agent）
+
+這導致：
+1. 無法透過 UI 修改 Line Bot 的 Prompt
+2. 個人對話和群組對話使用相同的 Prompt
+3. AI Log 無法正確關聯到 Agent
+
+## Scope
+- 修改 `linebot_ai.py` 使用資料庫中的 Agent 設定
+- 區分 `linebot-personal` 和 `linebot-group` 兩種 Agent
+- 在應用程式啟動時確保預設 Agent 存在
+- 更新 Prompt 內容包含 MCP 工具說明
+- 支援從 Agent 設定讀取內建工具（如 WebSearch）
+- 增強個人對話歷史功能（修正查詢、增加長度）
+- 實作對話重置功能（`/新對話` 指令）
+
+## Out of Scope
+- 不修改 Line Bot 前端介面
+- 不修改 AI 管理的 API
+- 不新增 Agent 動態切換功能
+- 群組對話不支援重置（多人共享歷史，靜默忽略）
+
+## Dependencies
+- `ai-management` spec（已實作）
+- `line-bot` spec（已實作）

--- a/openspec/changes/archive/2025-12-31-2025-12-31-linebot-agent-integration/specs/line-bot/spec.md
+++ b/openspec/changes/archive/2025-12-31-2025-12-31-linebot-agent-integration/specs/line-bot/spec.md
@@ -1,0 +1,81 @@
+# line-bot Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Line Bot Agent 整合
+Line Bot SHALL 使用資料庫中的 Agent/Prompt 設定進行 AI 對話處理。
+
+#### Scenario: 個人對話使用 linebot-personal Agent
+- **WHEN** Line 用戶在個人對話中發送訊息
+- **AND** 觸發 AI 處理
+- **THEN** 系統從資料庫取得 `linebot-personal` Agent 設定
+- **AND** 使用該 Agent 的 model 設定
+- **AND** 使用該 Agent 的 system_prompt 內容
+
+#### Scenario: 群組對話使用 linebot-group Agent
+- **WHEN** Line 用戶在群組中觸發 AI 處理
+- **THEN** 系統從資料庫取得 `linebot-group` Agent 設定
+- **AND** 使用該 Agent 的 model 設定
+- **AND** 使用該 Agent 的 system_prompt 內容
+- **AND** 動態附加群組資訊和綁定專案資訊到 prompt
+
+#### Scenario: Agent 不存在時的 Fallback
+- **WHEN** 系統找不到對應的 Agent 設定
+- **THEN** 系統使用硬編碼的預設 Prompt 作為 fallback
+- **AND** 記錄警告日誌
+
+---
+
+### Requirement: 預設 Line Bot Agent 初始化
+系統 SHALL 在啟動時確保預設的 Line Bot Agent 存在。
+
+#### Scenario: 應用程式啟動時檢查並建立預設 Agent
+- **WHEN** 應用程式啟動
+- **THEN** 系統檢查 `linebot-personal` Agent 是否存在
+- **AND** 若不存在則建立預設的 `linebot-personal` Agent 和對應的 Prompt
+- **AND** 系統檢查 `linebot-group` Agent 是否存在
+- **AND** 若不存在則建立預設的 `linebot-group` Agent 和對應的 Prompt
+
+#### Scenario: 保留使用者修改
+- **WHEN** 應用程式啟動
+- **AND** Agent 已存在
+- **THEN** 系統不覆蓋現有 Agent 設定
+- **AND** 保留使用者透過 UI 修改的內容
+
+#### Scenario: linebot-personal Agent 預設設定
+- **WHEN** 系統建立 `linebot-personal` Agent
+- **THEN** Agent 的 model 為 `claude-sonnet`
+- **AND** Prompt 類別為 `linebot`
+- **AND** Prompt 內容包含 MCP 工具說明（專案查詢、知識庫搜尋等）
+
+#### Scenario: linebot-group Agent 預設設定
+- **WHEN** 系統建立 `linebot-group` Agent
+- **THEN** Agent 的 model 為 `claude-haiku`
+- **AND** Prompt 類別為 `linebot`
+- **AND** Prompt 內容包含 MCP 工具說明
+- **AND** Prompt 內容限制回覆長度（不超過 200 字）
+
+---
+
+### Requirement: Line Bot AI Log 記錄
+Line Bot 的 AI 呼叫記錄 SHALL 正確關聯到 Agent。
+
+#### Scenario: AI Log 記錄關聯 Agent
+- **WHEN** Line Bot 完成一次 AI 呼叫
+- **THEN** AI Log 的 agent_id 關聯到實際使用的 Agent（`linebot-personal` 或 `linebot-group`）
+- **AND** 前端 AI Log 頁面顯示正確的 Agent 名稱
+
+---
+
+### Requirement: 個人對話重置功能
+Line Bot SHALL 支援個人對話的對話歷史重置。
+
+#### Scenario: 重置對話歷史
+- **WHEN** Line 用戶在個人對話中發送 `/新對話` 或 `/reset`
+- **THEN** 系統更新用戶的 `conversation_reset_at` 為當前時間
+- **AND** 回覆「已清除對話歷史，開始新對話！」
+- **AND** 後續 AI 處理不會看到重置前的對話內容
+
+#### Scenario: 群組不支援重置
+- **WHEN** Line 用戶在群組中發送重置指令
+- **THEN** 系統靜默忽略，不執行重置操作

--- a/openspec/changes/archive/2025-12-31-2025-12-31-linebot-agent-integration/tasks.md
+++ b/openspec/changes/archive/2025-12-31-2025-12-31-linebot-agent-integration/tasks.md
@@ -1,0 +1,77 @@
+# Tasks: linebot-agent-integration
+
+## 任務列表
+
+### 1. 建立預設 Agent 初始化模組
+- [x] 在 `services/` 目錄建立 `linebot_agents.py`
+- [x] 定義 `DEFAULT_LINEBOT_AGENTS` 常數（包含 `linebot-personal` 和 `linebot-group` 的完整設定）
+- [x] 實作 `ensure_default_linebot_agents()` 非同步函數
+  - 檢查 Agent 是否存在
+  - 若不存在則建立 Agent 和對應的 Prompt
+  - 若已存在則跳過（保留使用者修改）
+
+### 2. 整合啟動流程
+- [x] 在 `main.py` 的 lifespan 事件中調用 `ensure_default_linebot_agents()`
+- [x] 加入適當的日誌記錄
+
+### 3. 修改 Line Bot AI 使用 Agent 設定
+- [x] 修改 `linebot_ai.py` 的 AI 呼叫邏輯
+  - 根據對話類型（個人/群組）選擇對應的 Agent
+  - 從 Agent 取得 model 和 system_prompt
+  - 保留現有的群組資訊動態注入邏輯
+- [x] 實作 fallback 機制（當 Agent 不存在時使用預設值）
+- [x] 修正 `log_linebot_ai_call()` 正確關聯 Agent
+
+### 4. 設計 Prompt 內容
+- [x] 撰寫 `linebot-personal` Prompt（完整版，包含 MCP 工具說明）
+- [x] 撰寫 `linebot-group` Prompt（精簡版，限制回覆長度）
+
+### 5. 驗證與測試
+- [x] 驗證應用程式啟動時正確建立預設 Agent
+- [x] 驗證資料庫 prompt 已更新（migration 013）
+- [x] 驗證程式碼語法正確
+
+## 依賴關係
+
+```
+1. 建立預設 Agent 初始化模組
+   └── 2. 整合啟動流程
+       └── 3. 修改 Line Bot AI 使用 Agent 設定
+           └── 5. 驗證與測試
+
+4. 設計 Prompt 內容（可與 1-3 並行）
+```
+
+## 驗收標準
+
+- [x] 應用程式啟動時自動建立 `linebot-personal` 和 `linebot-group` Agent
+- [x] 個人對話使用 `linebot-personal` 的 model 和 prompt
+- [x] 群組對話使用 `linebot-group` 的 model 和 prompt
+- [x] AI Log 的 Agent 欄位正確顯示對應的 Agent 名稱
+- [x] 可透過前端 AI 管理介面修改 Line Bot 的 Prompt
+
+### 6. 增強功能：個人對話歷史與工具整合
+- [x] 增加對話歷史長度（10 → 20 則）
+- [x] 修正個人對話歷史查詢（原本只有群組有效）
+- [x] 修正 Bot 回應儲存，讓個人對話也能看到歷史回應
+- [x] 支援從 Agent 設定讀取內建工具（如 WebSearch）
+
+### 7. 對話重置功能
+- [x] 新增 `conversation_reset_at` 欄位（migration 014）
+- [x] 實作 `reset_conversation()` 和 `is_reset_command()` 函數
+- [x] 修改 `get_conversation_context()` 加入時間過濾
+- [x] 個人對話支援 `/新對話`、`/reset` 等重置指令
+- [x] 群組發送重置指令時靜默忽略
+- [x] 更新 Prompt 說明重置功能
+
+## 實作摘要
+
+### 新增檔案
+- `backend/migrations/versions/013_update_linebot_prompts.py` - 更新 prompt 預設內容
+- `backend/migrations/versions/014_add_conversation_reset.py` - 新增對話重置時間欄位
+- `backend/src/ching_tech_os/services/linebot_agents.py` - Agent 初始化模組
+
+### 修改檔案
+- `backend/src/ching_tech_os/main.py` - 在 lifespan 中調用初始化
+- `backend/src/ching_tech_os/services/linebot_ai.py` - 使用資料庫 Agent 設定、對話重置處理
+- `backend/src/ching_tech_os/services/linebot.py` - 新增重置函數、修正 Bot 回應儲存

--- a/openspec/specs/line-bot/spec.md
+++ b/openspec/specs/line-bot/spec.md
@@ -396,3 +396,81 @@ Line Bot SHALL 支援群組層級的 AI 回應開關。
 
 ---
 
+### Requirement: Line Bot Agent 整合
+Line Bot SHALL 使用資料庫中的 Agent/Prompt 設定進行 AI 對話處理。
+
+#### Scenario: 個人對話使用 linebot-personal Agent
+- **WHEN** Line 用戶在個人對話中發送訊息
+- **AND** 觸發 AI 處理
+- **THEN** 系統從資料庫取得 `linebot-personal` Agent 設定
+- **AND** 使用該 Agent 的 model 設定
+- **AND** 使用該 Agent 的 system_prompt 內容
+
+#### Scenario: 群組對話使用 linebot-group Agent
+- **WHEN** Line 用戶在群組中觸發 AI 處理
+- **THEN** 系統從資料庫取得 `linebot-group` Agent 設定
+- **AND** 使用該 Agent 的 model 設定
+- **AND** 使用該 Agent 的 system_prompt 內容
+- **AND** 動態附加群組資訊和綁定專案資訊到 prompt
+
+#### Scenario: Agent 不存在時的 Fallback
+- **WHEN** 系統找不到對應的 Agent 設定
+- **THEN** 系統使用硬編碼的預設 Prompt 作為 fallback
+- **AND** 記錄警告日誌
+
+---
+
+### Requirement: 預設 Line Bot Agent 初始化
+系統 SHALL 在啟動時確保預設的 Line Bot Agent 存在。
+
+#### Scenario: 應用程式啟動時檢查並建立預設 Agent
+- **WHEN** 應用程式啟動
+- **THEN** 系統檢查 `linebot-personal` Agent 是否存在
+- **AND** 若不存在則建立預設的 `linebot-personal` Agent 和對應的 Prompt
+- **AND** 系統檢查 `linebot-group` Agent 是否存在
+- **AND** 若不存在則建立預設的 `linebot-group` Agent 和對應的 Prompt
+
+#### Scenario: 保留使用者修改
+- **WHEN** 應用程式啟動
+- **AND** Agent 已存在
+- **THEN** 系統不覆蓋現有 Agent 設定
+- **AND** 保留使用者透過 UI 修改的內容
+
+#### Scenario: linebot-personal Agent 預設設定
+- **WHEN** 系統建立 `linebot-personal` Agent
+- **THEN** Agent 的 model 為 `claude-sonnet`
+- **AND** Prompt 類別為 `linebot`
+- **AND** Prompt 內容包含 MCP 工具說明（專案查詢、知識庫搜尋等）
+
+#### Scenario: linebot-group Agent 預設設定
+- **WHEN** 系統建立 `linebot-group` Agent
+- **THEN** Agent 的 model 為 `claude-haiku`
+- **AND** Prompt 類別為 `linebot`
+- **AND** Prompt 內容包含 MCP 工具說明
+- **AND** Prompt 內容限制回覆長度（不超過 200 字）
+
+---
+
+### Requirement: Line Bot AI Log 記錄
+Line Bot 的 AI 呼叫記錄 SHALL 正確關聯到 Agent。
+
+#### Scenario: AI Log 記錄關聯 Agent
+- **WHEN** Line Bot 完成一次 AI 呼叫
+- **THEN** AI Log 的 agent_id 關聯到實際使用的 Agent（`linebot-personal` 或 `linebot-group`）
+- **AND** 前端 AI Log 頁面顯示正確的 Agent 名稱
+
+---
+
+### Requirement: 個人對話重置功能
+Line Bot SHALL 支援個人對話的對話歷史重置。
+
+#### Scenario: 重置對話歷史
+- **WHEN** Line 用戶在個人對話中發送 `/新對話` 或 `/reset`
+- **THEN** 系統更新用戶的 `conversation_reset_at` 為當前時間
+- **AND** 回覆「已清除對話歷史，開始新對話！」
+- **AND** 後續 AI 處理不會看到重置前的對話內容
+
+#### Scenario: 群組不支援重置
+- **WHEN** Line 用戶在群組中發送重置指令
+- **THEN** 系統靜默忽略，不執行重置操作
+


### PR DESCRIPTION
## Summary
- 使用資料庫 Agent/Prompt 設定取代硬編碼
- 新增對話重置功能（/新對話、/reset 指令）
- 支援從 Agent 設定讀取內建工具（如 WebSearch）
- 修正個人對話歷史查詢
- 更新 README 功能列表與文件連結
- 新增 MIT LICENSE

## Test plan
- [x] 驗證應用程式啟動時正確建立預設 Agent
- [x] 驗證個人對話使用正確的 Agent 設定
- [x] 驗證群組對話使用正確的 Agent 設定
- [x] 驗證 /新對話 指令可重置對話歷史
- [x] 驗證群組中重置指令靜默忽略

🤖 Generated with [Claude Code](https://claude.com/claude-code)