### PR TITLE
feat(ui): P5 統一 Loading/Empty/Error 回饋元件

### DIFF
--- a/frontend/css/knowledge-base.css
+++ b/frontend/css/knowledge-base.css
@@ -310,7 +310,9 @@
   color: var(--tag-color-blue);
 }
 
-/* Loading & Empty States */
+/* Loading & Empty States
+   ※ 已遷移至 main.css 的 .ui-state 統一元件
+      保留舊 class 做向下相容（以防第三方或動態生成的片段仍使用） */
 .kb-loading,
 .kb-empty {
   display: flex;
@@ -558,7 +560,8 @@
   margin: 2em 0;
 }
 
-/* Content Empty State */
+/* Content Empty State
+   ※ 已遷移至 .ui-state--empty.ui-state--fill（保留舊 class 向下相容） */
 .kb-content-empty {
   display: flex;
   flex-direction: column;

--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -1331,3 +1331,136 @@ input {
 @keyframes spinner-rotate {
   to { transform: rotate(360deg); }
 }
+
+/* ==========================================================================
+   統一回饋狀態元件（Loading / Empty / Error）
+   各模組共用，取代原本分散的 .kb-loading、.ai-chat-empty 等
+   ========================================================================== */
+
+/* ── 共用基底：置中 flex 容器 ── */
+.ui-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm, 8px);
+  padding: var(--spacing-lg, 24px);
+  text-align: center;
+  color: var(--text-secondary, #a0a0a0);
+  font-size: var(--font-size-sm, 13px);
+  min-height: 120px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* 填滿父容器高度（用於主內容面板） */
+.ui-state--fill {
+  height: 100%;
+}
+
+/* 固定高度（用於列表區塊） */
+.ui-state--compact {
+  min-height: 80px;
+  padding: var(--spacing-md, 16px);
+}
+
+/* ── 圖示共用 ── */
+.ui-state .ui-state-icon svg {
+  width: 48px;
+  height: 48px;
+  opacity: 0.3;
+}
+
+.ui-state--fill .ui-state-icon svg {
+  width: 64px;
+  height: 64px;
+  opacity: 0.2;
+}
+
+.ui-state--compact .ui-state-icon svg {
+  width: 32px;
+  height: 32px;
+  opacity: 0.3;
+}
+
+/* ── Loading 狀態 ── */
+.ui-state--loading .ui-state-icon svg {
+  animation: ui-state-spin 1s linear infinite;
+}
+
+@keyframes ui-state-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Loading 骨架列表（多行佔位） */
+.ui-state-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs, 4px);
+  width: 100%;
+  padding: var(--spacing-sm, 8px);
+}
+
+.ui-state-skeleton .skeleton {
+  height: 44px;
+  width: 100%;
+  border-radius: var(--radius-sm, 6px);
+}
+
+.ui-state-skeleton .skeleton:nth-child(2) { width: 90%; }
+.ui-state-skeleton .skeleton:nth-child(3) { width: 75%; }
+
+/* ── Empty 狀態 ── */
+.ui-state--empty {
+  color: var(--text-muted, #888888);
+}
+
+.ui-state--empty .ui-state-text {
+  max-width: 280px;
+  line-height: 1.5;
+}
+
+/* ── Error 狀態 ── */
+.ui-state--error .ui-state-icon svg {
+  opacity: 0.6;
+  color: var(--color-error, #dc2626);
+}
+
+.ui-state--error .ui-state-text {
+  color: var(--color-error, #dc2626);
+  opacity: 0.85;
+}
+
+.ui-state--error .ui-state-detail {
+  font-size: var(--font-size-xs, 12px);
+  color: var(--text-muted, #888888);
+  max-width: 320px;
+  word-break: break-word;
+}
+
+/* 重試按鈕 */
+.ui-state-retry {
+  margin-top: var(--spacing-sm, 8px);
+  padding: var(--spacing-xs, 4px) var(--spacing-md, 16px);
+  border: 1px solid var(--border-light, rgba(255, 255, 255, 0.1));
+  border-radius: var(--radius-sm, 6px);
+  background: var(--bg-surface, rgba(0, 0, 0, 0.1));
+  color: var(--text-secondary, #a0a0a0);
+  font-size: var(--font-size-xs, 12px);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.ui-state-retry:hover {
+  background: var(--hover-bg, rgba(255, 255, 255, 0.1));
+  border-color: var(--border-medium, rgba(255, 255, 255, 0.15));
+  color: var(--text-primary, #f0f0f0);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ui-state--loading .ui-state-icon svg {
+    animation: none !important;
+    opacity: 0.5;
+  }
+}

--- a/frontend/js/ai-assistant.js
+++ b/frontend/js/ai-assistant.js
@@ -247,12 +247,10 @@ const AIAssistantApp = (function() {
     if (!container) return;
 
     if (chats.length === 0) {
-      container.innerHTML = `
-        <div class="ai-chat-empty">
-          <span class="icon">${getIcon('chat')}</span>
-          <p>尚無對話</p>
-        </div>
-      `;
+      UIHelpers.showEmpty(container, {
+        icon: 'chat',
+        text: '尚無對話',
+      });
       return;
     }
 

--- a/frontend/js/knowledge-base.js
+++ b/frontend/js/knowledge-base.js
@@ -188,9 +188,9 @@ const KnowledgeBaseModule = (function() {
               <span class="kb-list-count" id="kbListCount">0 筆</span>
             </div>
             <div class="kb-list" id="kbList">
-              <div class="kb-loading">
-                <span class="icon">${getIcon('refresh')}</span>
-                <span>載入中...</span>
+              <div class="ui-state ui-state--loading" role="status" aria-live="polite">
+                <span class="ui-state-icon">${getIcon('refresh')}</span>
+                <span class="ui-state-text">載入中…</span>
               </div>
             </div>
           </div>
@@ -198,10 +198,10 @@ const KnowledgeBaseModule = (function() {
           <div class="kb-resizer" id="kbResizer"></div>
 
           <div class="kb-content-panel" id="kbContentPanel">
-            <div class="kb-content-empty" id="kbContentEmpty">
-              <span class="icon">${getIcon('book-open-page-variant')}</span>
-              <p>選擇一個知識來查看內容</p>
-              <p>或點擊「新增」建立新知識</p>
+            <div class="ui-state ui-state--empty ui-state--fill" id="kbContentEmpty" role="status">
+              <span class="ui-state-icon">${getIcon('book-open-page-variant')}</span>
+              <span class="ui-state-text">選擇一個知識來查看內容</span>
+              <span class="ui-state-text">或點擊「新增」建立新知識</span>
             </div>
             <div class="kb-content-view" id="kbContentView" style="display: none;"></div>
             <div class="kb-editor" id="kbEditor" style="display: none;"></div>
@@ -345,12 +345,7 @@ const KnowledgeBaseModule = (function() {
     }
 
     const listEl = windowEl.querySelector('#kbList');
-    listEl.innerHTML = `
-      <div class="kb-loading">
-        <span class="icon">${getIcon('refresh')}</span>
-        <span>載入中...</span>
-      </div>
-    `;
+    UIHelpers.showLoading(listEl, { icon: 'refresh', text: '載入中…' });
 
     try {
       const params = new URLSearchParams();
@@ -366,12 +361,12 @@ const KnowledgeBaseModule = (function() {
       renderList(windowEl);
     } catch (error) {
       console.error('Failed to load knowledge:', error);
-      listEl.innerHTML = `
-        <div class="kb-empty">
-          <span class="icon">${getIcon('close')}</span>
-          <span>載入失敗: ${error.message}</span>
-        </div>
-      `;
+      UIHelpers.showError(listEl, {
+        icon: 'close',
+        message: '載入失敗',
+        detail: error.message,
+        onRetry: () => loadKnowledge(),
+      });
     }
   }
 
@@ -385,12 +380,10 @@ const KnowledgeBaseModule = (function() {
     countEl.textContent = `${knowledgeList.length} 筆`;
 
     if (knowledgeList.length === 0) {
-      listEl.innerHTML = `
-        <div class="kb-empty">
-          <span class="icon">${getIcon('book-open-page-variant')}</span>
-          <span>沒有找到符合條件的知識</span>
-        </div>
-      `;
+      UIHelpers.showEmpty(listEl, {
+        icon: 'book-open-page-variant',
+        text: '沒有找到符合條件的知識',
+      });
       return;
     }
 
@@ -1409,8 +1402,8 @@ const KnowledgeBaseModule = (function() {
       </div>
       <div class="kb-history-list">
         ${historyData.entries.length === 0 ? `
-          <div class="kb-empty" style="height: 100px;">
-            <span>尚無版本歷史</span>
+          <div class="ui-state ui-state--empty ui-state--compact" role="status">
+            <span class="ui-state-text">尚無版本歷史</span>
           </div>
         ` : historyData.entries.map(entry => `
           <div class="kb-history-item" data-commit="${entry.commit}">

--- a/frontend/js/ui-helpers.js
+++ b/frontend/js/ui-helpers.js
@@ -1,0 +1,161 @@
+/**
+ * ChingTech OS — 統一回饋狀態元件 (Loading / Empty / Error)
+ *
+ * 提供 showLoading / showEmpty / showError 三個 API，
+ * 取代各模組分散的 .kb-loading、.ai-chat-empty 等重複實作。
+ *
+ * 使用範例：
+ *   UIHelpers.showLoading(containerEl, { text: '載入知識庫…' });
+ *   UIHelpers.showEmpty(containerEl, { icon: 'book-open-page-variant', text: '尚無資料' });
+ *   UIHelpers.showError(containerEl, { message: err.message, onRetry: () => loadData() });
+ *   UIHelpers.showSkeleton(containerEl, { rows: 5 });
+ */
+const UIHelpers = (function () {
+  'use strict';
+
+  // ── 預設值 ──
+  const DEFAULTS = {
+    loadingIcon: 'refresh',
+    loadingText: '載入中…',
+    emptyIcon: 'information-outline',
+    emptyText: '目前沒有資料',
+    errorIcon: 'alert-circle',
+    errorText: '載入失敗',
+    retryText: '重試',
+    skeletonRows: 3,
+  };
+
+  /**
+   * 取得圖示 HTML（依賴全域 getIcon）
+   * @param {string} name - icon 名稱
+   * @returns {string} HTML
+   */
+  function icon(name) {
+    return typeof getIcon === 'function' ? getIcon(name) : '';
+  }
+
+  // ── 核心 API ─────────────────────────────────────────────
+
+  /**
+   * 顯示 Loading 狀態（旋轉圖示 + 文字）
+   *
+   * @param {HTMLElement} container - 要填入 HTML 的容器
+   * @param {Object}  [opts]
+   * @param {string}  [opts.icon]      - 圖示名稱（預設 'refresh'）
+   * @param {string}  [opts.text]      - 載入提示文字
+   * @param {string}  [opts.variant]   - 'fill' | 'compact' | '' （預設 ''）
+   * @returns {HTMLElement} 產生的 .ui-state 元素
+   */
+  function showLoading(container, opts = {}) {
+    const variant = opts.variant ? ` ui-state--${opts.variant}` : '';
+    const html = `
+      <div class="ui-state ui-state--loading${variant}" role="status" aria-live="polite">
+        <span class="ui-state-icon">${icon(opts.icon || DEFAULTS.loadingIcon)}</span>
+        <span class="ui-state-text">${opts.text || DEFAULTS.loadingText}</span>
+      </div>`;
+    container.innerHTML = html;
+    return container.firstElementChild;
+  }
+
+  /**
+   * 顯示 Empty 狀態（圖示 + 說明文字）
+   *
+   * @param {HTMLElement} container
+   * @param {Object}  [opts]
+   * @param {string}  [opts.icon]       - 圖示名稱
+   * @param {string}  [opts.text]       - 主要文字
+   * @param {string}  [opts.subtext]    - 次要說明（選填）
+   * @param {string}  [opts.variant]    - 'fill' | 'compact' | ''
+   * @returns {HTMLElement}
+   */
+  function showEmpty(container, opts = {}) {
+    const variant = opts.variant ? ` ui-state--${opts.variant}` : '';
+    const sub = opts.subtext ? `<p class="ui-state-text">${opts.subtext}</p>` : '';
+    const html = `
+      <div class="ui-state ui-state--empty${variant}" role="status">
+        <span class="ui-state-icon">${icon(opts.icon || DEFAULTS.emptyIcon)}</span>
+        <span class="ui-state-text">${opts.text || DEFAULTS.emptyText}</span>
+        ${sub}
+      </div>`;
+    container.innerHTML = html;
+    return container.firstElementChild;
+  }
+
+  /**
+   * 顯示 Error 狀態（錯誤圖示 + 訊息 + 可選重試按鈕）
+   *
+   * @param {HTMLElement} container
+   * @param {Object}  [opts]
+   * @param {string}  [opts.icon]       - 圖示名稱（預設 'alert-circle'）
+   * @param {string}  [opts.message]    - 錯誤訊息
+   * @param {string}  [opts.detail]     - 詳細資訊（選填，例如 error.message）
+   * @param {string}  [opts.variant]    - 'fill' | 'compact' | ''
+   * @param {Function} [opts.onRetry]   - 重試回呼（若提供則顯示重試按鈕）
+   * @returns {HTMLElement}
+   */
+  function showError(container, opts = {}) {
+    const variant = opts.variant ? ` ui-state--${opts.variant}` : '';
+    const detail = opts.detail
+      ? `<span class="ui-state-detail">${opts.detail}</span>`
+      : '';
+    const retryBtn = opts.onRetry
+      ? `<button class="ui-state-retry" type="button">${DEFAULTS.retryText}</button>`
+      : '';
+
+    const html = `
+      <div class="ui-state ui-state--error${variant}" role="alert" aria-live="assertive">
+        <span class="ui-state-icon">${icon(opts.icon || DEFAULTS.errorIcon)}</span>
+        <span class="ui-state-text">${opts.message || DEFAULTS.errorText}</span>
+        ${detail}
+        ${retryBtn}
+      </div>`;
+    container.innerHTML = html;
+
+    // 綁定重試事件
+    if (opts.onRetry) {
+      const btn = container.querySelector('.ui-state-retry');
+      if (btn) btn.addEventListener('click', opts.onRetry);
+    }
+    return container.firstElementChild;
+  }
+
+  /**
+   * 顯示骨架屏 Loading（shimmer 佔位列）
+   *
+   * @param {HTMLElement} container
+   * @param {Object}  [opts]
+   * @param {number}  [opts.rows]   - 骨架行數（預設 3）
+   * @param {number}  [opts.height] - 每行高度 px（預設 44）
+   * @returns {HTMLElement}
+   */
+  function showSkeleton(container, opts = {}) {
+    const rows = opts.rows || DEFAULTS.skeletonRows;
+    const h = opts.height || 44;
+    const items = Array.from({ length: rows }, (_, i) => {
+      // 交替寬度讓骨架看起來更自然
+      const w = i % 3 === 1 ? '90%' : i % 3 === 2 ? '75%' : '100%';
+      return `<div class="skeleton" style="height:${h}px;width:${w}"></div>`;
+    }).join('');
+
+    container.innerHTML = `<div class="ui-state-skeleton">${items}</div>`;
+    return container.firstElementChild;
+  }
+
+  /**
+   * 清除容器的回饋狀態
+   * @param {HTMLElement} container
+   */
+  function clear(container) {
+    const el = container.querySelector('.ui-state, .ui-state-skeleton');
+    if (el) el.remove();
+  }
+
+  // ── Public API ──
+  return {
+    showLoading,
+    showEmpty,
+    showError,
+    showSkeleton,
+    clear,
+  };
+})();

--- a/frontend/src/js/entry-compat.js
+++ b/frontend/src/js/entry-compat.js
@@ -23,6 +23,7 @@
 // ─── 基礎設施 ───
 import '../../js/config.js';
 import '../../js/icons.js';
+import '../../js/ui-helpers.js';         // 統一回饋狀態元件（依賴 icons.js 的 getIcon）
 import '../../js/file-utils.js';
 import '../../js/path-utils.js';
 

--- a/frontend/tests/ui-helpers.test.js
+++ b/frontend/tests/ui-helpers.test.js
@@ -1,0 +1,172 @@
+/**
+ * UIHelpers — Smoke Test
+ *
+ * 在 Node.js 環境下驗證 UIHelpers API 的基本正確性：
+ *   - showLoading / showEmpty / showError / showSkeleton / clear
+ *   - 產出 HTML 結構包含正確的 CSS class 與 ARIA 屬性
+ */
+
+/* ── 模擬瀏覽器最小 DOM 環境 ── */
+function createElement(tag) {
+  const children = [];
+  let html = '';
+  const el = {
+    tagName: tag,
+    className: '',
+    innerHTML: '',
+    children,
+    get firstElementChild() {
+      // 簡易解析：回傳自身作為代理（僅檢查 HTML 字串）
+      return el;
+    },
+    querySelector(sel) {
+      // 極簡：若 innerHTML 包含匹配的 class 名就回傳一個 stub
+      const classMatch = sel.match(/\.([\w-]+)/);
+      if (classMatch && el.innerHTML.includes(classMatch[1])) {
+        return {
+          remove() { el.innerHTML = el.innerHTML.replace(new RegExp(`<[^>]*${classMatch[1]}[^>]*>[\\s\\S]*?<\\/[^>]+>`), ''); },
+          addEventListener() {},
+        };
+      }
+      return null;
+    },
+  };
+  return el;
+}
+
+// 模擬全域 getIcon
+globalThis.getIcon = (name) => `<svg data-icon="${name}"></svg>`;
+
+// 載入模組（IIFE 會將 UIHelpers 註冊到 globalThis）
+const fs = require('fs');
+const vm = require('vm');
+const code = fs.readFileSync(require('path').join(__dirname, '..', 'js', 'ui-helpers.js'), 'utf8');
+vm.runInThisContext(code, { filename: 'ui-helpers.js' });
+
+/* ── 測試工具 ── */
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) {
+    passed++;
+    console.log(`  ✅ ${label}`);
+  } else {
+    failed++;
+    console.error(`  ❌ ${label}`);
+  }
+}
+
+/* ── 測試案例 ── */
+console.log('🧪 UIHelpers Smoke Tests\n');
+
+// 1. showLoading
+console.log('── showLoading ──');
+{
+  const c = createElement('div');
+  UIHelpers.showLoading(c, { text: '載入知識庫…' });
+  assert(c.innerHTML.includes('ui-state--loading'), 'has .ui-state--loading class');
+  assert(c.innerHTML.includes('role="status"'), 'has role="status"');
+  assert(c.innerHTML.includes('載入知識庫…'), 'renders custom text');
+  assert(c.innerHTML.includes('data-icon="refresh"'), 'renders default refresh icon');
+}
+
+// 2. showLoading with variant
+console.log('── showLoading (compact) ──');
+{
+  const c = createElement('div');
+  UIHelpers.showLoading(c, { variant: 'compact' });
+  assert(c.innerHTML.includes('ui-state--compact'), 'has .ui-state--compact class');
+  assert(c.innerHTML.includes('載入中'), 'renders default text');
+}
+
+// 3. showEmpty
+console.log('── showEmpty ──');
+{
+  const c = createElement('div');
+  UIHelpers.showEmpty(c, { icon: 'book-open-page-variant', text: '沒有找到資料', subtext: '請嘗試其他篩選條件' });
+  assert(c.innerHTML.includes('ui-state--empty'), 'has .ui-state--empty class');
+  assert(c.innerHTML.includes('沒有找到資料'), 'renders main text');
+  assert(c.innerHTML.includes('請嘗試其他篩選條件'), 'renders subtext');
+  assert(c.innerHTML.includes('data-icon="book-open-page-variant"'), 'renders custom icon');
+}
+
+// 4. showEmpty with fill variant
+console.log('── showEmpty (fill) ──');
+{
+  const c = createElement('div');
+  UIHelpers.showEmpty(c, { variant: 'fill', text: '選擇項目' });
+  assert(c.innerHTML.includes('ui-state--fill'), 'has .ui-state--fill class');
+}
+
+// 5. showError
+console.log('── showError ──');
+{
+  const c = createElement('div');
+  let retryCalled = false;
+  UIHelpers.showError(c, {
+    message: '載入失敗',
+    detail: 'Network timeout',
+    onRetry: () => { retryCalled = true; },
+  });
+  assert(c.innerHTML.includes('ui-state--error'), 'has .ui-state--error class');
+  assert(c.innerHTML.includes('role="alert"'), 'has role="alert"');
+  assert(c.innerHTML.includes('載入失敗'), 'renders error message');
+  assert(c.innerHTML.includes('Network timeout'), 'renders error detail');
+  assert(c.innerHTML.includes('ui-state-retry'), 'renders retry button');
+  assert(c.innerHTML.includes('data-icon="alert-circle"'), 'renders default error icon');
+}
+
+// 6. showError without retry
+console.log('── showError (no retry) ──');
+{
+  const c = createElement('div');
+  UIHelpers.showError(c, { message: '伺服器錯誤' });
+  assert(!c.innerHTML.includes('ui-state-retry'), 'no retry button when onRetry omitted');
+}
+
+// 7. showSkeleton
+console.log('── showSkeleton ──');
+{
+  const c = createElement('div');
+  UIHelpers.showSkeleton(c, { rows: 5, height: 40 });
+  assert(c.innerHTML.includes('ui-state-skeleton'), 'has .ui-state-skeleton class');
+  const skeletonCount = (c.innerHTML.match(/class="skeleton"/g) || []).length;
+  assert(skeletonCount === 5, `renders 5 skeleton rows (got ${skeletonCount})`);
+  assert(c.innerHTML.includes('height:40px'), 'uses custom height');
+}
+
+// 8. showSkeleton defaults
+console.log('── showSkeleton (defaults) ──');
+{
+  const c = createElement('div');
+  UIHelpers.showSkeleton(c);
+  const skeletonCount = (c.innerHTML.match(/class="skeleton"/g) || []).length;
+  assert(skeletonCount === 3, `renders 3 default skeleton rows (got ${skeletonCount})`);
+}
+
+// 9. clear
+console.log('── clear ──');
+{
+  const c = createElement('div');
+  UIHelpers.showLoading(c);
+  UIHelpers.clear(c);
+  // 因為我們的簡易 DOM，clear 會嘗試移除；檢查沒有拋錯即可
+  assert(true, 'clear() runs without error');
+}
+
+// 10. defaults
+console.log('── defaults ──');
+{
+  const c = createElement('div');
+  UIHelpers.showLoading(c);
+  assert(c.innerHTML.includes('載入中'), 'default loading text');
+  
+  const c2 = createElement('div');
+  UIHelpers.showEmpty(c2);
+  assert(c2.innerHTML.includes('目前沒有資料'), 'default empty text');
+}
+
+/* ── 結果 ── */
+console.log(`\n📊 結果：${passed} 通過, ${failed} 失敗`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## 變更摘要

### 🎯 目標
統一各模組分散的 loading / empty / error 狀態 UI，提供可重複使用的 **UIHelpers** 共用元件。

### 📦 新增檔案
| 檔案 | 說明 |
|------|------|
| `frontend/js/ui-helpers.js` | UIHelpers 模組 (IIFE)，提供 `showLoading`、`showEmpty`、`showError`、`showSkeleton`、`clear` API |
| `frontend/tests/ui-helpers.test.js` | 25 項 smoke test 斷言 |

### ✏️ 修改檔案
| 檔案 | 變更 |
|------|------|
| `frontend/css/main.css` | 新增 `.ui-state` 系列共用樣式 (loading / empty / error / skeleton)，含 ARIA 與 reduced-motion 支援 |
| `frontend/css/knowledge-base.css` | 加上遷移註解，保留舊 class 做向下相容 |
| `frontend/js/knowledge-base.js` | 5 處改用 UIHelpers (列表載入/空結果/載入失敗+重試/內容面板空狀態/版本歷史空狀態) |
| `frontend/js/ai-assistant.js` | 1 處改用 UIHelpers (對話列表空狀態) |
| `frontend/src/js/entry-compat.js` | 在 icons.js 後面引入 ui-helpers.js |

### 🔧 UIHelpers API
```js
UIHelpers.showLoading(container, { icon, text, variant })
UIHelpers.showEmpty(container, { icon, text, subtext, variant })
UIHelpers.showError(container, { icon, message, detail, variant, onRetry })
UIHelpers.showSkeleton(container, { rows, height })
UIHelpers.clear(container)
```

### ✅ 測試
- UIHelpers smoke test：**25/25 通過**
- 既有 path-utils test：**40/40 通過**
- Vite build：**成功** (64 modules, 708ms)

### 🎨 CSS 設計
- `.ui-state` 基底：flex 置中 + gap + padding
- `.ui-state--fill`：撐滿父容器 (height: 100%)
- `.ui-state--compact`：緊湊模式 (min-height: 80px)
- `.ui-state--loading`：旋轉圖示動畫
- `.ui-state--error`：紅色圖示/文字 + 重試按鈕
- 骨架屏：shimmer 動畫 + 交替寬度
- ARIA：`role=status` / `role=alert` + `aria-live`
- `prefers-reduced-motion`：停止動畫