### PR TITLE
uiux(sprint7): migrate image-viewer to UIHelpers

### DIFF
--- a/frontend/js/image-viewer.js
+++ b/frontend/js/image-viewer.js
@@ -87,6 +87,9 @@ const ImageViewerModule = (function() {
   function handleInit(windowEl, wId) {
     // Set windowId here since createWindow calls onInit before returning
     windowId = wId;
+    // [Sprint7] 使用 UIHelpers 初始化 loading 狀態
+    const loadingContainer = windowEl.querySelector('.image-viewer-loading-container');
+    if (loadingContainer) UIHelpers.showLoading(loadingContainer, { text: '載入中…' });
     bindEvents(windowEl);
     loadImage();
   }
@@ -114,10 +117,8 @@ const ImageViewerModule = (function() {
           </button>
         </div>
         <div class="viewer-content image-viewer-content" id="imgViewerContent">
-          <div class="image-viewer-loading">
-            <span class="icon">${getIcon('file-image')}</span>
-            <span>載入中...</span>
-          </div>
+          <!-- [Sprint7] 原始: <div class="image-viewer-loading"><span class="icon">...</span><span>載入中...</span></div> -->
+          <div class="image-viewer-loading-container"></div>
         </div>
         <div class="viewer-statusbar">
           <span id="imgStatusInfo">-</span>
@@ -175,12 +176,8 @@ const ImageViewerModule = (function() {
     };
 
     img.onerror = () => {
-      content.innerHTML = `
-        <div class="image-viewer-error">
-          <span class="icon">${getIcon('information')}</span>
-          <span>無法載入圖片</span>
-        </div>
-      `;
+      // [Sprint7] 原始: content.innerHTML = '<div class="image-viewer-error"><span class="icon">...</span><span>無法載入圖片</span></div>'
+      UIHelpers.showError(content, { message: '無法載入圖片' });
     };
 
     // Determine the URL to fetch
@@ -216,12 +213,8 @@ const ImageViewerModule = (function() {
       img.src = URL.createObjectURL(blob);
     })
     .catch(error => {
-      content.innerHTML = `
-        <div class="image-viewer-error">
-          <span class="icon">${getIcon('information')}</span>
-          <span>${error.message}</span>
-        </div>
-      `;
+      // [Sprint7] 原始: content.innerHTML = '<div class="image-viewer-error"><span class="icon">...</span><span>${error.message}</span></div>'
+      UIHelpers.showError(content, { message: '載入失敗', detail: error.message });
     });
   }
 


### PR DESCRIPTION
## Sprint 7 — image-viewer 模組遷移至 UIHelpers

### 替換摘要（3 處）

| 類型 | 位置 | 原始 | 新版 |
|------|------|------|------|
| Loading | 初始模板 image-viewer-loading | `<div class="image-viewer-loading">..載入中..</div>` | `UIHelpers.showLoading(container, { text: '載入中…' })` |
| Error | img.onerror | `<div class="image-viewer-error"><span>無法載入圖片</span></div>` | `UIHelpers.showError(content, { message })` |
| Error | fetch .catch | `<div class="image-viewer-error"><span>${error.message}</span></div>` | `UIHelpers.showError(content, { message, detail })` |

原始實作保留為註解以便回滾。