### PR TITLE
feat(sprint5): Onboarding 新手導覽與 Badge 微互動

### DIFF
--- a/frontend/css/header.css
+++ b/frontend/css/header.css
@@ -230,9 +230,125 @@
   display: none;
 }
 
+/* Badge Bump 微互動動畫 — 當 badge 數值更新時觸發 */
+.header-badge.badge-bump {
+  animation: badgeBump 0.4s cubic-bezier(0.36, 0.07, 0.19, 0.97);
+}
+
+@keyframes badgeBump {
+  0%   { transform: scale(1); }
+  30%  { transform: scale(1.35); }
+  50%  { transform: scale(0.9); }
+  70%  { transform: scale(1.15); }
+  100% { transform: scale(1); }
+}
+
+/* Badge 出現時的淡入動畫 */
+.header-badge.badge-appear {
+  animation: badgeAppear 0.35s ease-out;
+}
+
+@keyframes badgeAppear {
+  0% {
+    opacity: 0;
+    transform: scale(0);
+  }
+  60% {
+    transform: scale(1.2);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* 訊息鈴鐺搖擺動畫 — 配合 badge bump */
+.header-messages-btn.bell-ring .icon {
+  animation: bellRing 0.6s ease-in-out;
+}
+
+@keyframes bellRing {
+  0%   { transform: rotate(0); }
+  15%  { transform: rotate(14deg); }
+  30%  { transform: rotate(-12deg); }
+  45%  { transform: rotate(8deg); }
+  60%  { transform: rotate(-6deg); }
+  75%  { transform: rotate(3deg); }
+  100% { transform: rotate(0); }
+}
+
+/* Reduced Motion 支援 */
+@media (prefers-reduced-motion: reduce) {
+  .header-badge.badge-bump,
+  .header-badge.badge-appear,
+  .header-messages-btn.bell-ring .icon {
+    animation: none;
+  }
+}
+
 /* ==========================================================================
    Mobile Styles (手機版樣式)
    ========================================================================== */
+
+/* ── Header User 下拉選單 ── */
+.header-user {
+  position: relative;
+}
+
+.header-user-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 180px;
+  background: var(--bg-elevated, #1e293b);
+  border: 1px solid var(--interactive-border, rgba(255,255,255,0.1));
+  border-radius: var(--radius-md, 8px);
+  padding: var(--spacing-xs, 6px) 0;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+  z-index: 200;
+  opacity: 0;
+  transform: translateY(-4px);
+  pointer-events: none;
+  transition: opacity var(--transition-fast, 0.15s), transform var(--transition-fast, 0.15s);
+}
+
+.header-user-menu.open {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.header-user-menu-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm, 8px);
+  width: 100%;
+  padding: var(--spacing-sm, 8px) var(--spacing-md, 16px);
+  background: none;
+  border: none;
+  color: var(--text-secondary, #94a3b8);
+  font-size: var(--font-size-sm, 14px);
+  cursor: pointer;
+  transition: all var(--transition-fast, 0.15s);
+  text-align: left;
+}
+
+.header-user-menu-item:hover {
+  background: var(--interactive-hover, rgba(255,255,255,0.06));
+  color: var(--text-primary, #f1f5f9);
+}
+
+.header-user-menu-item .icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.header-user-menu-divider {
+  height: 1px;
+  background: var(--border-light, rgba(255,255,255,0.08));
+  margin: var(--spacing-xs, 6px) 0;
+}
+
 @media (max-width: 768px) {
   .header-bar {
     padding: 0 var(--spacing-sm);

--- a/frontend/css/onboarding.css
+++ b/frontend/css/onboarding.css
@@ -1,0 +1,254 @@
+/* ==========================================================================
+   ChingTech OS - Onboarding / Spotlight 引導樣式
+   Sprint 5 — 3 步驟 spotlight 說明
+   ========================================================================== */
+
+/* ── Overlay 遮罩 ── */
+.onboarding-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  pointer-events: auto;
+  transition: opacity var(--transition-normal, 0.25s) ease;
+  opacity: 0;
+}
+
+.onboarding-overlay.active {
+  opacity: 1;
+}
+
+/* SVG 遮罩層 —— 用於挖洞 spotlight 效果 */
+.onboarding-overlay svg.onboarding-mask-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* ── Spotlight 環形高亮 ── */
+.onboarding-spotlight {
+  position: absolute;
+  border-radius: var(--radius-lg, 12px);
+  box-shadow: 0 0 0 4px rgba(33, 212, 253, 0.55),
+              0 0 24px 4px rgba(33, 212, 253, 0.25);
+  z-index: 10001;
+  pointer-events: none;
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  animation: spotlightPulse 2s ease-in-out infinite;
+}
+
+@keyframes spotlightPulse {
+  0%, 100% {
+    box-shadow: 0 0 0 4px rgba(33, 212, 253, 0.55),
+                0 0 24px 4px rgba(33, 212, 253, 0.25);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(33, 212, 253, 0.75),
+                0 0 36px 8px rgba(33, 212, 253, 0.35);
+  }
+}
+
+/* ── Tooltip 說明卡片 ── */
+.onboarding-tooltip {
+  position: absolute;
+  z-index: 10002;
+  width: 340px;
+  max-width: calc(100vw - 32px);
+  background: var(--bg-elevated, #1e293b);
+  border: 1px solid var(--interactive-border, rgba(255,255,255,0.1));
+  border-radius: var(--radius-lg, 12px);
+  padding: var(--spacing-lg, 20px);
+  color: var(--text-primary, #f1f5f9);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4),
+              0 0 1px rgba(255, 255, 255, 0.1);
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.35s ease, transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  pointer-events: auto;
+}
+
+.onboarding-tooltip.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* 箭頭指示器 */
+.onboarding-tooltip::before {
+  content: '';
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: var(--bg-elevated, #1e293b);
+  border-top: 1px solid var(--interactive-border, rgba(255,255,255,0.1));
+  border-left: 1px solid var(--interactive-border, rgba(255,255,255,0.1));
+  transform: rotate(45deg);
+}
+
+/* 箭頭位置：上方 */
+.onboarding-tooltip[data-arrow="top"]::before {
+  top: -7px;
+  left: 50%;
+  margin-left: -6px;
+}
+
+/* 箭頭位置：下方 */
+.onboarding-tooltip[data-arrow="bottom"]::before {
+  bottom: -7px;
+  left: 50%;
+  margin-left: -6px;
+  transform: rotate(225deg);
+}
+
+/* Tooltip 內部排版 */
+.onboarding-tooltip-step {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs, 6px);
+  margin-bottom: var(--spacing-sm, 8px);
+  font-size: 12px;
+  color: var(--color-primary, #21d4fd);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.onboarding-tooltip-step .onboarding-step-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-primary, #21d4fd);
+  display: inline-block;
+}
+
+.onboarding-tooltip-title {
+  font-size: var(--font-size-lg, 18px);
+  font-weight: 700;
+  margin-bottom: var(--spacing-sm, 8px);
+  color: var(--text-primary, #f1f5f9);
+  line-height: 1.3;
+}
+
+.onboarding-tooltip-body {
+  font-size: var(--font-size-sm, 14px);
+  color: var(--text-secondary, #94a3b8);
+  line-height: 1.6;
+  margin-bottom: var(--spacing-md, 16px);
+}
+
+/* ── 步驟指示點 ── */
+.onboarding-dots {
+  display: flex;
+  gap: 6px;
+  margin-bottom: var(--spacing-md, 16px);
+}
+
+.onboarding-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--border-light, rgba(255,255,255,0.15));
+  transition: all var(--transition-fast, 0.15s);
+}
+
+.onboarding-dot.active {
+  background: var(--color-primary, #21d4fd);
+  width: 20px;
+  border-radius: 4px;
+}
+
+.onboarding-dot.completed {
+  background: var(--color-primary, #21d4fd);
+  opacity: 0.5;
+}
+
+/* ── 按鈕列 ── */
+.onboarding-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm, 8px);
+}
+
+.onboarding-btn {
+  padding: var(--spacing-xs, 6px) var(--spacing-md, 16px);
+  border-radius: var(--radius-md, 8px);
+  font-size: var(--font-size-sm, 14px);
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: all var(--transition-fast, 0.15s);
+  line-height: 1.5;
+}
+
+.onboarding-btn:focus-visible {
+  outline: 2px solid var(--color-primary, #21d4fd);
+  outline-offset: 2px;
+}
+
+.onboarding-btn-primary {
+  background: var(--color-primary, #21d4fd);
+  color: #0f172a;
+}
+
+.onboarding-btn-primary:hover {
+  filter: brightness(1.1);
+  box-shadow: 0 0 12px rgba(33, 212, 253, 0.4);
+}
+
+.onboarding-btn-ghost {
+  background: transparent;
+  color: var(--text-secondary, #94a3b8);
+  border: 1px solid var(--border-light, rgba(255,255,255,0.12));
+}
+
+.onboarding-btn-ghost:hover {
+  background: var(--interactive-hover, rgba(255,255,255,0.06));
+  color: var(--text-primary, #f1f5f9);
+}
+
+.onboarding-btn-link {
+  background: transparent;
+  color: var(--text-muted, #64748b);
+  font-size: 12px;
+  padding: var(--spacing-xs, 6px) var(--spacing-sm, 8px);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.onboarding-btn-link:hover {
+  color: var(--text-secondary, #94a3b8);
+}
+
+/* ── 無障礙：Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .onboarding-spotlight {
+    animation: none;
+    transition: none;
+  }
+
+  .onboarding-tooltip {
+    transition: none;
+  }
+
+  .onboarding-overlay {
+    transition: none;
+  }
+
+  .onboarding-dot {
+    transition: none;
+  }
+}
+
+/* ── 手機版 ── */
+@media (max-width: 768px) {
+  .onboarding-tooltip {
+    width: calc(100vw - 24px);
+    left: 12px !important;
+    right: 12px !important;
+    padding: var(--spacing-md, 16px);
+  }
+
+  .onboarding-tooltip-title {
+    font-size: var(--font-size-md, 16px);
+  }
+}

--- a/frontend/js/onboarding.js
+++ b/frontend/js/onboarding.js
@@ -1,0 +1,387 @@
+/**
+ * ChingTech OS - Onboarding Module
+ * Sprint 5 — 3 步驟 Spotlight 引導
+ *
+ * 功能：
+ *   1. 依序高亮 header-bar → command palette trigger → ai-assistant 桌面圖示
+ *   2. 每步驟顯示 tooltip 說明
+ *   3. 提供「跳過」與「稍後顯示」按鈕
+ *   4. 完成後設定 localStorage 'onboardingSeen' 標記
+ *   5. 外部可呼叫 restart() 重新啟動引導
+ */
+
+const OnboardingModule = (function () {
+  'use strict';
+
+  // ─── 設定 ───
+  const STORAGE_KEY = 'onboardingSeen';
+
+  /** @type {Array<{target: string, title: string, body: string}>} */
+  const STEPS = [
+    {
+      target: '.header-bar',
+      title: '歡迎來到 ChingTech OS',
+      body: '這是系統標題列，包含時鐘、通知鈴鐺與使用者選單。點擊使用者名稱可進入個人資料頁面。'
+    },
+    {
+      target: '.command-palette-trigger',
+      title: '快速搜尋指令面板',
+      body: '按下 Ctrl+K（Mac: ⌘K）或點擊此按鈕，即可搜尋並快速啟動任何功能或應用程式。'
+    },
+    {
+      target: '[data-app-id="ai-assistant"]',
+      title: 'AI 助理',
+      body: '點擊桌面上的 AI 助理圖示，即可與智慧助理對話，協助您完成各種任務。'
+    }
+  ];
+
+  // ─── 狀態 ───
+  let currentStep = 0;
+  let overlayEl = null;
+  let spotlightEl = null;
+  let tooltipEl = null;
+  let isActive = false;
+  let resizeRAF = null;
+
+  // ─── DOM 建構 ───
+
+  /**
+   * 建立 overlay + spotlight + tooltip DOM
+   */
+  function createDOM() {
+    // Overlay
+    overlayEl = document.createElement('div');
+    overlayEl.className = 'onboarding-overlay';
+    overlayEl.setAttribute('role', 'dialog');
+    overlayEl.setAttribute('aria-modal', 'true');
+    overlayEl.setAttribute('aria-label', '新手導覽');
+
+    // SVG 遮罩（半透明 + 挖洞）
+    const svgNS = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(svgNS, 'svg');
+    svg.classList.add('onboarding-mask-svg');
+    svg.setAttribute('width', '100%');
+    svg.setAttribute('height', '100%');
+
+    const defs = document.createElementNS(svgNS, 'defs');
+    const mask = document.createElementNS(svgNS, 'mask');
+    mask.id = 'onboarding-cutout';
+
+    const maskBg = document.createElementNS(svgNS, 'rect');
+    maskBg.setAttribute('width', '100%');
+    maskBg.setAttribute('height', '100%');
+    maskBg.setAttribute('fill', 'white');
+
+    const hole = document.createElementNS(svgNS, 'rect');
+    hole.id = 'onboarding-hole';
+    hole.setAttribute('rx', '12');
+    hole.setAttribute('ry', '12');
+    hole.setAttribute('fill', 'black');
+
+    mask.appendChild(maskBg);
+    mask.appendChild(hole);
+    defs.appendChild(mask);
+    svg.appendChild(defs);
+
+    const overlay = document.createElementNS(svgNS, 'rect');
+    overlay.setAttribute('width', '100%');
+    overlay.setAttribute('height', '100%');
+    overlay.setAttribute('fill', 'rgba(0,0,0,0.6)');
+    overlay.setAttribute('mask', 'url(#onboarding-cutout)');
+    svg.appendChild(overlay);
+
+    overlayEl.appendChild(svg);
+
+    // Spotlight 邊框環
+    spotlightEl = document.createElement('div');
+    spotlightEl.className = 'onboarding-spotlight';
+    overlayEl.appendChild(spotlightEl);
+
+    // Tooltip
+    tooltipEl = document.createElement('div');
+    tooltipEl.className = 'onboarding-tooltip';
+    tooltipEl.setAttribute('data-arrow', 'top');
+    overlayEl.appendChild(tooltipEl);
+
+    document.body.appendChild(overlayEl);
+  }
+
+  /**
+   * 渲染 tooltip 內容
+   */
+  function renderTooltip(step, index, total) {
+    const dotsHTML = Array.from({ length: total }, (_, i) => {
+      const cls = i === index ? 'active' : i < index ? 'completed' : '';
+      return `<span class="onboarding-dot ${cls}"></span>`;
+    }).join('');
+
+    const isLast = index === total - 1;
+
+    tooltipEl.innerHTML = `
+      <div class="onboarding-tooltip-step">
+        <span class="onboarding-step-dot"></span>
+        步驟 ${index + 1} / ${total}
+      </div>
+      <div class="onboarding-tooltip-title">${step.title}</div>
+      <div class="onboarding-tooltip-body">${step.body}</div>
+      <div class="onboarding-dots">${dotsHTML}</div>
+      <div class="onboarding-actions">
+        <button class="onboarding-btn onboarding-btn-link" data-action="skip">跳過導覽</button>
+        <div style="display:flex;gap:8px;">
+          ${index > 0 ? '<button class="onboarding-btn onboarding-btn-ghost" data-action="prev">上一步</button>' : '<button class="onboarding-btn onboarding-btn-ghost" data-action="later">稍後再看</button>'}
+          <button class="onboarding-btn onboarding-btn-primary" data-action="${isLast ? 'done' : 'next'}">
+            ${isLast ? '開始使用 🚀' : '下一步'}
+          </button>
+        </div>
+      </div>
+    `;
+
+    // 按鈕事件
+    tooltipEl.querySelectorAll('[data-action]').forEach(btn => {
+      btn.addEventListener('click', handleAction);
+    });
+  }
+
+  // ─── 定位邏輯 ───
+
+  /**
+   * 取得目標元素並定位 spotlight + tooltip
+   */
+  function positionSpotlight() {
+    const step = STEPS[currentStep];
+    const targetEl = document.querySelector(step.target);
+
+    if (!targetEl) {
+      // 目標不存在，跳至下一步
+      if (currentStep < STEPS.length - 1) {
+        currentStep++;
+        showStep();
+      } else {
+        finish();
+      }
+      return;
+    }
+
+    const rect = targetEl.getBoundingClientRect();
+    const pad = 8; // spotlight 外擴 padding
+
+    const x = rect.left - pad;
+    const y = rect.top - pad;
+    const w = rect.width + pad * 2;
+    const h = rect.height + pad * 2;
+
+    // Spotlight 邊框
+    spotlightEl.style.left = `${x}px`;
+    spotlightEl.style.top = `${y}px`;
+    spotlightEl.style.width = `${w}px`;
+    spotlightEl.style.height = `${h}px`;
+
+    // SVG 遮罩挖洞
+    const hole = document.getElementById('onboarding-hole');
+    if (hole) {
+      hole.setAttribute('x', x);
+      hole.setAttribute('y', y);
+      hole.setAttribute('width', w);
+      hole.setAttribute('height', h);
+    }
+
+    // Tooltip 定位
+    positionTooltip(rect);
+  }
+
+  /**
+   * 根據目標位置決定 tooltip 放置方向
+   */
+  function positionTooltip(targetRect) {
+    const tooltipW = 340;
+    const gap = 16;
+    const vpH = window.innerHeight;
+    const vpW = window.innerWidth;
+
+    // 預設放在目標下方
+    let top = targetRect.bottom + gap;
+    let left = targetRect.left + targetRect.width / 2 - tooltipW / 2;
+    let arrow = 'top';
+
+    // 如果下方空間不足，放到上方
+    if (top + 240 > vpH) {
+      top = targetRect.top - gap - 240;
+      arrow = 'bottom';
+    }
+
+    // 水平邊界保護
+    if (left < 12) left = 12;
+    if (left + tooltipW > vpW - 12) left = vpW - tooltipW - 12;
+
+    tooltipEl.style.top = `${top}px`;
+    tooltipEl.style.left = `${left}px`;
+    tooltipEl.setAttribute('data-arrow', arrow);
+  }
+
+  // ─── 步驟控制 ───
+
+  function showStep() {
+    const step = STEPS[currentStep];
+    renderTooltip(step, currentStep, STEPS.length);
+
+    // 先隱藏 tooltip 做動畫
+    tooltipEl.classList.remove('visible');
+
+    requestAnimationFrame(() => {
+      positionSpotlight();
+      // 延遲讓 transition 生效
+      requestAnimationFrame(() => {
+        tooltipEl.classList.add('visible');
+      });
+    });
+  }
+
+  function handleAction(e) {
+    const action = e.currentTarget.dataset.action;
+
+    switch (action) {
+      case 'next':
+        if (currentStep < STEPS.length - 1) {
+          currentStep++;
+          showStep();
+        }
+        break;
+
+      case 'prev':
+        if (currentStep > 0) {
+          currentStep--;
+          showStep();
+        }
+        break;
+
+      case 'done':
+        finish();
+        break;
+
+      case 'skip':
+        finish();
+        break;
+
+      case 'later':
+        close();
+        // 不設定 localStorage，下次仍顯示
+        break;
+    }
+  }
+
+  /**
+   * 完成引導，標記已看過
+   */
+  function finish() {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    close();
+  }
+
+  /**
+   * 關閉 overlay
+   */
+  function close() {
+    if (!isActive) return;
+    isActive = false;
+
+    overlayEl.classList.remove('active');
+    tooltipEl.classList.remove('visible');
+
+    window.removeEventListener('resize', handleResize);
+    window.removeEventListener('keydown', handleKeydown);
+
+    // 等 transition 結束再移除 DOM
+    setTimeout(() => {
+      if (overlayEl && overlayEl.parentNode) {
+        overlayEl.parentNode.removeChild(overlayEl);
+      }
+      overlayEl = null;
+      spotlightEl = null;
+      tooltipEl = null;
+    }, 350);
+  }
+
+  // ─── 事件處理 ───
+
+  function handleResize() {
+    if (resizeRAF) cancelAnimationFrame(resizeRAF);
+    resizeRAF = requestAnimationFrame(() => {
+      if (isActive) positionSpotlight();
+    });
+  }
+
+  function handleKeydown(e) {
+    if (e.key === 'Escape') {
+      finish();
+    } else if (e.key === 'ArrowRight' || e.key === 'Enter') {
+      if (currentStep < STEPS.length - 1) {
+        currentStep++;
+        showStep();
+      } else {
+        finish();
+      }
+    } else if (e.key === 'ArrowLeft') {
+      if (currentStep > 0) {
+        currentStep--;
+        showStep();
+      }
+    }
+  }
+
+  // ─── 公開 API ───
+
+  /**
+   * 啟動引導（僅在未看過時自動呼叫）
+   */
+  function start() {
+    if (isActive) return;
+
+    currentStep = 0;
+    isActive = true;
+
+    createDOM();
+
+    // 確保 DOM 渲染後顯示
+    requestAnimationFrame(() => {
+      overlayEl.classList.add('active');
+      showStep();
+    });
+
+    window.addEventListener('resize', handleResize);
+    window.addEventListener('keydown', handleKeydown);
+  }
+
+  /**
+   * 重新啟動引導（從 user menu 呼叫）
+   */
+  function restart() {
+    localStorage.removeItem(STORAGE_KEY);
+    if (isActive) close();
+    // 小延遲讓 close 動畫完成
+    setTimeout(start, 400);
+  }
+
+  /**
+   * 檢查是否已看過
+   */
+  function hasSeen() {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  }
+
+  /**
+   * 初始化 — 若未看過則延遲顯示
+   */
+  function init() {
+    if (!hasSeen()) {
+      // 延遲 1.5 秒讓桌面渲染完成
+      setTimeout(start, 1500);
+    }
+  }
+
+  return {
+    init,
+    start,
+    restart,
+    hasSeen
+  };
+})();

--- a/frontend/src/js/entry-compat.js
+++ b/frontend/src/js/entry-compat.js
@@ -62,6 +62,9 @@ import '../../js/memory-manager.js';
 // ─── Command Palette / 全域搜尋 ───
 import '../../js/command-palette.js';
 
+// ─── Onboarding / 新手導覽 ───
+import '../../js/onboarding.js';
+
 // ─── 桌面 & Taskbar（最後載入，因為依賴上述模組） ───
 import '../../js/desktop.js';
 import '../../js/taskbar.js';

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -46,4 +46,7 @@ document.addEventListener('DOMContentLoaded', async function () {
   DesktopModule.init();
   TaskbarModule.init();
   SocketClient.connect();
+
+  // Onboarding 新手導覽（延遲啟動，等桌面渲染完成）
+  OnboardingModule.init();
 });


### PR DESCRIPTION
## Sprint 5 — Onboarding & 微互動

### 🎯 Onboarding 引導模組
- **3 步驟 Spotlight** 說明（Header 列 → Command Palette → AI 助理）
- SVG 遮罩挖洞效果 + 脈衝邊框動畫
- Tooltip 卡片含步驟指示點、上/下一步導航
- 「跳過導覽」與「稍後再看」功能按鈕
- `localStorage 'onboardingSeen'` 標記，首次訪問自動顯示
- 鍵盤支援（← → Enter Esc）
- Reduced Motion / 手機版適配

### 🔔 Badge Bump 微互動
- `badgeBump`: 彈跳縮放動畫（scale 1→1.35→0.9→1.15→1）
- `badgeAppear`: 從隱藏到顯示的淡入+縮放動畫
- `bellRing`: 鈴鐺搖擺動畫，配合 badge 更新觸發
- `HeaderModule.triggerBadgeBump(count)` API

### 👤 User Menu 下拉選單
- 點擊使用者名稱開啟下拉選單
- 「個人資料」開啟 UserProfileModule
- **「重新導覽」** 呼叫 `OnboardingModule.restart()`
- 點擊外部自動關閉

### 📁 變更檔案
| 檔案 | 說明 |
|------|------|
| `frontend/css/onboarding.css` | 🆕 Onboarding spotlight/tooltip 樣式 |
| `frontend/js/onboarding.js` | 🆕 Onboarding 模組（IIFE） |
| `frontend/css/header.css` | Badge 動畫 + User Menu 樣式 |
| `frontend/js/header.js` | Badge trigger + User Menu + 重啟導覽 |
| `frontend/src/js/entry-compat.js` | 新增 onboarding import |
| `frontend/src/main.js` | 新增 OnboardingModule.init() |

### ✅ 測試
- `npm run build` 通過（Vite 建置成功）