### PR TITLE
feat(login): P9 登入頁微優化 — autofill CSS 變數化、reduced-motion、按鈕改色

### DIFF
--- a/frontend/css/login.css
+++ b/frontend/css/login.css
@@ -206,24 +206,15 @@
   height: 44px;
 }
 
-/* 覆蓋瀏覽器自動填入樣式 */
+/* 覆蓋瀏覽器自動填入樣式（使用 CSS 變數，自動適應主題） */
 .form-group .input:-webkit-autofill,
 .form-group .input:-webkit-autofill:hover,
 .form-group .input:-webkit-autofill:focus,
 .form-group .input:-webkit-autofill:active {
-  -webkit-box-shadow: 0 0 0 1000px #1a1a1a inset !important;
+  -webkit-box-shadow: 0 0 0 1000px var(--color-background) inset !important;
   -webkit-text-fill-color: var(--text-primary) !important;
   caret-color: var(--text-primary);
   transition: background-color 5000s ease-in-out 0s;
-}
-
-/* 亮色主題自動填入樣式 */
-:root[data-theme="light"] .form-group .input:-webkit-autofill,
-:root[data-theme="light"] .form-group .input:-webkit-autofill:hover,
-:root[data-theme="light"] .form-group .input:-webkit-autofill:focus,
-:root[data-theme="light"] .form-group .input:-webkit-autofill:active {
-  -webkit-box-shadow: 0 0 0 1000px #f5f5f5 inset !important;
-  -webkit-text-fill-color: var(--text-primary) !important;
 }
 
 .form-group .input-icon {
@@ -412,23 +403,15 @@
   color: var(--text-muted);
 }
 
-/* 覆蓋瀏覽器自動填入樣式 */
+/* 覆蓋瀏覽器自動填入樣式（使用 CSS 變數，自動適應主題） */
 .change-password-form .form-group .input:-webkit-autofill,
 .change-password-form .form-group .input:-webkit-autofill:hover,
 .change-password-form .form-group .input:-webkit-autofill:focus,
 .change-password-form .form-group .input:-webkit-autofill:active {
-  -webkit-box-shadow: 0 0 0 1000px #1a1a1a inset !important;
+  -webkit-box-shadow: 0 0 0 1000px var(--color-background) inset !important;
   -webkit-text-fill-color: var(--text-primary) !important;
   caret-color: var(--text-primary);
   transition: background-color 5000s ease-in-out 0s;
-}
-
-:root[data-theme="light"] .change-password-form .form-group .input:-webkit-autofill,
-:root[data-theme="light"] .change-password-form .form-group .input:-webkit-autofill:hover,
-:root[data-theme="light"] .change-password-form .form-group .input:-webkit-autofill:focus,
-:root[data-theme="light"] .change-password-form .form-group .input:-webkit-autofill:active {
-  -webkit-box-shadow: 0 0 0 1000px #f5f5f5 inset !important;
-  -webkit-text-fill-color: var(--text-primary) !important;
 }
 
 .change-password-error {

--- a/frontend/js/matrix-rain.js
+++ b/frontend/js/matrix-rain.js
@@ -51,9 +51,29 @@ const MatrixRain = (function() {
   }
 
   /**
+   * 偵測使用者是否偏好減少動態效果
+   */
+  function prefersReducedMotion() {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }
+
+  /**
    * 初始化
    */
   function init() {
+    // 尊重使用者的 prefers-reduced-motion 設定
+    if (prefersReducedMotion()) {
+      return;
+    }
+
+    // 監聽設定變化（使用者可能在執行期間切換）
+    window.matchMedia('(prefers-reduced-motion: reduce)')
+      .addEventListener('change', (e) => {
+        if (e.matches) {
+          destroy();
+        }
+      });
+
     canvas = document.createElement('canvas');
     canvas.id = 'matrix-rain';
     canvas.style.cssText = `

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -66,7 +66,7 @@
         </div>
 
         <!-- Submit Button -->
-        <button type="submit" class="btn btn-accent login-btn">
+        <button type="submit" class="btn btn-primary login-btn">
           <span class="icon" id="iconLogin"></span>
           登入
         </button>


### PR DESCRIPTION
## 變更摘要

### 1. Autofill CSS 變數化 (`login.css`)
- 將 `-webkit-box-shadow` 中硬編碼的 `#1a1a1a`（暗色）/ `#f5f5f5`（亮色）改為 `var(--color-background)`
- 消除暗/亮主題各自維護的重複規則（登入表單 + 變更密碼表單共減少 **18 行**）
- 自動隨主題切換，無需額外 override

### 2. `prefers-reduced-motion` 偵測 (`matrix-rain.js`)
- 初始化前檢查 `prefers-reduced-motion: reduce`，若命中直接 return 不產生 canvas
- 加入 `matchMedia` change listener，使用者在執行期間切換時自動 `destroy()` 動畫
- 對前庭功能障礙使用者友善（WCAG 2.1 Level AAA §2.3.3）

### 3. 登入按鈕色彩：`btn-accent` → `btn-primary` (`login.html`)
> **設計建議**：登入按鈕是頁面唯一的主要動作（CTA），依照設計系統慣例應使用 `btn-primary`（ChingTech Cyan #0891b2）而非 `btn-accent`（Orange #ea580c）。
> - `btn-primary` 與 Logo 的 cyan 色調一致，強化品牌識別
> - `btn-accent` 適合用於次要強調元素（如通知、標籤）
> - 已實作改色，若不同意可在此 PR revert 單一行即可

### 變更檔案
| 檔案 | 說明 |
|------|------|
| `frontend/css/login.css` | autofill 硬編碼→CSS 變數，刪除重複規則 |
| `frontend/js/matrix-rain.js` | 加入 reduced-motion 偵測與即時監聽 |
| `frontend/login.html` | 登入按鈕 btn-accent → btn-primary |
