### PR TITLE
uiux(sprint7): migrate user-profile to UIHelpers

### DIFF
--- a/frontend/js/user-profile.js
+++ b/frontend/js/user-profile.js
@@ -33,7 +33,8 @@ const UserProfileModule = (function() {
   function getWindowContent() {
     return `
       <div class="user-profile-content">
-        <div class="user-profile-loading">載入中...</div>
+        <!-- [Sprint7] 原始: <div class="user-profile-loading">載入中...</div> -->
+        <div class="user-profile-loading-container"></div>
       </div>
     `;
   }
@@ -198,14 +199,14 @@ const UserProfileModule = (function() {
             }
           }
         } else {
-          messageEl.className = 'user-profile-message error';
-          messageEl.textContent = result.error || '操作失敗';
+          // [Sprint7] 原始: messageEl.className = 'user-profile-message error'; messageEl.textContent = result.error || '操作失敗'
+          UIHelpers.showError(messageEl, { message: result.error || '操作失敗', variant: 'compact' });
           confirmBtn.disabled = false;
           confirmBtn.textContent = hasPassword ? '變更密碼' : '設定密碼';
         }
       } catch (error) {
-        messageEl.className = 'user-profile-message error';
-        messageEl.textContent = error.message || '操作失敗';
+        // [Sprint7] 原始: messageEl.className = 'user-profile-message error'; messageEl.textContent = error.message || '操作失敗'
+        UIHelpers.showError(messageEl, { message: error.message || '操作失敗', variant: 'compact' });
         confirmBtn.disabled = false;
         confirmBtn.textContent = hasPassword ? '變更密碼' : '設定密碼';
       }
@@ -349,15 +350,16 @@ const UserProfileModule = (function() {
     const contentEl = windowEl.querySelector('.user-profile-content');
     if (!contentEl) return;
 
+    // [Sprint7] 使用 UIHelpers 初始化 loading 狀態
+    const loadingContainer = contentEl.querySelector('.user-profile-loading-container');
+    if (loadingContainer) UIHelpers.showLoading(loadingContainer, { text: '載入中…' });
+
     try {
       const user = await fetchUserInfo();
       renderUserInfo(contentEl, user);
     } catch (error) {
-      contentEl.innerHTML = `
-        <div class="user-profile-message error" style="margin: var(--spacing-lg);">
-          ${error.message || '無法載入使用者資訊'}
-        </div>
-      `;
+      // [Sprint7] 原始: contentEl.innerHTML = '<div class="user-profile-message error">...${error.message}</div>'
+      UIHelpers.showError(contentEl, { message: '無法載入使用者資訊', detail: error.message });
     }
   }
 


### PR DESCRIPTION
## Sprint 7 — user-profile 模組遷移至 UIHelpers

### 替換摘要（3 處）

| 類型 | 位置 | 原始 | 新版 |
|------|------|------|------|
| Loading | 初始模板 | `<div class="user-profile-loading">載入中...</div>` | `UIHelpers.showLoading(container, { text: '載入中…' })` |
| Error | 密碼操作失敗 (×2) | `messageEl.textContent = '操作失敗'` | `UIHelpers.showError(messageEl, { message, variant: 'compact' })` |
| Error | initWindow catch | `<div class="user-profile-message error">...\</div>` | `UIHelpers.showError(contentEl, { message, detail })` |

原始實作保留為註解以便回滾。