### PR TITLE
uiux(sprint7): migrate desktop to UIHelpers

### DIFF
--- a/frontend/js/desktop.js
+++ b/frontend/js/desktop.js
@@ -55,12 +55,11 @@ const DesktopModule = (function() {
     const overlay = document.createElement('div');
     overlay.className = 'app-loading-overlay';
     overlay.dataset.loadingFor = appId;
-    overlay.innerHTML = `
-      <div class="app-loading-skeleton">
-        <div class="skeleton-spinner"></div>
-        <span class="skeleton-label">正在載入模組…</span>
-      </div>
-    `;
+    // [Sprint7] 原始: overlay.innerHTML = '<div class="app-loading-skeleton"><div class="skeleton-spinner"></div><span class="skeleton-label">正在載入模組…</span></div>'
+    const inner = document.createElement('div');
+    inner.className = 'app-loading-skeleton';
+    overlay.appendChild(inner);
+    UIHelpers.showLoading(inner, { text: '正在載入模組…' });
     document.body.appendChild(overlay);
     return overlay;
   }


### PR DESCRIPTION
## Sprint 7 — desktop 模組遷移至 UIHelpers

### 替換摘要（1 處）

| 類型 | 位置 | 原始 | 新版 |
|------|------|------|------|
| Loading | showLoadingSkeleton | `<div class="app-loading-skeleton"><div class="skeleton-spinner"></div>正在載入模組…</div>` | `UIHelpers.showLoading(inner, { text: '正在載入模組…' })` |

原始實作保留為註解以便回滾。