### PR TITLE
feat(mobile): Sprint 3 手機深度優化

### DIFF
--- a/frontend/css/code-editor.css
+++ b/frontend/css/code-editor.css
@@ -55,3 +55,17 @@
   opacity: 0;
   transition: opacity var(--transition-slow);
 }
+
+/* ==========================================================================
+   Sprint 3 — 手機響應式優化
+   ========================================================================== */
+@media (max-width: 768px) {
+  .code-editor-loading {
+    font-size: var(--font-size-sm);
+    gap: var(--spacing-sm);
+  }
+
+  .code-editor-loading .icon {
+    font-size: 24px;
+  }
+}

--- a/frontend/css/external-app.css
+++ b/frontend/css/external-app.css
@@ -95,3 +95,33 @@
   font-size: 16px;
   color: inherit;
 }
+
+/* ==========================================================================
+   Sprint 3 — 手機響應式優化
+   ========================================================================== */
+@media (max-width: 768px) {
+  .external-app-loading {
+    font-size: var(--font-size-sm);
+    gap: var(--spacing-sm);
+  }
+
+  .external-app-loading .icon {
+    font-size: 24px;
+  }
+
+  /* 錯誤狀態按鈕加大觸控區域 */
+  .external-app-open-link {
+    padding: var(--spacing-md) var(--spacing-lg);
+    font-size: var(--font-size-md);
+    min-height: 44px;
+  }
+
+  .external-app-error {
+    padding: var(--spacing-md);
+    font-size: var(--font-size-sm);
+  }
+
+  .external-app-error .icon {
+    font-size: 36px;
+  }
+}

--- a/frontend/css/mobile-common.css
+++ b/frontend/css/mobile-common.css
@@ -1,5 +1,6 @@
 /* ==========================================================================
    ChingTech OS - Mobile Common Styles（手機響應式共用樣式）
+   Sprint 3 深度優化
    ========================================================================== */
 
 /* --------------------------------------------------------------------------
@@ -61,6 +62,59 @@
   html {
     -webkit-text-size-adjust: 100%;
     text-size-adjust: 100%;
+  }
+
+  /* ========================================================================
+     6. Sprint 3 — 全域字體與間距微調
+     ======================================================================== */
+
+  /* 基礎字體略為放大，提高小螢幕可讀性 */
+  body {
+    font-size: var(--font-size-md, 15px);
+    line-height: 1.5;
+  }
+
+  /* ========================================================================
+     7. Sprint 3 — Taskbar / Dock 在手機視窗開啟時隱藏
+     ======================================================================== */
+  body.mobile-window-active .taskbar {
+    display: none;
+  }
+
+  /* ========================================================================
+     8. Sprint 3 — 應用程式選單按鈕（由 JS 插入 .header-mobile-menu-btn）
+     ======================================================================== */
+  .header-mobile-menu-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: var(--radius-sm, 6px);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+    margin-right: var(--spacing-xs, 4px);
+  }
+
+  .header-mobile-menu-btn:hover,
+  .header-mobile-menu-btn:active {
+    background-color: var(--hover-bg, rgba(255, 255, 255, 0.08));
+    color: var(--text-primary);
+  }
+
+  .header-mobile-menu-btn .icon svg {
+    width: 22px;
+    height: 22px;
+  }
+
+  /* ========================================================================
+     9. Sprint 3 — 通用工具列換行（給子元件 CSS 繼承用）
+     ======================================================================== */
+  .toolbar-wrap-mobile {
+    flex-wrap: wrap;
+    gap: var(--spacing-xs, 4px);
+    justify-content: center;
   }
 }
 

--- a/frontend/css/share-dialog.css
+++ b/frontend/css/share-dialog.css
@@ -354,3 +354,72 @@
 .share-retry-btn:hover {
   background: var(--bg-surface-dark);
 }
+
+/* ==========================================================================
+   Sprint 3 — 手機響應式優化
+   ========================================================================== */
+@media (max-width: 768px) {
+  /* 對話框全寬 */
+  .share-dialog {
+    width: calc(100vw - 24px);
+    max-width: none;
+    border-radius: 8px;
+  }
+
+  /* 標頭緊湊 */
+  .share-dialog-header {
+    padding: 12px 16px;
+  }
+
+  .share-dialog-header h3 {
+    font-size: 15px;
+  }
+
+  /* 內容區域 */
+  .share-dialog-body {
+    padding: 16px;
+  }
+
+  /* 連結輸入組：堆疊佈局 */
+  .share-link-input-group {
+    flex-direction: column;
+  }
+
+  .share-copy-btn {
+    width: 100%;
+    justify-content: center;
+    min-height: 44px;
+  }
+
+  /* QR Code 區域縮小 */
+  .share-qr-code {
+    padding: 12px;
+  }
+
+  .share-qr-code canvas {
+    max-width: 160px;
+    max-height: 160px;
+  }
+
+  /* 表單選項觸控友善 */
+  .share-form-group select {
+    min-height: 44px;
+    font-size: 15px;
+  }
+
+  /* 建立按鈕加大 */
+  .share-create-btn {
+    min-height: 44px;
+    font-size: 15px;
+  }
+
+  /* 底部按鈕 */
+  .share-dialog-footer {
+    padding: 10px 16px;
+  }
+
+  .share-dialog-footer .btn {
+    min-height: 40px;
+    padding: 8px 14px;
+  }
+}

--- a/frontend/css/terminal.css
+++ b/frontend/css/terminal.css
@@ -237,3 +237,42 @@
 @keyframes spin {
   to { transform: rotate(360deg); }
 }
+
+/* ==========================================================================
+   Sprint 3 — 手機響應式優化
+   ========================================================================== */
+@media (max-width: 768px) {
+  /* 終端機容器移除多餘 padding */
+  .terminal-container {
+    padding: 2px;
+  }
+
+  /* 狀態列：縮小字體、改為換行佈局 */
+  .terminal-status-bar {
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-xs);
+    font-size: 10px;
+  }
+
+  /* 重新連線對話框：適應小螢幕 */
+  .terminal-reconnect-dialog {
+    max-width: calc(100vw - 32px);
+    padding: var(--spacing-md);
+  }
+
+  .terminal-reconnect-actions {
+    flex-direction: column;
+  }
+
+  .terminal-reconnect-actions .btn {
+    min-width: unset;
+    width: 100%;
+  }
+
+  /* Session 列表觸控友善 */
+  .terminal-session-item {
+    padding: var(--spacing-md) var(--spacing-sm);
+    min-height: 44px;
+  }
+}

--- a/frontend/css/viewer.css
+++ b/frontend/css/viewer.css
@@ -490,6 +490,78 @@
   opacity: 1;
 }
 
+/* ==========================================================================
+   Sprint 3 — 手機響應式優化
+   ========================================================================== */
+@media (max-width: 768px) {
+  /* 共用工具列：換行且縮小間距 */
+  .viewer-toolbar {
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-xs);
+  }
+
+  /* 工具列按鈕略微加大觸控區域 */
+  .viewer-toolbar-btn {
+    width: 40px;
+    height: 40px;
+  }
+
+  /* 隱藏分隔線以節省空間 */
+  .viewer-toolbar-divider {
+    display: none;
+  }
+
+  /* 狀態列縮小 */
+  .viewer-statusbar {
+    padding: var(--spacing-xs) var(--spacing-sm);
+    font-size: 11px;
+  }
+
+  /* 文字檢視器 toolbar 換行 */
+  .txt-toolbar {
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-xs) var(--spacing-sm);
+  }
+
+  .txt-mode-group {
+    flex-wrap: wrap;
+  }
+
+  .txt-mode-btn {
+    padding: 6px 10px;
+    font-size: 12px;
+  }
+
+  /* 文字內容字體 */
+  .text-viewer-content pre {
+    font-size: 13px;
+    padding: var(--spacing-sm);
+  }
+
+  /* PDF 工具列換行 */
+  .pdf-toolbar {
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-xs) var(--spacing-sm);
+  }
+
+  .pdf-toolbar-divider {
+    display: none;
+  }
+
+  .pdf-toolbar-btn {
+    width: 36px;
+    height: 36px;
+  }
+
+  /* PDF 內容：減少 padding */
+  .pdf-content {
+    padding: var(--spacing-xs);
+  }
+}
+
 /* PDF Viewer Scrollbar */
 .pdf-content::-webkit-scrollbar {
   width: 10px;


### PR DESCRIPTION
## Sprint 3 手機深度優化

### 📱 變更摘要

#### CSS 響應式 `@media (max-width:768px)` 區塊新增/增強
| 檔案 | 變更內容 |
|------|----------|
| `mobile-common.css` | 全域字體微調、Taskbar 隱藏、選單按鈕樣式、工具列換行 |
| `terminal.css` | 容器 padding 縮減、狀態列換行、重連對話框全寬、Session 觸控友善 |
| `viewer.css` | 工具列/PDF 工具列換行、分隔線隱藏、觸控區域加大 |
| `code-editor.css` | 載入狀態適配 |
| `external-app.css` | 載入/錯誤狀態適配、按鈕加大 |
| `share-dialog.css` | 對話框全寬、輸入堆疊、QR Code 限制、表單觸控友善 |

#### JS 行為強化
| 檔案 | 變更內容 |
|------|----------|
| `window.js` | Dock 隱藏管理、漢堡選單按鈕注入、手機↔桌面 resize 還原 |
| `matrix-rain.js` | 行動裝置停用動畫、Page Visibility 暫停/恢復、降頻配置 |

### 🧪 測試
- ✅ Vite build 成功
- ✅ JS 語法驗證通過
- ✅ CSS 大括號配對平衡
- ✅ 8 個寬度場景模擬測試 PASS（375px / 414px / 768px / 769px / 1920px / Visibility / Reduced-Motion / Resize 過渡）

### 📐 設計原則
- 最小侵入性：**不改動後端**，不影響桌面版既有行為
- 漸進增強：所有手機樣式透過 `@media` 查詢隔離
- 8 個檔案變更，+457 行 / -3 行