### PR TITLE
feat(a11y): Sprint2 無障礙改進 — focus-visible、通知按鈕、modal ARIA

### DIFF
--- a/frontend/css/agent-settings.css
+++ b/frontend/css/agent-settings.css
@@ -161,7 +161,6 @@
 }
 
 .agent-form-input:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 
@@ -181,7 +180,6 @@
 }
 
 .agent-form-select:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 
@@ -201,7 +199,6 @@
 }
 
 .agent-form-textarea:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 
@@ -324,7 +321,6 @@
 }
 
 .agent-test-input:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 

--- a/frontend/css/ai-assistant.css
+++ b/frontend/css/ai-assistant.css
@@ -204,7 +204,6 @@
 
 .ai-prompt-select:focus,
 .ai-agent-select:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 
@@ -471,7 +470,6 @@
 }
 
 .ai-input:focus {
-  outline: none;
   border: none;
   background: transparent;
 }

--- a/frontend/css/ai-log.css
+++ b/frontend/css/ai-log.css
@@ -48,7 +48,6 @@
 }
 
 .ai-log-filter-select:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 
@@ -63,7 +62,6 @@
 }
 
 .ai-log-filter-input:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 

--- a/frontend/css/command-palette.css
+++ b/frontend/css/command-palette.css
@@ -124,7 +124,6 @@
   flex: 1;
   background: transparent;
   border: none;
-  outline: none;
   font-size: var(--font-size-base);
   color: var(--text-primary);
   font-family: inherit;

--- a/frontend/css/file-manager.css
+++ b/frontend/css/file-manager.css
@@ -103,7 +103,6 @@
   border-radius: var(--radius-sm);
   font-size: var(--font-size-sm);
   color: var(--text-primary);
-  outline: none;
 }
 
 .fm-path-input-wrapper {
@@ -168,7 +167,6 @@
   padding: var(--spacing-xs) var(--spacing-sm);
   font-size: var(--font-size-sm);
   color: var(--text-primary);
-  outline: none;
 }
 
 .fm-search-input::placeholder {
@@ -689,7 +687,6 @@
   border-radius: var(--radius-sm);
   font-size: var(--font-size-sm);
   color: var(--text-primary);
-  outline: none;
   transition: border-color var(--transition-fast);
 }
 
@@ -1124,7 +1121,6 @@
   border-radius: var(--radius-sm);
   font-size: var(--font-size-sm);
   color: var(--text-primary);
-  outline: none;
   transition: border-color var(--transition-fast);
 }
 

--- a/frontend/css/inventory-management.css
+++ b/frontend/css/inventory-management.css
@@ -48,7 +48,6 @@
 }
 
 .inv-search-input:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 
@@ -794,7 +793,6 @@
 .inv-form-group input:focus,
 .inv-form-group select:focus,
 .inv-form-group textarea:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 

--- a/frontend/css/knowledge-base.css
+++ b/frontend/css/knowledge-base.css
@@ -63,7 +63,6 @@
   padding: var(--spacing-sm);
   font-size: var(--font-size-sm);
   color: var(--text-primary);
-  outline: none;
 }
 
 .kb-search-input::placeholder {
@@ -114,7 +113,6 @@
   color: var(--text-secondary);
   cursor: pointer;
   appearance: none;
-  outline: none;
   transition: all var(--transition-fast);
 }
 
@@ -658,7 +656,6 @@
   font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--text-primary);
-  outline: none;
   transition: border-color var(--transition-fast);
 }
 
@@ -696,7 +693,6 @@
   border-radius: var(--radius-sm);
   font-size: var(--font-size-sm);
   color: var(--text-primary);
-  outline: none;
   appearance: none;
   -webkit-appearance: none;
   cursor: pointer;
@@ -733,7 +729,6 @@
   line-height: 1.6;
   color: var(--text-primary);
   resize: none;
-  outline: none;
 }
 
 .kb-editor-textarea::placeholder {

--- a/frontend/css/login.css
+++ b/frontend/css/login.css
@@ -394,7 +394,6 @@
 }
 
 .change-password-form .form-group .input:focus {
-  outline: none;
   border-color: var(--color-accent);
   background-color: var(--bg-surface-darker);
 }

--- a/frontend/css/memory-manager.css
+++ b/frontend/css/memory-manager.css
@@ -495,7 +495,6 @@
 
 .mm-input:focus,
 .mm-textarea:focus {
-  outline: none;
   border-color: var(--color-primary);
 }
 

--- a/frontend/css/message-center.css
+++ b/frontend/css/message-center.css
@@ -62,7 +62,6 @@
   padding: var(--spacing-sm);
   font-size: var(--font-size-sm);
   color: var(--text-primary);
-  outline: none;
 }
 
 .mc-search-input::placeholder {
@@ -84,7 +83,6 @@
   font-size: var(--font-size-xs);
   color: var(--text-primary);
   cursor: pointer;
-  outline: none;
 }
 
 .mc-filter-select:focus {

--- a/frontend/css/notification.css
+++ b/frontend/css/notification.css
@@ -65,15 +65,21 @@
 }
 
 .notification-close {
-  width: 20px;
-  height: 20px;
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  min-height: 32px;
   background: none;
   border: none;
+  border-radius: var(--radius-sm, 4px);
   cursor: pointer;
   color: var(--text-secondary, #a0a0a0);
   opacity: 0.6;
   transition: opacity var(--transition-normal);
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .notification-close:hover {

--- a/frontend/css/project-management.css
+++ b/frontend/css/project-management.css
@@ -45,7 +45,6 @@
 }
 
 .pm-search-input:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 
@@ -1043,7 +1042,6 @@
 .pm-form-group input:focus,
 .pm-form-group select:focus,
 .pm-form-group textarea:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 

--- a/frontend/css/prompt-editor.css
+++ b/frontend/css/prompt-editor.css
@@ -184,7 +184,6 @@
 }
 
 .prompt-form-input:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 
@@ -204,7 +203,6 @@
 }
 
 .prompt-form-select:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 
@@ -230,7 +228,6 @@
 }
 
 .prompt-content-textarea:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 

--- a/frontend/css/share-dialog.css
+++ b/frontend/css/share-dialog.css
@@ -124,7 +124,6 @@
 }
 
 .share-form-group select:focus {
-  outline: none;
   border-color: var(--color-primary);
 }
 
@@ -227,7 +226,6 @@
 }
 
 .share-link-input:focus {
-  outline: none;
   border-color: var(--color-primary);
 }
 

--- a/frontend/css/share-manager.css
+++ b/frontend/css/share-manager.css
@@ -87,7 +87,6 @@
   font-size: var(--font-size-sm);
   cursor: pointer;
   appearance: none;
-  outline: none;
   transition: all var(--transition-fast);
 }
 
@@ -96,7 +95,6 @@
 }
 
 .sm-filter-select:focus {
-  outline: none;
   border-color: var(--color-primary);
 }
 

--- a/frontend/css/taskbar.css
+++ b/frontend/css/taskbar.css
@@ -45,7 +45,6 @@
   position: relative;
   user-select: none;
   -webkit-user-select: none;
-  outline: none;
   background: transparent;
   border: none;
   padding: 0;
@@ -58,6 +57,11 @@
 
 .taskbar-icon:active {
   transform: translateY(-2px);
+}
+
+.taskbar-icon:focus-visible {
+  outline: var(--focus-ring-width, 2px) solid var(--focus-ring-color, var(--color-primary));
+  outline-offset: var(--focus-ring-offset, 2px);
 }
 
 .taskbar-icon .icon {

--- a/frontend/css/user-profile.css
+++ b/frontend/css/user-profile.css
@@ -101,7 +101,6 @@
 }
 
 .form-group input:focus {
-  outline: none;
   border-color: var(--color-accent);
   background-color: var(--bg-surface-darker);
 }
@@ -299,7 +298,6 @@
 }
 
 .change-password-modal .form-group .input:focus {
-  outline: none;
   border-color: var(--color-primary);
 }
 

--- a/frontend/css/vendor-manager.css
+++ b/frontend/css/vendor-manager.css
@@ -48,7 +48,6 @@
 }
 
 .vnd-search-input:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 
@@ -503,7 +502,6 @@
 .vnd-form-group input:focus,
 .vnd-form-group select:focus,
 .vnd-form-group textarea:focus {
-  outline: none;
   border-color: var(--color-accent);
 }
 

--- a/frontend/css/viewer.css
+++ b/frontend/css/viewer.css
@@ -427,7 +427,6 @@
 }
 
 .pdf-page-input:focus {
-  outline: none;
   border-color: var(--color-primary);
 }
 

--- a/frontend/js/desktop.js
+++ b/frontend/js/desktop.js
@@ -347,6 +347,15 @@ const DesktopModule = (function() {
         }
         closeContextMenu();
       });
+      // 鍵盤操作：Enter / Space 觸發、Escape 關閉
+      item.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          item.click();
+        } else if (e.key === 'Escape') {
+          closeContextMenu();
+        }
+      });
       // hover 效果
       item.addEventListener('mouseenter', () => { item.style.background = 'rgba(255,255,255,0.1)'; });
       item.addEventListener('mouseleave', () => { item.style.background = 'transparent'; });

--- a/frontend/js/notification.js
+++ b/frontend/js/notification.js
@@ -14,8 +14,9 @@ const NotificationModule = (function () {
 
     container = document.createElement('div');
     container.className = 'notification-container';
-    container.setAttribute('role', 'status');
-    container.setAttribute('aria-live', 'polite');
+    container.setAttribute('role', 'log');
+    container.setAttribute('aria-live', 'assertive');
+    container.setAttribute('aria-atomic', 'false');
     container.setAttribute('aria-label', '通知');
     document.body.appendChild(container);
   }

--- a/frontend/js/window.js
+++ b/frontend/js/window.js
@@ -131,6 +131,9 @@ const WindowModule = (function() {
     windowEl.dataset.appId = appId;
     windowEl.setAttribute('role', 'dialog');
     windowEl.setAttribute('aria-label', title);
+    windowEl.setAttribute('aria-modal', 'true');
+    windowEl.setAttribute('aria-labelledby', `${windowId}-title`);
+    windowEl.tabIndex = -1;
     windowEl.style.width = `${width}px`;
     windowEl.style.height = `${height}px`;
     windowEl.style.left = `${x}px`;
@@ -193,6 +196,14 @@ const WindowModule = (function() {
     if (onInit) {
       onInit(windowEl, windowId);
     }
+
+    // 無障礙：視窗開啟後將焦點移入，讓鍵盤使用者能直接操作
+    requestAnimationFrame(() => {
+      const firstFocusable = windowEl.querySelector(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (firstFocusable) firstFocusable.focus();
+    });
 
     // Notify state change
     notifyStateChange('open', appId);


### PR DESCRIPTION
## Sprint2 無障礙改進

### 📋 變更範圍（22 檔案，+36/-43）

#### 1. 全域 :focus-visible 修正（18 CSS 檔案）
- 移除 18 個元件 CSS 中不當的 `outline: none`（共 39 處）
- 改依賴 `main.css` 全域 `:focus-visible` / `:focus:not(:focus-visible)` 規則
- 鍵盤使用者現在可正常看到焦點指示器

**受影響檔案：** agent-settings / ai-assistant / ai-log / command-palette / file-manager / inventory-management / knowledge-base / login / memory-manager / message-center / project-management / prompt-editor / share-dialog / share-manager / taskbar / user-profile / vendor-manager / viewer

#### 2. 通知系統無障礙（notification.css + notification.js）
- 關閉按鈕尺寸 20×20 → **32×32**（符合 WCAG 2.5.8 目標尺寸）
- 容器改用 `role=log` + `aria-live=assertive`
- 新增 `aria-atomic=false` 讓螢幕閱讀器逐條朗讀

#### 3. 視窗 Modal 無障礙（window.js）
- 新增 `aria-modal=true` + `aria-labelledby` 連結標題
- 新增 `tabIndex=-1` 讓視窗可程式化聚焦
- 視窗開啟後自動聚焦首個可互動元素
- 既有 focus trap (Tab) 與 Esc 關閉已驗證完好

#### 4. 桌面與工作列（desktop.js + taskbar.css）
- 右鍵選單項目新增 Enter/Space/Esc 鍵盤操作
- taskbar.css 新增 `:focus-visible` 規則

### ✅ 檢查結果
- `node --check`: 3 JS 檔語法全通過
- CSS brace-matching: 全部平衡
- `npm run build`: 建置成功

### 📝 決策記錄
- 保留 `main.css` 中 `:focus:not(:focus-visible) { outline: none }`（全域正確規則）
- 通知容器改用 `assertive` 而非 `polite`：通知本質為即時警示
- 無後端改動