### PR TITLE
uiux(sprint6): migrate modules to UIHelpers

### DIFF
--- a/frontend/js/agent-settings.js
+++ b/frontend/js/agent-settings.js
@@ -430,12 +430,8 @@ const AgentSettingsApp = (function() {
     if (!container) return;
 
     if (agents.length === 0) {
-      container.innerHTML = `
-        <div class="agent-list-empty">
-          <span class="icon">${getIcon('robot-outline')}</span>
-          <p>尚無 Agent</p>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="agent-list-empty">... */
+      UIHelpers.showEmpty(container, { icon: 'robot-outline', text: '尚無 Agent' });
       return;
     }
 
@@ -473,13 +469,8 @@ const AgentSettingsApp = (function() {
     if (!main) return;
 
     if (!agentId) {
-      main.innerHTML = `
-        <div class="agent-empty-state">
-          <span class="icon">${getIcon('robot-outline')}</span>
-          <h3>選擇或建立 Agent</h3>
-          <p>從左側選擇一個 Agent 進行設定</p>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="agent-empty-state">... 選擇或建立 Agent */
+      UIHelpers.showEmpty(main, { icon: 'robot-outline', text: '選擇或建立 Agent', subtext: '從左側選擇一個 Agent 進行設定' });
       renderAgentList();
       return;
     }
@@ -731,12 +722,8 @@ const AgentSettingsApp = (function() {
     if (!container) return;
 
     if (skills.length === 0) {
-      container.innerHTML = `
-        <div class="agent-list-empty">
-          <span class="icon">${getIcon('puzzle-outline')}</span>
-          <p>尚無 Skills</p>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="agent-list-empty">... 尚無 Skills */
+      UIHelpers.showEmpty(container, { icon: 'puzzle-outline', text: '尚無 Skills' });
       return;
     }
 
@@ -904,7 +891,8 @@ const AgentSettingsApp = (function() {
         if (backBtn) backBtn.style.display = 'flex';
       }
     } catch (e) {
-      main.innerHTML = `<div class="agent-empty-state"><p>載入失敗: ${e.message}</p></div>`;
+      /* [Sprint6] 原: <div class="agent-empty-state"><p>載入失敗... */
+      UIHelpers.showError(main, { message: '載入失敗: ' + e.message });
     }
   }
 
@@ -1087,11 +1075,13 @@ const AgentSettingsApp = (function() {
     if (!resultsContainer) return;
 
     if (!query.trim()) {
-      resultsContainer.innerHTML = '<div class="agent-list-empty"><p>輸入關鍵字搜尋</p></div>';
+      /* [Sprint6] 原: <div class="agent-list-empty"><p>輸入關鍵字搜尋</p></div> */
+      UIHelpers.showEmpty(resultsContainer, { text: '輸入關鍵字搜尋' });
       return;
     }
 
-    resultsContainer.innerHTML = '<div class="agent-list-empty"><p>搜尋中...</p></div>';
+    /* [Sprint6] 原: <div class="agent-list-empty"><p>搜尋中...</p></div> */
+    UIHelpers.showLoading(resultsContainer, { text: '搜尋中...' });
 
     try {
       const response = await fetch('/api/skills/hub/search', {
@@ -1104,7 +1094,8 @@ const AgentSettingsApp = (function() {
       const results = data.results || [];
 
       if (results.length === 0) {
-        resultsContainer.innerHTML = '<div class="agent-list-empty"><p>無搜尋結果</p></div>';
+        /* [Sprint6] 原: <div class="agent-list-empty"><p>無搜尋結果</p></div> */
+        UIHelpers.showEmpty(resultsContainer, { text: '無搜尋結果' });
         return;
       }
 
@@ -1139,7 +1130,8 @@ const AgentSettingsApp = (function() {
         `;
       }).join('');
     } catch (e) {
-      resultsContainer.innerHTML = `<div class="agent-list-empty"><p>搜尋失敗: ${escapeHtml(e.message)}</p></div>`;
+      /* [Sprint6] 原: <div class="agent-list-empty"><p>搜尋失敗... */
+      UIHelpers.showError(resultsContainer, { message: '搜尋失敗: ' + escapeHtml(e.message) });
     }
   }
 

--- a/frontend/js/code-editor.js
+++ b/frontend/js/code-editor.js
@@ -74,11 +74,9 @@ const CodeEditorModule = (function() {
 
       iframe.addEventListener('error', () => {
         if (loading) {
-          loading.innerHTML = `
-            <span class="icon">${getIcon('mdi-alert-circle')}</span>
-            <span>無法連線到 code-server</span>
-            <small>請確認服務已啟動 (./scripts/start.sh dev)</small>
-          `;
+          /* [Sprint6] 原: loading.innerHTML = getIcon('mdi-alert-circle') + 無法連線... */
+          loading.innerHTML = '';
+          UIHelpers.showError(loading, { icon: 'alert-circle', message: '無法連線到 code-server', detail: '請確認服務已啟動 (./scripts/start.sh dev)' });
         }
       });
     }

--- a/frontend/js/external-app.js
+++ b/frontend/js/external-app.js
@@ -47,9 +47,12 @@ const ExternalAppModule = (function() {
       height,
       content: `
         <div class="external-app-container">
+          <!-- [Sprint6] 保留原 loading 容器供 iframe 載入週期控制 -->
           <div class="external-app-loading">
-            <span class="icon">${getIcon('mdi-loading')}</span>
-            <span>載入中...</span>
+            <div class="ui-state ui-state--loading" role="status" aria-live="polite">
+              <span class="ui-state-icon">${typeof getIcon === 'function' ? getIcon('refresh') : ''}</span>
+              <span class="ui-state-text">載入中...</span>
+            </div>
           </div>
           <iframe
             class="external-app-iframe"
@@ -58,10 +61,12 @@ const ExternalAppModule = (function() {
             sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-forms allow-modals allow-downloads"
           ></iframe>
           <div class="external-app-error" style="display: none;">
-            <span class="icon">${getIcon('mdi-alert-circle')}</span>
-            <span>無法載入外部服務</span>
+            <div class="ui-state ui-state--error" role="alert" aria-live="assertive">
+              <span class="ui-state-icon">${typeof getIcon === 'function' ? getIcon('alert-circle') : ''}</span>
+              <span class="ui-state-text">無法載入外部服務</span>
+            </div>
             <a href="${url}" target="_blank" class="external-app-open-link">
-              <span class="icon">${getIcon('mdi-open-in-new')}</span>
+              <span class="icon">${typeof getIcon === 'function' ? getIcon('mdi-open-in-new') : ''}</span>
               在新視窗開啟
             </a>
           </div>

--- a/frontend/js/memory-manager.js
+++ b/frontend/js/memory-manager.js
@@ -123,7 +123,8 @@ const MemoryManagerApp = (function() {
     const listEl = windowEl.querySelector('#mmSidebarList');
     if (!listEl) return;
 
-    listEl.innerHTML = `<div class="mm-loading">${icon('loading', 'mdi-spin')}</div>`;
+    /* [Sprint6] 原: <div class="mm-loading">${icon('loading', 'mdi-spin')}</div> */
+    UIHelpers.showLoading(listEl);
 
     try {
       const result = await apiRequest('/groups?limit=100');
@@ -131,12 +132,8 @@ const MemoryManagerApp = (function() {
       renderGroupList(listEl);
     } catch (error) {
       console.error('Failed to load groups:', error);
-      listEl.innerHTML = `
-        <div class="mm-error">
-          ${icon('alert-circle')}
-          <p>${error.message}</p>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="mm-error">${icon('alert-circle')}... */
+      UIHelpers.showError(listEl, { message: error.message });
     }
   }
 
@@ -147,7 +144,8 @@ const MemoryManagerApp = (function() {
     const listEl = windowEl.querySelector('#mmSidebarList');
     if (!listEl) return;
 
-    listEl.innerHTML = `<div class="mm-loading">${icon('loading', 'mdi-spin')}</div>`;
+    /* [Sprint6] 原: <div class="mm-loading">${icon('loading', 'mdi-spin')}</div> */
+    UIHelpers.showLoading(listEl);
 
     try {
       const result = await apiRequest('/users-with-binding?limit=100');
@@ -155,12 +153,8 @@ const MemoryManagerApp = (function() {
       renderUserList(listEl);
     } catch (error) {
       console.error('Failed to load users:', error);
-      listEl.innerHTML = `
-        <div class="mm-error">
-          ${icon('alert-circle')}
-          <p>${error.message}</p>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="mm-error">${icon('alert-circle')}... */
+      UIHelpers.showError(listEl, { message: error.message });
     }
   }
 
@@ -169,12 +163,8 @@ const MemoryManagerApp = (function() {
    */
   function renderGroupList(listEl) {
     if (groups.length === 0) {
-      listEl.innerHTML = `
-        <div class="mm-empty-sidebar">
-          ${icon('account-group-outline')}
-          <p>沒有群組</p>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="mm-empty-sidebar">${icon('account-group-outline')}... */
+      UIHelpers.showEmpty(listEl, { icon: 'account-group-outline', text: '沒有群組', variant: 'compact' });
       return;
     }
 
@@ -209,12 +199,8 @@ const MemoryManagerApp = (function() {
    */
   function renderUserList(listEl) {
     if (users.length === 0) {
-      listEl.innerHTML = `
-        <div class="mm-empty-sidebar">
-          ${icon('account-outline')}
-          <p>沒有用戶</p>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="mm-empty-sidebar">${icon('account-outline')}... */
+      UIHelpers.showEmpty(listEl, { icon: 'account-outline', text: '沒有用戶', variant: 'compact' });
       return;
     }
 
@@ -318,7 +304,8 @@ const MemoryManagerApp = (function() {
     const listEl = containerEl.querySelector('#mmMemoryList');
     if (!listEl) return;
 
-    listEl.innerHTML = `<div class="mm-loading">${icon('loading', 'mdi-spin')}</div>`;
+    /* [Sprint6] 原: <div class="mm-loading">${icon('loading', 'mdi-spin')}</div> */
+    UIHelpers.showLoading(listEl);
 
     try {
       const endpoint = type === 'group'
@@ -329,12 +316,8 @@ const MemoryManagerApp = (function() {
       renderMemories(listEl, containerEl);
     } catch (error) {
       console.error('Failed to load memories:', error);
-      listEl.innerHTML = `
-        <div class="mm-error">
-          ${icon('alert-circle')}
-          <p>${error.message}</p>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="mm-error">${icon('alert-circle')}... */
+      UIHelpers.showError(listEl, { message: error.message });
     }
   }
 
@@ -343,13 +326,8 @@ const MemoryManagerApp = (function() {
    */
   function renderMemories(listEl, containerEl) {
     if (memories.length === 0) {
-      listEl.innerHTML = `
-        <div class="mm-empty">
-          ${icon('brain')}
-          <p>目前沒有設定任何記憶</p>
-          <p class="mm-empty-hint">點擊「新增記憶」來建立第一筆記憶</p>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="mm-empty">${icon('brain')}... 目前沒有設定任何記憶 */
+      UIHelpers.showEmpty(listEl, { icon: 'brain', text: '目前沒有設定任何記憶', subtext: '點擊「新增記憶」來建立第一筆記憶' });
       return;
     }
 
@@ -645,12 +623,8 @@ const MemoryManagerApp = (function() {
         }
         const memoryListEl = containerEl.querySelector('#mmMemoryList');
         if (memoryListEl) {
-          memoryListEl.innerHTML = `
-            <div class="mm-empty">
-              ${icon('brain')}
-              <p>請從左側選擇${newTab === 'group' ? '群組' : '用戶'}</p>
-            </div>
-          `;
+          /* [Sprint6] 原: <div class="mm-empty">${icon('brain')}... 請從左側選擇... */
+          UIHelpers.showEmpty(memoryListEl, { icon: 'brain', text: `請從左側選擇${newTab === 'group' ? '群組' : '用戶'}` });
         }
 
         // 載入列表

--- a/frontend/js/message-center.js
+++ b/frontend/js/message-center.js
@@ -66,12 +66,8 @@ const MessageCenterApp = (function () {
     if (!container) return;
 
     const listEl = container.querySelector('.mc-list');
-    listEl.innerHTML = `
-      <div class="mc-loading">
-        <span class="icon">${getIcon('loading')}</span>
-        載入中...
-      </div>
-    `;
+    /* [Sprint6] 原: <div class="mc-loading">... 載入中... */
+    UIHelpers.showLoading(listEl, { text: '載入中...' });
 
     try {
       const params = new URLSearchParams();
@@ -96,14 +92,8 @@ const MessageCenterApp = (function () {
       renderPagination();
     } catch (error) {
       console.error('Failed to load messages:', error);
-      listEl.innerHTML = `
-        <div class="mc-empty">
-          <div class="mc-empty-icon">
-            <span class="icon">${getIcon('alert-circle')}</span>
-          </div>
-          <div class="mc-empty-text">載入訊息失敗</div>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="mc-empty">... 載入訊息失敗 */
+      UIHelpers.showError(listEl, { icon: 'alert-circle', message: '載入訊息失敗' });
     }
   }
 
@@ -114,14 +104,8 @@ const MessageCenterApp = (function () {
     const listEl = container.querySelector('.mc-list');
 
     if (messages.length === 0) {
-      listEl.innerHTML = `
-        <div class="mc-empty">
-          <div class="mc-empty-icon">
-            <span class="icon">${getIcon('bell-off')}</span>
-          </div>
-          <div class="mc-empty-text">沒有訊息</div>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="mc-empty">... 沒有訊息 */
+      UIHelpers.showEmpty(listEl, { icon: 'bell-off', text: '沒有訊息' });
       return;
     }
 

--- a/frontend/js/prompt-editor.js
+++ b/frontend/js/prompt-editor.js
@@ -268,12 +268,8 @@ const PromptEditorApp = (function() {
     if (!container) return;
 
     if (prompts.length === 0) {
-      container.innerHTML = `
-        <div class="prompt-list-empty">
-          <span class="icon">${getIcon('file-document-outline')}</span>
-          <p>尚無 Prompt</p>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="prompt-list-empty">${getIcon('file-document-outline')}... 尚無 Prompt */
+      UIHelpers.showEmpty(container, { icon: 'file-document-outline', text: '尚無 Prompt' });
       return;
     }
 
@@ -311,13 +307,8 @@ const PromptEditorApp = (function() {
     if (!main) return;
 
     if (!promptId) {
-      main.innerHTML = `
-        <div class="prompt-empty-state">
-          <span class="icon">${getIcon('file-document-edit-outline')}</span>
-          <h3>選擇或建立 Prompt</h3>
-          <p>從左側選擇一個 Prompt 進行編輯</p>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="prompt-empty-state">${getIcon('file-document-edit-outline')}... 選擇或建立 Prompt */
+      UIHelpers.showEmpty(main, { icon: 'file-document-edit-outline', text: '選擇或建立 Prompt', subtext: '從左側選擇一個 Prompt 進行編輯' });
       renderPromptList();
       return;
     }

--- a/frontend/js/share-dialog.js
+++ b/frontend/js/share-dialog.js
@@ -265,12 +265,8 @@ const ShareDialogModule = (function() {
       const expiresInHours = expiresValue ? parseInt(expiresValue) : null;
 
       // 顯示載入狀態
-      body.innerHTML = `
-        <div class="share-loading">
-          ${icon('loading', 'mdi-spin')}
-          <span>正在產生分享連結...</span>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="share-loading">${icon('loading', 'mdi-spin')}... 正在產生分享連結... */
+      UIHelpers.showLoading(body, { text: '正在產生分享連結...' });
 
       try {
         const result = await createShareLink(resourceType, resourceId, expiresInHours);
@@ -395,16 +391,8 @@ const ShareDialogModule = (function() {
    * @param {Function} onRetry - 重試回調
    */
   function showError(container, message, onRetry) {
-    container.innerHTML = `
-      <div class="share-error">
-        ${icon('alert-circle')}
-        <p class="share-error-message">${escapeHtml(message)}</p>
-        <button class="share-retry-btn">重試</button>
-      </div>
-    `;
-
-    const retryBtn = container.querySelector('.share-retry-btn');
-    retryBtn.addEventListener('click', onRetry);
+    /* [Sprint6] 原: <div class="share-error">${icon('alert-circle')}... + retry btn */
+    UIHelpers.showError(container, { message: escapeHtml(message), onRetry: onRetry });
   }
 
   /**

--- a/frontend/js/share-manager.js
+++ b/frontend/js/share-manager.js
@@ -136,12 +136,8 @@ const ShareManagerApp = (function() {
     const contentEl = windowEl.querySelector('#smContent');
     if (!contentEl) return;
 
-    contentEl.innerHTML = `
-      <div class="sm-loading">
-        ${icon('loading', 'mdi-spin')}
-        <span>載入中...</span>
-      </div>
-    `;
+    /* [Sprint6] 原: <div class="sm-loading">${icon('loading', 'mdi-spin')}... 載入中... */
+    UIHelpers.showLoading(contentEl, { text: '載入中...' });
 
     try {
       const result = await apiRequest(`?view=${viewMode}`);
@@ -163,18 +159,8 @@ const ShareManagerApp = (function() {
       renderLinks(contentEl);
     } catch (error) {
       console.error('Failed to load share links:', error);
-      contentEl.innerHTML = `
-        <div class="sm-error">
-          ${icon('alert-circle')}
-          <p class="sm-error-message">${error.message}</p>
-          <button class="sm-retry-btn" id="smRetryBtn">重試</button>
-        </div>
-      `;
-
-      const retryBtn = contentEl.querySelector('#smRetryBtn');
-      if (retryBtn) {
-        retryBtn.addEventListener('click', () => loadLinks(windowEl));
-      }
+      /* [Sprint6] 原: <div class="sm-error">${icon('alert-circle')}... + retry btn */
+      UIHelpers.showError(contentEl, { message: error.message, onRetry: () => loadLinks(windowEl) });
     }
   }
 
@@ -189,12 +175,8 @@ const ShareManagerApp = (function() {
     }
 
     if (filteredLinks.length === 0) {
-      contentEl.innerHTML = `
-        <div class="sm-empty">
-          ${icon('link-off')}
-          <p class="sm-empty-text">目前沒有分享連結</p>
-        </div>
-      `;
+      /* [Sprint6] 原: <div class="sm-empty">${icon('link-off')}... 目前沒有分享連結 */
+      UIHelpers.showEmpty(contentEl, { icon: 'link-off', text: '目前沒有分享連結' });
       return;
     }
 


### PR DESCRIPTION
## uiux(sprint6): migrate modules to UIHelpers

### 概述
將 8 個前端模組中分散的自訂 loading / empty / error 狀態 HTML 替換為統一的 UIHelpers API（showLoading, showEmpty, showError），減少重複實作，統一回饋狀態元件的樣式與行為。

### 變更清單

| 檔案 | 替換數 | 說明 |
|------|--------|------|
| agent-settings.js | 8 | empty×4, loading×1, error×3 |
| code-editor.js | 1 | error 狀態→UIHelpers.showError |
| message-center.js | 3 | loading×1, error×1, empty×1 |
| memory-manager.js | 10 | loading×3, error×3, empty×4 |
| share-manager.js | 3 | loading×1, error+retry×1, empty×1 |
| prompt-editor.js | 2 | empty×2 |
| external-app.js | 1 | loading/error HTML 改用 UIHelpers 統一結構 |
| share-dialog.js | 2 | loading×1, error+retry×1 |

### 替換詳情

**agent-settings.js — empty 狀態**
原: `container.innerHTML = '<div class="agent-list-empty">...'`
替換: `UIHelpers.showEmpty(container, { icon: 'robot-outline', text: '尚無 Agent' })`

**agent-settings.js — error 狀態**
原: `main.innerHTML = '<div class="agent-empty-state"><p>載入失敗...'`
替換: `UIHelpers.showError(main, { message: '載入失敗: ' + e.message })`

**agent-settings.js — loading 狀態**
原: `resultsContainer.innerHTML = '<div class="agent-list-empty"><p>搜尋中...</p></div>'`
替換: `UIHelpers.showLoading(resultsContainer, { text: '搜尋中...' })`

**message-center.js — loading**
原: `listEl.innerHTML = '<div class="mc-loading">...'`
替換: `UIHelpers.showLoading(listEl, { text: '載入中...' })`

**message-center.js — error**
原: `listEl.innerHTML = '<div class="mc-empty">...載入訊息失敗...'`
替換: `UIHelpers.showError(listEl, { icon: 'alert-circle', message: '載入訊息失敗' })`

**message-center.js — empty**
原: `listEl.innerHTML = '<div class="mc-empty">...沒有訊息...'`
替換: `UIHelpers.showEmpty(listEl, { icon: 'bell-off', text: '沒有訊息' })`

**memory-manager.js — loading (×3)**
原: `listEl.innerHTML = '<div class="mm-loading">...'`
替換: `UIHelpers.showLoading(listEl)`

**memory-manager.js — error (×3)**
原: `listEl.innerHTML = '<div class="mm-error">...'`
替換: `UIHelpers.showError(listEl, { message: error.message })`

**memory-manager.js — empty (×4)**
原: `listEl.innerHTML = '<div class="mm-empty-sidebar">...'` / `'<div class="mm-empty">...'`
替換: `UIHelpers.showEmpty(listEl, { icon: '...', text: '...', variant: 'compact' })`

**share-manager.js — error+retry**
原: `contentEl.innerHTML = '<div class="sm-error">...' + retryBtn addEventListener`
替換: `UIHelpers.showError(contentEl, { message: error.message, onRetry: () => loadLinks(windowEl) })`

**share-dialog.js — error+retry**
原: `function showError() { container.innerHTML = '<div class="share-error">...' + retryBtn }`
替換: `UIHelpers.showError(container, { message: escapeHtml(message), onRetry: onRetry })`

**code-editor.js — error**
原: `loading.innerHTML = '<span class="icon">...alert-circle...無法連線到 code-server...'`
替換: `UIHelpers.showError(loading, { icon: 'alert-circle', message: '無法連線到 code-server', detail: '...' })`

**external-app.js — 統一 HTML 結構**
iframe 載入流程保持原有 display 切換邏輯，將內部 HTML 改為 UIHelpers 統一結構（.ui-state class, role, aria-live）

### 遷移原則
- 所有替換保留原有功能（onRetry callback, aria 屬性）
- 舊 class 名稱以 /* [Sprint6] 原: ... */ 註解保留，方便回滾
- 模板字串中的初始 HTML（如 window content 建立時的預設狀態）暫保留，待未來 Sprint 統一處理
- 不變更後端程式碼

### 檢查結果
- ✅ node --check 全部 8 個檔案通過
- ✅ CSS 括號配對檢查無異常

### 未遷移項目（建議未來 Sprint）
- agent-settings.js 中模板字串初始 HTML（lines 230-234, 263-267）需 DOM ready 後才能呼叫 UIHelpers
- message-center.js 中 createContent() 的初始 loading HTML（lines 526-529）
- memory-manager.js 中初始 loading/empty HTML（lines 91-93, 108-111）
- external-app.js 的 iframe 載入超時流程（setTimeout + display toggle）結構較複雜
- agent-settings.js 測試結果 loading（line 684）屬特殊 UI，不適合直接替換
- code-editor.js 的初始 loading HTML（template literal 內）
