### PR TITLE
feat: 支援 scripts/ assets/ 目錄（Agent Skills 標準完整支援）

### DIFF
--- a/backend/src/ching_tech_os/api/skills.py
+++ b/backend/src/ching_tech_os/api/skills.py
@@ -23,6 +23,8 @@ async def list_skills(session: SessionData = Depends(require_admin)):
                 "tools_count": len(skill.allowed_tools),
                 "has_prompt": bool(skill.prompt),
                 "references": skill.references,
+                "scripts": skill.scripts,
+                "assets": skill.assets,
                 "source": skill.source,
                 "license": skill.license,
                 "compatibility": skill.compatibility,
@@ -49,6 +51,8 @@ async def get_skill(name: str, session: SessionData = Depends(require_admin)):
         "has_prompt": bool(skill.prompt),
         "prompt": skill.prompt,
         "references": skill.references,
+        "scripts": skill.scripts,
+        "assets": skill.assets,
         "source": skill.source,
         "license": skill.license,
         "compatibility": skill.compatibility,
@@ -56,13 +60,28 @@ async def get_skill(name: str, session: SessionData = Depends(require_admin)):
     }
 
 
+@router.get("/{name}/files/{file_path:path}")
+async def get_skill_file(
+    name: str,
+    file_path: str,
+    session: SessionData = Depends(require_admin),
+):
+    """讀取 skill 的檔案（references/ scripts/ assets/ 下）"""
+    sm = get_skill_manager()
+    content = await sm.get_skill_file(name, file_path)
+    if content is None:
+        raise HTTPException(status_code=404, detail="File not found")
+    return {"path": file_path, "content": content}
+
+
+# 向下相容舊端點
 @router.get("/{name}/references/{ref_path:path}")
 async def get_skill_reference(
     name: str,
     ref_path: str,
     session: SessionData = Depends(require_admin),
 ):
-    """讀取 skill 的 reference 檔案"""
+    """讀取 skill 的 reference 檔案（向下相容）"""
     sm = get_skill_manager()
     content = await sm.get_skill_reference(name, ref_path)
     if content is None:


### PR DESCRIPTION
## 改動
完成 Agent Skills 標準三個子目錄的支援：

| 目錄 | 用途 | 支援 |
|---|---|---|
| `references/` | 參考文件（按需載入） | PR #45 ✅ → 本 PR 保留 |
| `scripts/` | 可執行腳本 | **本 PR 新增** ✅ |
| `assets/` | 靜態資源（模板、圖片） | **本 PR 新增** ✅ |

### 具體改動
- Skill dataclass 新增 `scripts`、`assets` 欄位
- `_build_skill()` 掃描三個目錄
- 新增 `get_skill_file()` 統一檔案讀取（安全限制只能存取 references/scripts/assets/）
- 新增 `GET /api/skills/{name}/files/{path}` 端點
- 保留 `GET /api/skills/{name}/references/{path}` 向下相容
- list/detail API 回傳 `scripts`、`assets` 欄位

匯入 OpenClaw skill 時，`scripts/`、`assets/` 目錄也會一併複製。

/gemini review