### PR TITLE
feat(taskbar): P8 恢復 Taskbar/Dock 底部啟動列

### DIFF
--- a/frontend/css/taskbar.css
+++ b/frontend/css/taskbar.css
@@ -1,0 +1,194 @@
+/* ==========================================================================
+   ChingTech OS - Taskbar/Dock Styles
+   底部應用程式啟動列（macOS Dock 風格）
+   ========================================================================== */
+
+/* ── CSS 變數（在 :root 層級補齊，以便其他模組引用） ── */
+:root {
+  --taskbar-height: 64px;
+  --taskbar-icon-size: 48px;
+}
+
+/* ── Taskbar 容器 ── */
+.taskbar {
+  position: fixed;
+  bottom: var(--spacing-md, 12px);
+  left: 50%;
+  transform: translateX(-50%);
+  height: var(--taskbar-height);
+  background-color: var(--bg-glass-light);
+  border: 1px solid var(--border-light, rgba(255,255,255,0.08));
+  border-radius: var(--radius-xl, 16px);
+  display: flex;
+  align-items: center;
+  padding: 0 var(--spacing-md, 12px);
+  gap: var(--spacing-sm, 8px);
+  z-index: 100;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: var(--shadow-lg, 0 8px 32px rgba(0,0,0,0.3));
+  user-select: none;
+  -webkit-user-select: none;
+  transition: opacity var(--transition-normal, 0.2s) ease;
+}
+
+/* ── Taskbar 圖示 ── */
+.taskbar-icon {
+  width: var(--taskbar-icon-size);
+  height: var(--taskbar-icon-size);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md, 12px);
+  cursor: pointer;
+  transition: all var(--transition-fast, 0.15s) ease;
+  position: relative;
+  user-select: none;
+  -webkit-user-select: none;
+  outline: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.taskbar-icon:hover {
+  background-color: var(--interactive-active, rgba(255,255,255,0.12));
+  transform: translateY(-4px);
+}
+
+.taskbar-icon:active {
+  transform: translateY(-2px);
+}
+
+.taskbar-icon .icon {
+  color: var(--text-secondary, #aaa);
+  transition: color var(--transition-fast, 0.15s) ease;
+}
+
+.taskbar-icon .icon svg {
+  width: 28px;
+  height: 28px;
+}
+
+.taskbar-icon:hover .icon {
+  color: var(--color-primary, #00d4aa);
+}
+
+/* ── Tooltip ── */
+.taskbar-icon::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: var(--spacing-xs, 4px) var(--spacing-sm, 8px);
+  background-color: var(--bg-tooltip, rgba(0,0,0,0.85));
+  border-radius: var(--radius-sm, 6px);
+  font-size: var(--font-size-xs, 12px);
+  color: var(--tooltip-text, #fff);
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+  transition: all var(--transition-fast, 0.15s) ease;
+  pointer-events: none;
+}
+
+.taskbar-icon:hover::after {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ── 分隔線 ── */
+.taskbar-divider {
+  width: 1px;
+  height: 32px;
+  background-color: var(--border-light, rgba(255,255,255,0.08));
+  margin: 0 var(--spacing-xs, 4px);
+  flex-shrink: 0;
+}
+
+/* ── 運行指示器（小點） ── */
+.taskbar-icon .running-indicator {
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 3px;
+  align-items: center;
+}
+
+.taskbar-icon .indicator-dot {
+  width: 4px;
+  height: 4px;
+  background-color: var(--color-accent, #00d4aa);
+  border-radius: 50%;
+}
+
+/* ── 多視窗選單 ── */
+.taskbar-window-menu {
+  position: fixed;
+  transform: translateX(-50%);
+  min-width: 180px;
+  max-width: 280px;
+  background-color: var(--bg-glass, rgba(26,26,26,0.95));
+  border: 1px solid var(--interactive-active, rgba(255,255,255,0.12));
+  border-radius: var(--radius-md, 12px);
+  padding: var(--spacing-xs, 4px);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: var(--shadow-lg, 0 8px 32px rgba(0,0,0,0.3));
+  z-index: 200;
+  animation: taskbar-menu-in 0.15s ease-out;
+}
+
+@keyframes taskbar-menu-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+
+.taskbar-window-menu-item {
+  padding: var(--spacing-sm, 8px) var(--spacing-md, 12px);
+  border-radius: var(--radius-sm, 6px);
+  cursor: pointer;
+  font-size: var(--font-size-sm, 13px);
+  color: var(--text-primary, #eee);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background-color var(--transition-fast, 0.15s) ease;
+}
+
+.taskbar-window-menu-item:hover {
+  background-color: var(--hover-bg, rgba(255,255,255,0.08));
+}
+
+.taskbar-window-menu-item.minimized {
+  color: var(--text-secondary, #aaa);
+  font-style: italic;
+}
+
+.taskbar-window-menu-item.minimized::before {
+  content: '(最小化) ';
+  font-size: var(--font-size-xs, 12px);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .taskbar-icon:hover {
+    transform: none;
+  }
+  .taskbar-icon:active {
+    transform: none;
+  }
+  .taskbar-window-menu {
+    animation: none;
+  }
+}
+
+/* ── 手機版隱藏 Taskbar（≤768px 桌面圖示已足夠） ── */
+@media (max-width: 768px) {
+  .taskbar {
+    display: none;
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -35,6 +35,7 @@
   <link rel="stylesheet" href="css/share-manager.css">
   <link rel="stylesheet" href="css/memory-manager.css">
   <link rel="stylesheet" href="css/notification.css">
+  <link rel="stylesheet" href="css/taskbar.css">
 
   <!-- xterm.js -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.css">
@@ -89,6 +90,10 @@
       <!-- Desktop icons will be rendered by JavaScript -->
     </main>
 
+    <!-- Taskbar / Dock -->
+    <nav class="taskbar" role="navigation" aria-label="快速啟動列">
+      <!-- Taskbar icons will be rendered by JavaScript -->
+    </nav>
   </div>
 
   <!-- 外部 CDN 相依（非 module，同步載入以確保全域變數可用） -->

--- a/frontend/js/taskbar.js
+++ b/frontend/js/taskbar.js
@@ -1,0 +1,216 @@
+/**
+ * ChingTech OS - Taskbar Module
+ * 底部 Dock 啟動列：快速啟動、視窗聚焦、運行指示器
+ */
+
+const TaskbarModule = (function () {
+  'use strict';
+
+  // ── 狀態 ───────────────────────────────────────────────────
+  let activeWindowMenu = null;
+
+  // 快速啟動列應用程式（可依需求增減）
+  const quickLaunchApps = [
+    { id: 'file-manager',  name: '檔案管理', icon: 'mdi-folder' },
+    { id: 'terminal',      name: '終端機',   icon: 'mdi-console' },
+    { id: 'code-editor',   name: 'VSCode',   icon: 'mdi-code-braces' },
+    { id: 'ai-assistant',  name: 'AI 助手',  icon: 'mdi-robot' },
+    { id: 'settings',      name: '系統設定', icon: 'mdi-cog' },
+  ];
+
+  // ── DOM 建立 ───────────────────────────────────────────────
+
+  /**
+   * 建立單一 Taskbar 圖示
+   * @param {Object} app - { id, name, icon }
+   * @returns {HTMLElement}
+   */
+  function createIconElement(app) {
+    const el = document.createElement('button');
+    el.type = 'button';
+    el.className = 'taskbar-icon';
+    el.dataset.appId = app.id;
+    el.dataset.tooltip = app.name;
+    el.setAttribute('aria-label', app.name);
+    el.innerHTML = `<span class="icon">${typeof getIcon === 'function' ? getIcon(app.icon) : ''}</span>`;
+    return el;
+  }
+
+  // ── 點擊行為（Dock 邏輯） ─────────────────────────────────
+
+  /**
+   * 處理圖示點擊
+   *  - 無視窗 → 開啟 App
+   *  - 單視窗 → 聚焦 / 恢復
+   *  - 多視窗 → 顯示選單
+   */
+  function handleIconClick(event) {
+    const appId = event.currentTarget.dataset.appId;
+    closeWindowMenu();
+
+    if (typeof WindowModule === 'undefined') {
+      // 無視窗系統，直接開啟
+      _openApp(appId);
+      return;
+    }
+
+    const wins = WindowModule.getWindowsByAppId(appId);
+
+    if (wins.length === 0) {
+      _openApp(appId);
+    } else if (wins.length === 1) {
+      const w = wins[0];
+      if (w.minimized) {
+        WindowModule.restoreWindow(w.windowId);
+      } else {
+        WindowModule.focusWindow(w.windowId);
+      }
+    } else {
+      showWindowMenu(event.currentTarget, wins);
+    }
+  }
+
+  /** 透過 DesktopModule 開啟應用 */
+  function _openApp(appId) {
+    if (typeof DesktopModule !== 'undefined' && typeof DesktopModule.openApp === 'function') {
+      DesktopModule.openApp(appId);
+    }
+  }
+
+  // ── 多視窗選單 ─────────────────────────────────────────────
+
+  function showWindowMenu(iconEl, windows) {
+    const menu = document.createElement('div');
+    menu.className = 'taskbar-window-menu';
+
+    windows.forEach(function (win) {
+      const item = document.createElement('div');
+      item.className = 'taskbar-window-menu-item';
+      if (win.minimized) item.classList.add('minimized');
+      item.textContent = win.title || '無標題';
+      item.addEventListener('click', function (e) {
+        e.stopPropagation();
+        if (win.minimized) {
+          WindowModule.restoreWindow(win.windowId);
+        } else {
+          WindowModule.focusWindow(win.windowId);
+        }
+        closeWindowMenu();
+      });
+      menu.appendChild(item);
+    });
+
+    const rect = iconEl.getBoundingClientRect();
+    menu.style.left = rect.left + rect.width / 2 + 'px';
+    menu.style.bottom = (window.innerHeight - rect.top + 8) + 'px';
+
+    document.body.appendChild(menu);
+    activeWindowMenu = menu;
+
+    setTimeout(function () {
+      document.addEventListener('click', _onOutsideClick);
+    }, 0);
+  }
+
+  function closeWindowMenu() {
+    if (activeWindowMenu) {
+      activeWindowMenu.remove();
+      activeWindowMenu = null;
+      document.removeEventListener('click', _onOutsideClick);
+    }
+  }
+
+  function _onOutsideClick(event) {
+    if (activeWindowMenu && !activeWindowMenu.contains(event.target)) {
+      closeWindowMenu();
+    }
+  }
+
+  // ── 運行指示器 ─────────────────────────────────────────────
+
+  /**
+   * 更新單一 App 的運行指示器
+   */
+  function updateRunningIndicator(appId, windowCount) {
+    var iconEl = document.querySelector('.taskbar-icon[data-app-id="' + appId + '"]');
+    if (!iconEl) return;
+
+    var existing = iconEl.querySelector('.running-indicator');
+    if (existing) existing.remove();
+    iconEl.classList.remove('active', 'multi-window');
+
+    if (windowCount > 0) {
+      iconEl.classList.add('active');
+      var indicator = document.createElement('div');
+      indicator.className = 'running-indicator';
+      var dots = Math.min(windowCount, 3);
+      for (var i = 0; i < dots; i++) {
+        var dot = document.createElement('span');
+        dot.className = 'indicator-dot';
+        indicator.appendChild(dot);
+      }
+      if (windowCount > 1) iconEl.classList.add('multi-window');
+      iconEl.appendChild(indicator);
+    }
+  }
+
+  /**
+   * 重算所有指示器
+   */
+  function updateAllRunningIndicators() {
+    if (typeof WindowModule === 'undefined') return;
+
+    var counts = {};
+    quickLaunchApps.forEach(function (a) { counts[a.id] = 0; });
+
+    var allWins = WindowModule.getWindows();
+    Object.values(allWins).forEach(function (w) {
+      if (counts.hasOwnProperty(w.appId)) counts[w.appId]++;
+    });
+
+    quickLaunchApps.forEach(function (a) {
+      updateRunningIndicator(a.id, counts[a.id]);
+    });
+  }
+
+  // ── 渲染 & 初始化 ─────────────────────────────────────────
+
+  function renderIcons() {
+    var taskbar = document.querySelector('.taskbar');
+    if (!taskbar) return;
+
+    quickLaunchApps.forEach(function (app, idx) {
+      var el = createIconElement(app);
+      el.addEventListener('click', handleIconClick);
+      taskbar.appendChild(el);
+
+      // 在第 3 個圖示後加分隔線
+      if (idx === 2) {
+        var div = document.createElement('div');
+        div.className = 'taskbar-divider';
+        taskbar.appendChild(div);
+      }
+    });
+  }
+
+  function init() {
+    renderIcons();
+
+    // 註冊視窗狀態變更回呼
+    if (typeof WindowModule !== 'undefined' && typeof WindowModule.onStateChange === 'function') {
+      WindowModule.onStateChange(function () {
+        updateAllRunningIndicators();
+      });
+    }
+
+    updateAllRunningIndicators();
+    console.log('[TaskbarModule] ✅ Dock 已初始化');
+  }
+
+  // Public API
+  return {
+    init: init,
+    updateRunningIndicator: updateRunningIndicator,
+    updateAllRunningIndicators: updateAllRunningIndicators,
+  };
+})();

--- a/frontend/src/js/entry-compat.js
+++ b/frontend/src/js/entry-compat.js
@@ -58,5 +58,6 @@ import '../../js/share-dialog.js';
 import '../../js/share-manager.js';
 import '../../js/memory-manager.js';
 
-// ─── 桌面（最後載入，因為依賴上述模組） ───
+// ─── 桌面 & Taskbar（最後載入，因為依賴上述模組） ───
 import '../../js/desktop.js';
+import '../../js/taskbar.js';

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -43,5 +43,6 @@ document.addEventListener('DOMContentLoaded', async function () {
   WindowModule.init();
   HeaderModule.init();
   DesktopModule.init();
+  TaskbarModule.init();
   SocketClient.connect();
 });


### PR DESCRIPTION
## 背景

Taskbar 模組（`taskbar.css` + `taskbar.js`）在 commit `9960d9d`（改進手機版 UI/UX）中被刪除，但以下仍殘留引用：

- `docs/frontend.md` 文件提及 `taskbar.css`、`taskbar.js`、`TaskbarModule`
- `design/brand.md` / `docs/design-system.md` 定義 `--taskbar-height`、`--taskbar-icon-size`
- `frontend/css/settings.css:296` 使用 `var(--taskbar-height)`
- `openspec/project.md` 將 Taskbar/Dock 列為核心 UI 組件

## 做法：路徑 A — 恢復簡易 Dock

### 新增檔案
| 檔案 | 說明 |
|------|------|
| `frontend/css/taskbar.css` | Dock 容器、圖示、tooltip、運行指示器、多視窗選單、手機版隱藏、reduced-motion |
| `frontend/js/taskbar.js` | TaskbarModule IIFE：快速啟動列、Dock 點擊邏輯、WindowModule 整合 |

### 修改檔案
| 檔案 | 變更 |
|------|------|
| `frontend/index.html` | 加入 `<link>` + `<nav class="taskbar">` 容器 |
| `frontend/src/js/entry-compat.js` | `import taskbar.js` |
| `frontend/src/main.js` | `TaskbarModule.init()` |

### 功能
- 底部浮動 Dock（macOS 風格，圓角毛玻璃）
- 5 個快速啟動圖示 + 分隔線
- Hover tooltip + 上浮動畫
- 運行指示器小點（1-3 個）
- 多視窗選單（點擊聚焦/恢復）
- 手機版（≤768px）自動隱藏
- `prefers-reduced-motion` 支援
- `--taskbar-height` / `--taskbar-icon-size` CSS 變數

## 測試建議
1. 桌面版瀏覽器開啟，確認 Dock 出現在底部中央
2. 開啟多個視窗，確認指示器小點正確顯示
3. 手機模擬器確認 Dock 隱藏
4. 系統設定面板 `bottom: calc(var(--taskbar-height) + ...)` 不再失效