### PR TITLE
uiux(sprint7): migrate command-palette to UIHelpers

### DIFF
--- a/frontend/js/command-palette.js
+++ b/frontend/js/command-palette.js
@@ -194,9 +194,8 @@ const CommandPaletteModule = (function () {
     const hasResults = apps.length > 0 || windows.length > 0;
 
     if (!hasResults) {
-      resultsEl.innerHTML = `<div class="command-palette-empty">${
-        q ? '找不到符合的結果' : '輸入關鍵字開始搜尋'
-      }</div>`;
+      // [Sprint7] 原始: resultsEl.innerHTML = '<div class="command-palette-empty">...(找不到符合的結果|輸入關鍵字開始搜尋)</div>'
+      UIHelpers.showEmpty(resultsEl, { icon: 'magnify', text: q ? '找不到符合的結果' : '輸入關鍵字開始搜尋' });
       return;
     }
 


### PR DESCRIPTION
## Sprint 7 — command-palette 模組遷移至 UIHelpers

### 替換摘要（1 處）

| 類型 | 位置 | 原始 | 新版 |
|------|------|------|------|
| Empty | 搜尋無結果/初始狀態 | `<div class="command-palette-empty">找不到符合的結果</div>` | `UIHelpers.showEmpty(resultsEl, { icon: 'magnify', text })` |

原始實作保留為註解以便回滾。