### PR TITLE
fix: 圖片生成 timeout 時觸發 Hugging Face fallback

### DIFF
--- a/backend/src/ching_tech_os/services/huggingface_image.py
+++ b/backend/src/ching_tech_os/services/huggingface_image.py
@@ -119,7 +119,7 @@ async def generate_image_fallback(
     # 檢查是否應該觸發備用
     should_fallback = any(
         keyword in original_error.lower()
-        for keyword in ["overloaded", "quota", "limit", "503", "429"]
+        for keyword in ["overloaded", "quota", "limit", "503", "429", "timeout"]
     )
 
     if not should_fallback:


### PR DESCRIPTION
## Summary
- 修正圖片生成 timeout 時不會觸發備用服務的問題
- 當 nanobanana (Gemini) 超時時，現在會自動使用 Hugging Face FLUX 生成圖片

## 問題
原本 `generate_image_fallback()` 只在以下錯誤時觸發：
- overloaded, quota, limit, 503, 429

但 timeout 不在列表中，導致 Gemini 超時時備用服務不會啟動。

## 修改
在 `huggingface_image.py` 的 fallback 觸發條件加入 `"timeout"`

## Test plan
- [ ] 測試正常圖片生成（Gemini 可用時）
- [ ] 測試 Gemini timeout 時是否自動使用 Hugging Face fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)