### PR TITLE
feat: SkillManager 完整整合 + Skills 管理介面

### DIFF
--- a/backend/src/ching_tech_os/api/skills.py
+++ b/backend/src/ching_tech_os/api/skills.py
@@ -1,0 +1,47 @@
+"""Skills API（僅限管理員）"""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..models.auth import SessionData
+from .auth import require_admin
+from ..skills import get_skill_manager
+
+router = APIRouter(prefix="/api/skills", tags=["skills"])
+
+
+@router.get("")
+async def list_skills(session: SessionData = Depends(require_admin)):
+    """列出所有 skills（僅限管理員）"""
+    sm = get_skill_manager()
+    all_skills = await sm.get_all_skills()
+    return {
+        "skills": [
+            {
+                "name": skill.name,
+                "description": skill.description,
+                "requires_app": skill.requires_app,
+                "tools_count": len(skill.tools),
+                "has_prompt": bool(skill.prompt),
+            }
+            for skill in all_skills
+        ]
+    }
+
+
+@router.get("/{name}")
+async def get_skill(name: str, session: SessionData = Depends(require_admin)):
+    """取得單一 skill 詳情（含 prompt，僅限管理員）"""
+    sm = get_skill_manager()
+    skill = await sm.get_skill(name)
+    if not skill:
+        raise HTTPException(status_code=404, detail=f"Skill '{name}' not found")
+    return {
+        "name": skill.name,
+        "description": skill.description,
+        "requires_app": skill.requires_app,
+        "tools_count": len(skill.tools),
+        "tools": skill.tools,
+        "mcp_servers": skill.mcp_servers,
+        "has_prompt": bool(skill.prompt),
+        "prompt": skill.prompt,
+    }

--- a/frontend/css/agent-settings.css
+++ b/frontend/css/agent-settings.css
@@ -2,13 +2,6 @@
  * ChingTech OS - Agent Settings Styles
  */
 
-.agent-settings {
-  display: flex;
-  height: 100%;
-  overflow: hidden;
-  background: var(--bg-primary);
-}
-
 /* 側邊欄 */
 .agent-sidebar {
   width: 260px;
@@ -400,6 +393,141 @@
 .agent-empty-state h3 {
   color: var(--text-secondary);
   margin-bottom: 8px;
+}
+
+/* ==========================================================================
+   Tab Bar & Wrapper
+   ========================================================================== */
+
+.agent-settings-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.agent-settings-tabs {
+  display: flex;
+  gap: 0;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+}
+
+.agent-settings-tab {
+  padding: 10px 24px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.agent-settings-tab:hover {
+  color: var(--text-primary);
+}
+
+.agent-settings-tab.active {
+  color: var(--text-primary);
+  border-bottom-color: var(--color-accent, var(--primary, #6c9fff));
+}
+
+.agent-settings-tab-content {
+  display: none;
+  flex: 1;
+  overflow: hidden;
+}
+
+.agent-settings-tab-content.active {
+  display: flex;
+}
+
+/* ==========================================================================
+   Skills
+   ========================================================================== */
+
+.skill-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.skill-list-item-meta {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.skill-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 11px;
+  border-radius: 10px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+}
+
+.skill-badge-tool {
+  background: rgba(108, 159, 255, 0.15);
+  color: var(--color-accent, #6c9fff);
+}
+
+.skill-detail {
+  padding: 16px;
+}
+
+.skill-detail-field {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.skill-detail-field .agent-form-label {
+  min-width: 120px;
+  flex-shrink: 0;
+}
+
+.skill-detail-value {
+  color: var(--text-primary);
+  font-size: 14px;
+}
+
+.skill-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.skill-chip {
+  display: inline-block;
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 14px;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-subtle);
+}
+
+.skill-prompt-content {
+  width: 100%;
+  padding: 12px;
+  background: var(--bg-input, var(--bg-tertiary));
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 400px;
+  overflow-y: auto;
+  margin: 0;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## 改動

### 後端 — SkillManager 動態工具載入 + Skills API

- **linebot_ai.py**: 硬編碼的工具列表（nanobanana/printer/erpnext 50+ 行）改為 `SkillManager.get_tool_names(app_permissions)` 動態載入，保留 fallback
- **skill.yaml 更新**: inventory/project/printer/base 的 tools 列表補齊所有工具名
- **Skills API**: `GET /api/skills` + `GET /api/skills/{name}`，需認證

### 前端 — Skills 管理介面（唯讀）

- agent-settings 頂部加入 Agents / Skills tab 切換
- Skills 分頁：左側列表（名稱、說明、權限 badge、工具數量）
- 右側詳情：工具 chips、MCP Servers、Prompt 內容（readonly）
- 暗色主題一致風格

## 部署注意
- 需要公司環境（PostgreSQL、ERPNext、MCP servers）才能完整測試
- SkillManager 失敗時自動 fallback 到硬編碼，不影響現有功能