### PR TITLE
refactor: 前端 API 路徑從 /api/linebot 遷移至 /api/bot

### DIFF
--- a/backend/tests/test_bot_api_routes.py
+++ b/backend/tests/test_bot_api_routes.py
@@ -1,0 +1,146 @@
+"""Bot API 路由測試
+
+驗證 /api/bot/* 路由能正常運作（前端已遷移至此路徑）。
+
+用法：
+    cd backend
+    uv run pytest tests/test_bot_api_routes.py -v
+"""
+
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, patch, MagicMock
+from uuid import UUID
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ching_tech_os.api.linebot_router import router as bot_router
+from ching_tech_os.api.tenant import router as tenant_router
+from ching_tech_os.api.auth import get_current_session
+from ching_tech_os.models.auth import SessionData
+
+
+MOCK_TENANT_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+def create_session_override(username: str, user_id: int = 1, role: str = "user"):
+    """建立 session 覆寫函數"""
+    async def override():
+        now = datetime.now()
+        return SessionData(
+            username=username,
+            password="test-password",
+            nas_host="test-nas",
+            user_id=user_id,
+            created_at=now,
+            expires_at=now + timedelta(hours=1),
+            tenant_id=MOCK_TENANT_ID,
+            role=role,
+        )
+    return override
+
+
+def create_bot_app():
+    """建立包含 /api/bot 路由的測試應用程式"""
+    app = FastAPI()
+    app.include_router(bot_router, prefix="/api/bot")
+    app.include_router(tenant_router)
+    return app
+
+
+# ============================================================
+# /api/bot/* 路由測試（前端主要使用的路徑）
+# ============================================================
+
+class TestBotApiRoutes:
+    """/api/bot/* 路由可達性測試"""
+
+    def setup_method(self):
+        self.app = create_bot_app()
+        self.app.dependency_overrides[get_current_session] = create_session_override(
+            "testuser", role="tenant_admin"
+        )
+        self.client = TestClient(self.app)
+
+    def test_bot_groups_returns_200(self):
+        """/api/bot/groups 應回傳 200"""
+        with patch("ching_tech_os.api.linebot_router.list_groups", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = ([], 0)
+            response = self.client.get("/api/bot/groups")
+            assert response.status_code == 200
+            assert response.json()["items"] == []
+
+    def test_bot_users_returns_200(self):
+        """/api/bot/users 應回傳 200"""
+        with patch("ching_tech_os.api.linebot_router.list_users", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = ([], 0)
+            response = self.client.get("/api/bot/users")
+            assert response.status_code == 200
+
+    def test_bot_messages_returns_200(self):
+        """/api/bot/messages 應回傳 200"""
+        with patch("ching_tech_os.api.linebot_router.list_messages", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = ([], 0)
+            response = self.client.get("/api/bot/messages")
+            assert response.status_code == 200
+
+    def test_bot_files_returns_200(self):
+        """/api/bot/files 應回傳 200"""
+        with patch("ching_tech_os.api.linebot_router.list_files", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = ([], 0)
+            response = self.client.get("/api/bot/files")
+            assert response.status_code == 200
+
+    def test_bot_webhook_route_exists(self):
+        """/api/bot/webhook 路由應存在（POST）"""
+        from ching_tech_os.api import linebot_router
+
+        with patch.object(linebot_router, "verify_webhook_signature", new_callable=AsyncMock) as mock_verify, \
+             patch.object(linebot_router, "get_webhook_parser") as mock_parser:
+            mock_verify.return_value = (True, MOCK_TENANT_ID, "test-secret")
+            mock_parser_instance = MagicMock()
+            mock_parser_instance.parse.return_value = []
+            mock_parser.return_value = mock_parser_instance
+
+            response = self.client.post(
+                "/api/bot/webhook",
+                content=b'{"events":[]}',
+                headers={"X-Line-Signature": "test"},
+            )
+            assert response.status_code == 200
+
+    def test_nonexistent_route_returns_404(self):
+        """/api/bot/nonexistent 應回傳 404"""
+        response = self.client.get("/api/bot/nonexistent")
+        assert response.status_code in (404, 405)
+
+
+# ============================================================
+# /api/tenant/bot 路由測試
+# ============================================================
+
+class TestTenantBotRoutes:
+    """/api/tenant/bot 路由可達性測試"""
+
+    def setup_method(self):
+        self.app = create_bot_app()
+        self.app.dependency_overrides[get_current_session] = create_session_override(
+            "admin", role="tenant_admin"
+        )
+        self.client = TestClient(self.app)
+
+    def test_tenant_bot_settings_returns_200(self):
+        """/api/tenant/bot 應回傳 200"""
+        with patch("ching_tech_os.services.tenant.get_tenant_line_credentials", new_callable=AsyncMock) as mock_creds:
+            mock_creds.return_value = None
+            response = self.client.get("/api/tenant/bot")
+            assert response.status_code == 200
+            assert response.json()["configured"] is False
+
+    def test_tenant_bot_delete_returns_200(self):
+        """/api/tenant/bot DELETE 應回傳 200"""
+        with patch("ching_tech_os.services.tenant.update_tenant_line_settings", new_callable=AsyncMock) as mock_update, \
+             patch("ching_tech_os.services.linebot.invalidate_tenant_secrets_cache"):
+            mock_update.return_value = True
+            response = self.client.delete("/api/tenant/bot")
+            assert response.status_code == 200

--- a/frontend/js/linebot.js
+++ b/frontend/js/linebot.js
@@ -47,7 +47,7 @@ const LineBotApp = (function () {
 
     // API 呼叫
     async function api(endpoint, options = {}) {
-        const url = `/api/linebot${endpoint}`;
+        const url = `/api/bot${endpoint}`;
         const token = getToken();
         const response = await fetch(url, {
             ...options,
@@ -1038,7 +1038,7 @@ const LineBotApp = (function () {
     // 刪除檔案
     async function deleteFile(fileId) {
         try {
-            const response = await fetch(`/api/linebot/files/${fileId}`, {
+            const response = await fetch(`/api/bot/files/${fileId}`, {
                 method: 'DELETE',
                 headers: {
                     'Authorization': `Bearer ${getToken()}`,
@@ -1070,7 +1070,7 @@ const LineBotApp = (function () {
     // 刪除群組
     async function deleteGroup(groupId) {
         try {
-            const response = await fetch(`/api/linebot/groups/${groupId}`, {
+            const response = await fetch(`/api/bot/groups/${groupId}`, {
                 method: 'DELETE',
                 headers: {
                     'Authorization': `Bearer ${getToken()}`,
@@ -1155,7 +1155,7 @@ const LineBotApp = (function () {
                     openFile(file);
                     break;
                 case 'download':
-                    FileUtils.downloadWithAuth(`/api/linebot/files/${file.id}/download`, file.file_name);
+                    FileUtils.downloadWithAuth(`/api/bot/files/${file.id}/download`, file.file_name);
                     break;
                 case 'delete':
                     const fileName = card?.querySelector('.linebot-file-name')?.textContent || '此檔案';
@@ -1191,7 +1191,7 @@ const LineBotApp = (function () {
         }
 
         let fileName = file.file_name || `${file.file_type}_${file.id.slice(0, 8)}`;
-        const fileUrl = `/api/linebot/files/${file.id}/download`;
+        const fileUrl = `/api/bot/files/${file.id}/download`;
 
         // 如果檔名沒有副檔名，根據 file_type 加上預設副檔名
         if (!fileName.includes('.')) {

--- a/frontend/js/memory-manager.js
+++ b/frontend/js/memory-manager.js
@@ -45,7 +45,7 @@ const MemoryManagerApp = (function() {
    */
   async function apiRequest(endpoint, options = {}) {
     const token = typeof LoginModule !== 'undefined' ? LoginModule.getToken() : null;
-    const response = await fetch(`/api/linebot${endpoint}`, {
+    const response = await fetch(`/api/bot${endpoint}`, {
       ...options,
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/js/platform-admin.js
+++ b/frontend/js/platform-admin.js
@@ -1310,7 +1310,7 @@ const PlatformAdminApp = (function () {
     content.style.display = 'none';
 
     try {
-      const response = await APIClient.get(`/admin/tenants/${tenantId}/linebot`);
+      const response = await APIClient.get(`/admin/tenants/${tenantId}/bot`);
       renderTenantLineBotSettings(dialog, content, response, tenantId);
       loading.style.display = 'none';
       content.style.display = '';
@@ -1389,7 +1389,7 @@ const PlatformAdminApp = (function () {
       resultEl.style.display = 'none';
 
       try {
-        const response = await APIClient.post(`/admin/tenants/${tenantId}/linebot/test`);
+        const response = await APIClient.post(`/admin/tenants/${tenantId}/bot/test`);
 
         if (response.success) {
           resultEl.className = 'tenant-linebot-test-result success';
@@ -1442,7 +1442,7 @@ const PlatformAdminApp = (function () {
         if (channelSecret) data.channel_secret = channelSecret;
         if (accessToken) data.access_token = accessToken;
 
-        await APIClient.put(`/admin/tenants/${tenantId}/linebot`, data);
+        await APIClient.put(`/admin/tenants/${tenantId}/bot`, data);
 
         // 清空密碼欄位
         container.querySelector('#tenantLineChannelSecret').value = '';
@@ -1470,7 +1470,7 @@ const PlatformAdminApp = (function () {
       btn.innerHTML = `<span class="icon">${getIcon('loading', 'mdi-spin')}</span><span>清除中...</span>`;
 
       try {
-        await APIClient.request(`/admin/tenants/${tenantId}/linebot`, { method: 'DELETE' });
+        await APIClient.request(`/admin/tenants/${tenantId}/bot`, { method: 'DELETE' });
         loadTenantLineBotSettings(dialog, tenantId);
         showToast('Line Bot 設定已清除', 'check');
       } catch (error) {

--- a/frontend/js/tenant-admin.js
+++ b/frontend/js/tenant-admin.js
@@ -1565,7 +1565,7 @@ const TenantAdminApp = (function () {
 
     try {
       // 使用租戶 API（平台管理員和租戶管理員都可以用）
-      const response = await APIClient.get('/tenant/linebot');
+      const response = await APIClient.get('/tenant/bot');
 
       // 更新狀態顯示
       if (response.configured) {
@@ -1620,7 +1620,7 @@ const TenantAdminApp = (function () {
 
     try {
       // 使用租戶 API
-      const response = await APIClient.post('/tenant/linebot/test');
+      const response = await APIClient.post('/tenant/bot/test');
 
       if (response.success) {
         resultEl.className = 'linebot-test-result success';
@@ -1686,7 +1686,7 @@ const TenantAdminApp = (function () {
       if (accessToken) data.access_token = accessToken;
 
       // 使用租戶 API
-      await APIClient.put('/tenant/linebot', data);
+      await APIClient.put('/tenant/bot', data);
 
       // 清空密碼欄位
       container.querySelector('#lineChannelSecret').value = '';
@@ -1721,7 +1721,7 @@ const TenantAdminApp = (function () {
 
     try {
       // 使用租戶 API
-      await APIClient.delete('/tenant/linebot');
+      await APIClient.delete('/tenant/bot');
 
       // 清空表單
       container.querySelector('#lineChannelId').value = '';


### PR DESCRIPTION
## Summary
- 前端 4 個 JS 檔案的 API 呼叫路徑從 `/api/linebot/*` 遷移至 `/api/bot/*`
- 租戶管理 `/tenant/linebot` → `/tenant/bot`
- 平台管理 `/admin/tenants/{id}/linebot` → `/admin/tenants/{id}/bot`
- 新增 `test_bot_api_routes.py`（8 個測試）驗證 `/api/bot/*` 路由可達性

## Test plan
- [x] `uv run pytest tests/test_bot_api_routes.py -v` — 8 passed
- [x] `uv run pytest tests/` — 331 passed, 10 skipped, 0 failed
- [ ] 手動驗證前端 Bot 管理頁面功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)