### PR TITLE
P7: 品牌色文件同步 — sync spec.md brand colors with main.css

### DIFF
--- a/openspec/specs/design-system/spec.md
+++ b/openspec/specs/design-system/spec.md
@@ -51,13 +51,15 @@ CSS 變數架構 SHALL 支援主題切換功能。
 
 #### Scenario: 主色系使用
 - **WHEN** UI 需要使用主要品牌色
-- **THEN** 必須使用 ChingTech Blue `#1C4FA8`、Deep Industrial Navy `#0F1C2E`、AI Neon Cyan `#21D4FD`
+- **THEN** 必須使用 ChingTech Cyan `#0891b2`、Background `#1a1a1a`、Accent Orange `#ea580c`
 - **AND** 透過 `--color-primary`、`--color-background`、`--color-accent` 變數引用
+- **NOTE** 色碼同步來源：`frontend/css/main.css :root` 與 `design/brand.md`
 
 #### Scenario: 狀態色使用
 - **WHEN** UI 需要表示成功、警告、錯誤狀態
-- **THEN** 必須使用 Action Green `#4CC577`、Warning Amber `#FFC557`、Error Red `#E65050`
+- **THEN** 必須使用 Success Green `#16a34a`、Warning Amber `#d97706`、Error Red `#dc2626`
 - **AND** 透過 `--color-success`、`--color-warning`、`--color-error` 變數引用
+- **NOTE** 色碼同步來源：`frontend/css/main.css :root` 與 `design/brand.md`
 
 ### Requirement: CSS Variable Naming Convention
 The system SHALL use industry-standard CSS variable naming conventions for text colors.


### PR DESCRIPTION
## 變更摘要

**P7 品牌色文件同步**：將 `openspec/specs/design-system/spec.md` 中過時的品牌色碼更新為與 `frontend/css/main.css` 及 `design/brand.md` 一致的實際值。

### 修正內容

| 項目 | 舊值（spec.md） | 新值（與 CSS/brand.md 同步） |
|------|-----------------|---------------------------|
| 主要品牌色 | ChingTech Blue `#1C4FA8` | ChingTech Cyan `#0891b2` |
| 背景色 | Deep Industrial Navy `#0F1C2E` | Background `#1a1a1a` |
| 強調色 | AI Neon Cyan `#21D4FD` | Accent Orange `#ea580c` |
| 成功色 | Action Green `#4CC577` | Success Green `#16a34a` |
| 警告色 | Warning Amber `#FFC557` | Warning Amber `#d97706` |
| 錯誤色 | Error Red `#E65050` | Error Red `#dc2626` |

### 影響檔案
- `openspec/specs/design-system/spec.md` — 更新品牌色 HEX 碼 + 加入同步來源 NOTE
- `design/brand.md` — 已與 CSS 一致，無需修改

### 驗證
- [x] spec.md 色碼 = main.css :root 色碼
- [x] spec.md 色碼 = design/brand.md 色碼
- [x] design/brand.md 與 main.css 一致