### PR TITLE
feat(command-palette): P10 全域搜尋 / Command Palette

### DIFF
--- a/frontend/css/command-palette.css
+++ b/frontend/css/command-palette.css
@@ -1,0 +1,285 @@
+/* ==========================================================================
+   ChingTech OS - Command Palette / 全域搜尋 (P10)
+   ========================================================================== */
+
+/* ---------- Trigger Button (header-center) ---------- */
+.command-palette-trigger {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: 4px 12px;
+  height: 28px;
+  min-width: 200px;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.command-palette-trigger:hover {
+  background-color: var(--interactive-hover);
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.command-palette-trigger .icon svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.command-palette-trigger-text {
+  flex: 1;
+  text-align: left;
+  opacity: 0.7;
+}
+
+.command-palette-trigger-kbd {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  opacity: 0.6;
+}
+
+.command-palette-trigger-kbd kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  background-color: var(--bg-surface-dark);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  font-family: inherit;
+  line-height: 1.2;
+}
+
+/* ---------- Overlay / Backdrop ---------- */
+.command-palette-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 15vh;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--transition-fast), visibility var(--transition-fast);
+}
+
+.command-palette-overlay.open {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ---------- Dialog ---------- */
+.command-palette-dialog {
+  width: 560px;
+  max-width: 90vw;
+  max-height: 420px;
+  background-color: var(--bg-glass-heavy);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg), 0 0 40px rgba(var(--color-primary-rgb), 0.1);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transform: scale(0.96) translateY(-10px);
+  transition: transform var(--transition-fast);
+}
+
+.command-palette-overlay.open .command-palette-dialog {
+  transform: scale(1) translateY(0);
+}
+
+/* ---------- Search Input Area ---------- */
+.command-palette-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+  border-bottom: 1px solid var(--border-light);
+}
+
+.command-palette-input-wrap .icon {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.command-palette-input-wrap .icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.command-palette-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: var(--font-size-base);
+  color: var(--text-primary);
+  font-family: inherit;
+}
+
+.command-palette-input::placeholder {
+  color: var(--text-secondary);
+  opacity: 0.6;
+}
+
+/* ---------- Results List ---------- */
+.command-palette-results {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-sm) 0;
+}
+
+.command-palette-results::-webkit-scrollbar {
+  width: 4px;
+}
+
+.command-palette-results::-webkit-scrollbar-thumb {
+  background-color: var(--border-light);
+  border-radius: 2px;
+}
+
+/* Section Header */
+.command-palette-section {
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Result Item */
+.command-palette-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.command-palette-item:hover,
+.command-palette-item.active {
+  background-color: var(--interactive-hover);
+}
+
+.command-palette-item.active {
+  background-color: var(--accent-bg-subtle);
+}
+
+.command-palette-item .icon {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.command-palette-item .icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.command-palette-item-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.command-palette-item-name {
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.command-palette-item-desc {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Highlight matched text */
+.command-palette-item-name mark {
+  background: transparent;
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.command-palette-item-badge {
+  flex-shrink: 0;
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background-color: var(--bg-surface-dark);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-light);
+}
+
+/* ---------- Footer ---------- */
+.command-palette-footer {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-top: 1px solid var(--border-light);
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+.command-palette-footer kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  background-color: var(--bg-surface-dark);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  font-size: 10px;
+  font-family: var(--font-mono);
+  line-height: 1.3;
+}
+
+.command-palette-empty {
+  padding: var(--spacing-lg) var(--spacing-md);
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+/* ---------- Mobile ---------- */
+@media (max-width: 768px) {
+  .command-palette-trigger {
+    min-width: 36px;
+    max-width: 36px;
+    height: 36px;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .command-palette-trigger-text,
+  .command-palette-trigger-kbd {
+    display: none;
+  }
+
+  .command-palette-overlay {
+    padding-top: 10vh;
+  }
+
+  .command-palette-dialog {
+    width: 95vw;
+    max-height: 50vh;
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -42,6 +42,7 @@
   <link rel="stylesheet" href="css/memory-manager.css">
   <link rel="stylesheet" href="css/notification.css">
   <link rel="stylesheet" href="css/taskbar.css">
+  <link rel="stylesheet" href="css/command-palette.css">
   -->
 
   <!-- xterm.js -->

--- a/frontend/js/command-palette.js
+++ b/frontend/js/command-palette.js
@@ -1,0 +1,381 @@
+/**
+ * ChingTech OS - Command Palette / 全域搜尋 (P10)
+ *
+ * Client-only 實作：搜尋已註冊的應用程式名稱與已開啟視窗標題。
+ *
+ * 限制（需後端支援時再擴充）：
+ *  - 目前僅搜尋前端已載入的應用清單（DesktopModule.getApplications()）
+ *  - 僅搜尋目前已開啟視窗標題（WindowModule.getWindows()）
+ *  - 不包含檔案搜尋、知識庫全文搜尋等需後端 API 的功能
+ */
+
+const CommandPaletteModule = (function () {
+  'use strict';
+
+  // ── DOM refs ───────────────────────────────────────────────
+  let overlayEl = null;
+  let inputEl = null;
+  let resultsEl = null;
+  let activeIndex = -1;
+  let flatItems = [];   // 目前搜尋結果的扁平陣列 { type, data, element }
+
+  // ── Build DOM ──────────────────────────────────────────────
+
+  /**
+   * 在 header-center 插入觸發按鈕
+   */
+  function createTriggerButton() {
+    const headerCenter = document.querySelector('.header-center');
+    if (!headerCenter) return;
+
+    const btn = document.createElement('button');
+    btn.className = 'command-palette-trigger';
+    btn.type = 'button';
+    btn.setAttribute('aria-label', '全域搜尋');
+
+    const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+    const modKey = isMac ? '⌘' : 'Ctrl';
+
+    btn.innerHTML = `
+      <span class="icon">${typeof getIcon === 'function' ? getIcon('search') : '🔍'}</span>
+      <span class="command-palette-trigger-text">搜尋…</span>
+      <span class="command-palette-trigger-kbd">
+        <kbd>${modKey}</kbd><kbd>K</kbd>
+      </span>
+    `;
+
+    btn.addEventListener('click', open);
+    headerCenter.appendChild(btn);
+  }
+
+  /**
+   * 建立 overlay + dialog DOM（附加到 body）
+   */
+  function createOverlay() {
+    overlayEl = document.createElement('div');
+    overlayEl.className = 'command-palette-overlay';
+    overlayEl.setAttribute('role', 'dialog');
+    overlayEl.setAttribute('aria-label', '全域搜尋');
+
+    overlayEl.innerHTML = `
+      <div class="command-palette-dialog">
+        <div class="command-palette-input-wrap">
+          <span class="icon">${typeof getIcon === 'function' ? getIcon('search') : '🔍'}</span>
+          <input class="command-palette-input"
+                 type="text"
+                 placeholder="搜尋應用程式或視窗…"
+                 autocomplete="off"
+                 spellcheck="false" />
+        </div>
+        <div class="command-palette-results"></div>
+        <div class="command-palette-footer">
+          <span><kbd>↑↓</kbd> 瀏覽</span>
+          <span><kbd>Enter</kbd> 開啟</span>
+          <span><kbd>Esc</kbd> 關閉</span>
+        </div>
+      </div>
+    `;
+
+    // Cache refs
+    inputEl = overlayEl.querySelector('.command-palette-input');
+    resultsEl = overlayEl.querySelector('.command-palette-results');
+
+    // Events
+    overlayEl.addEventListener('click', (e) => {
+      if (e.target === overlayEl) close();
+    });
+    inputEl.addEventListener('input', () => handleSearch(inputEl.value));
+    inputEl.addEventListener('keydown', handleInputKeydown);
+
+    document.body.appendChild(overlayEl);
+  }
+
+  // ── Open / Close ───────────────────────────────────────────
+
+  function open() {
+    if (!overlayEl) createOverlay();
+    overlayEl.classList.add('open');
+    inputEl.value = '';
+    handleSearch('');
+    // Delay focus to let the CSS transition start
+    requestAnimationFrame(() => inputEl.focus());
+  }
+
+  function close() {
+    if (!overlayEl) return;
+    overlayEl.classList.remove('open');
+    activeIndex = -1;
+  }
+
+  function toggle() {
+    if (overlayEl && overlayEl.classList.contains('open')) {
+      close();
+    } else {
+      open();
+    }
+  }
+
+  // ── Search Logic ───────────────────────────────────────────
+
+  /**
+   * 收集所有可搜尋項目並回傳分類結果
+   */
+  function collectItems(query) {
+    const q = query.trim().toLowerCase();
+    const results = { apps: [], windows: [] };
+
+    // 1. 已註冊應用程式
+    if (typeof DesktopModule !== 'undefined' && DesktopModule.getApplications) {
+      const apps = DesktopModule.getApplications();
+      apps.forEach((app) => {
+        if (!q || app.name.toLowerCase().includes(q) || app.id.toLowerCase().includes(q)) {
+          results.apps.push(app);
+        }
+      });
+    }
+
+    // 2. 已開啟的視窗
+    if (typeof WindowModule !== 'undefined' && WindowModule.getWindows) {
+      const windows = WindowModule.getWindows();
+      Object.entries(windows).forEach(([winId, win]) => {
+        const title = win.title || '';
+        if (!q || title.toLowerCase().includes(q) || (win.appId && win.appId.toLowerCase().includes(q))) {
+          results.windows.push({ winId, ...win });
+        }
+      });
+    }
+
+    return results;
+  }
+
+  /**
+   * 高亮匹配文字
+   */
+  function highlight(text, query) {
+    if (!query) return escapeHtml(text);
+    const escaped = escapeHtml(text);
+    const q = escapeHtml(query);
+    const regex = new RegExp(`(${escapeRegex(q)})`, 'gi');
+    return escaped.replace(regex, '<mark>$1</mark>');
+  }
+
+  function escapeHtml(str) {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  function escapeRegex(str) {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  /**
+   * 取得應用程式的圖示 HTML
+   */
+  function getAppIconHtml(app) {
+    if (typeof getIcon === 'function') {
+      // 嘗試直接用 icon id
+      const svg = getIcon(app.icon);
+      if (svg) return svg;
+    }
+    return getIcon ? getIcon('application') || getIcon('apps') || '' : '';
+  }
+
+  /**
+   * 渲染搜尋結果至 DOM
+   */
+  function handleSearch(query) {
+    const q = query.trim();
+    const { apps, windows } = collectItems(q);
+    resultsEl.innerHTML = '';
+    flatItems = [];
+    activeIndex = -1;
+
+    const hasResults = apps.length > 0 || windows.length > 0;
+
+    if (!hasResults) {
+      resultsEl.innerHTML = `<div class="command-palette-empty">${
+        q ? '找不到符合的結果' : '輸入關鍵字開始搜尋'
+      }</div>`;
+      return;
+    }
+
+    // ── 應用程式 ──
+    if (apps.length > 0) {
+      const section = document.createElement('div');
+      section.className = 'command-palette-section';
+      section.textContent = '應用程式';
+      resultsEl.appendChild(section);
+
+      apps.forEach((app) => {
+        const item = createResultItem({
+          iconHtml: getAppIconHtml(app),
+          name: highlight(app.name, q),
+          desc: app.id,
+          badge: '開啟',
+          type: 'app',
+          data: app,
+        });
+        resultsEl.appendChild(item);
+      });
+    }
+
+    // ── 開啟中的視窗 ──
+    if (windows.length > 0) {
+      const section = document.createElement('div');
+      section.className = 'command-palette-section';
+      section.textContent = '開啟中的視窗';
+      resultsEl.appendChild(section);
+
+      windows.forEach((win) => {
+        const item = createResultItem({
+          iconHtml: typeof getIcon === 'function' ? (getIcon('window-maximize') || getIcon('application') || '') : '',
+          name: highlight(win.title || '(無標題)', q),
+          desc: win.appId || '',
+          badge: '切換',
+          type: 'window',
+          data: win,
+        });
+        resultsEl.appendChild(item);
+      });
+    }
+
+    // 預設選取第一項
+    if (flatItems.length > 0) {
+      activeIndex = 0;
+      flatItems[0].element.classList.add('active');
+    }
+  }
+
+  /**
+   * 建立單一結果項目 DOM
+   */
+  function createResultItem({ iconHtml, name, desc, badge, type, data }) {
+    const el = document.createElement('div');
+    el.className = 'command-palette-item';
+    el.innerHTML = `
+      <span class="icon">${iconHtml}</span>
+      <div class="command-palette-item-text">
+        <span class="command-palette-item-name">${name}</span>
+        ${desc ? `<span class="command-palette-item-desc">${escapeHtml(desc)}</span>` : ''}
+      </div>
+      ${badge ? `<span class="command-palette-item-badge">${escapeHtml(badge)}</span>` : ''}
+    `;
+
+    const entry = { type, data, element: el };
+    flatItems.push(entry);
+
+    el.addEventListener('click', () => executeItem(entry));
+    el.addEventListener('mouseenter', () => {
+      setActiveIndex(flatItems.indexOf(entry));
+    });
+
+    return el;
+  }
+
+  // ── Keyboard Navigation ────────────────────────────────────
+
+  function handleInputKeydown(e) {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveIndex(activeIndex + 1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setActiveIndex(activeIndex - 1);
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (activeIndex >= 0 && activeIndex < flatItems.length) {
+          executeItem(flatItems[activeIndex]);
+        }
+        break;
+      case 'Escape':
+        e.preventDefault();
+        close();
+        break;
+    }
+  }
+
+  function setActiveIndex(newIndex) {
+    if (flatItems.length === 0) return;
+    // Clamp
+    if (newIndex < 0) newIndex = flatItems.length - 1;
+    if (newIndex >= flatItems.length) newIndex = 0;
+
+    // Remove old active
+    if (activeIndex >= 0 && activeIndex < flatItems.length) {
+      flatItems[activeIndex].element.classList.remove('active');
+    }
+
+    activeIndex = newIndex;
+    flatItems[activeIndex].element.classList.add('active');
+
+    // Scroll into view
+    flatItems[activeIndex].element.scrollIntoView({ block: 'nearest' });
+  }
+
+  // ── Execute ────────────────────────────────────────────────
+
+  function executeItem(entry) {
+    close();
+
+    if (entry.type === 'app') {
+      // 開啟應用程式
+      if (typeof DesktopModule !== 'undefined' && DesktopModule.openApp) {
+        DesktopModule.openApp(entry.data.id);
+      }
+    } else if (entry.type === 'window') {
+      // 切換至已開啟的視窗
+      if (typeof WindowModule !== 'undefined') {
+        const winId = entry.data.winId;
+        // 如果視窗被最小化，先還原
+        if (entry.data.minimized && WindowModule.restoreWindow) {
+          WindowModule.restoreWindow(winId);
+        }
+        if (WindowModule.focusWindow) {
+          WindowModule.focusWindow(winId);
+        }
+      }
+    }
+  }
+
+  // ── Global Shortcut ────────────────────────────────────────
+
+  function handleGlobalKeydown(e) {
+    // Ctrl+K / Cmd+K
+    if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+      e.preventDefault();
+      e.stopPropagation();
+      toggle();
+    }
+  }
+
+  // ── Init / Destroy ─────────────────────────────────────────
+
+  function init() {
+    createTriggerButton();
+    // 全域快捷鍵在 overlay 建立前就要監聽
+    document.addEventListener('keydown', handleGlobalKeydown, true);
+  }
+
+  function destroy() {
+    document.removeEventListener('keydown', handleGlobalKeydown, true);
+    if (overlayEl && overlayEl.parentNode) {
+      overlayEl.parentNode.removeChild(overlayEl);
+    }
+    overlayEl = null;
+    inputEl = null;
+    resultsEl = null;
+  }
+
+  // ── Public API ─────────────────────────────────────────────
+  return {
+    init,
+    destroy,
+    open,
+    close,
+    toggle,
+  };
+})();

--- a/frontend/src/js/entry-compat.js
+++ b/frontend/src/js/entry-compat.js
@@ -58,6 +58,9 @@ import '../../js/share-dialog.js';
 import '../../js/share-manager.js';
 import '../../js/memory-manager.js';
 
+// ─── Command Palette / 全域搜尋 ───
+import '../../js/command-palette.js';
+
 // ─── 桌面 & Taskbar（最後載入，因為依賴上述模組） ───
 import '../../js/desktop.js';
 import '../../js/taskbar.js';

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -42,6 +42,7 @@ document.addEventListener('DOMContentLoaded', async function () {
   // Initialize all modules
   WindowModule.init();
   HeaderModule.init();
+  CommandPaletteModule.init();
   DesktopModule.init();
   TaskbarModule.init();
   SocketClient.connect();

--- a/scripts/build-frontend.mjs
+++ b/scripts/build-frontend.mjs
@@ -55,6 +55,7 @@ const INDEX_CSS = [
   'css/memory-manager.css',
   'css/notification.css',
   'css/taskbar.css',
+  'css/command-palette.css',
 ];
 
 // index.html JS 已由 Vite 管理（src/main.js），此處不再需要獨立 JS bundle。


### PR DESCRIPTION
## P10 全域搜尋 / Command Palette

### 功能概述
在 header-center 區域新增 Command Palette 元件，提供全域搜尋入口。

### 功能特性
- **快捷鍵**：`Ctrl+K` / `Cmd+K` 開啟/關閉搜尋面板
- **搜尋範圍**：
  - 已註冊的應用程式名稱（透過 `DesktopModule.getApplications()`）
  - 已開啟的視窗標題（透過 `WindowModule.getWindows()`）
- **鍵盤操作**：`↑↓` 瀏覽結果、`Enter` 開啟/切換、`Esc` 關閉
- **即時高亮**：搜尋結果中匹配文字以主題色高亮
- **響應式設計**：手機版觸發按鈕收縮為圖示

### 變更檔案
| 檔案 | 變更類型 | 說明 |
|------|---------|------|
| `frontend/css/command-palette.css` | 新增 | 元件樣式（trigger、overlay、dialog、results） |
| `frontend/js/command-palette.js` | 新增 | CommandPaletteModule IIFE 模組 |
| `frontend/index.html` | 修改 | CSS 註解清單加入 command-palette.css |
| `frontend/src/js/entry-compat.js` | 修改 | 加入 command-palette.js import |
| `frontend/src/main.js` | 修改 | DOMContentLoaded 初始化 CommandPaletteModule |
| `scripts/build-frontend.mjs` | 修改 | INDEX_CSS 陣列加入 command-palette.css |

### Demo 操作說明
1. 登入後在 header 中間區域可見「搜尋…」按鈕
2. 點擊按鈕或按 `Ctrl+K`（Mac: `⌘K`）開啟搜尋面板
3. 輸入關鍵字即時篩選應用程式與已開啟視窗
4. 用方向鍵 ↑↓ 選擇，Enter 開啟應用 / 切換視窗
5. 按 Esc 或點擊外部區域關閉

### 後端搜尋 API 需求（未來擴充）
目前為 **client-only demo**，搜尋範圍限於前端已載入資料。
若需擴充以下功能，需後端提供搜尋 API：
- 檔案名稱 / 內容搜尋（`GET /api/search?q=...`）
- 知識庫全文搜尋
- 訊息搜尋
- 使用者搜尋

屆時可在 `CommandPaletteModule.collectItems()` 中加入 `fetch()` 呼叫，
並以 debounce 控制請求頻率。