### PR TITLE
uiux(sprint7): migrate login to UIHelpers

### DIFF
--- a/frontend/js/login.js
+++ b/frontend/js/login.js
@@ -298,13 +298,15 @@ const LoginModule = (function() {
             overlay.remove();
             resolve(true);
           } else {
-            errorDiv.textContent = result.error || '變更密碼失敗';
+            // [Sprint7] 原始: errorDiv.textContent = result.error || '變更密碼失敗'; errorDiv.classList.add('show')
+            UIHelpers.showError(errorDiv, { message: result.error || '變更密碼失敗', variant: 'compact' });
             errorDiv.classList.add('show');
             submitBtn.disabled = false;
             submitBtn.textContent = '確認變更';
           }
         } catch (error) {
-          errorDiv.textContent = '發生錯誤，請稍後再試';
+          // [Sprint7] 原始: errorDiv.textContent = '發生錯誤，請稍後再試'; errorDiv.classList.add('show')
+          UIHelpers.showError(errorDiv, { message: '發生錯誤，請稍後再試', variant: 'compact' });
           errorDiv.classList.add('show');
           submitBtn.disabled = false;
           submitBtn.textContent = '確認變更';
@@ -387,11 +389,13 @@ const LoginModule = (function() {
           window.location.href = 'index.html';
         }
       } else {
-        errorDiv.textContent = result.error || '登入失敗';
+        // [Sprint7] 原始: errorDiv.textContent = result.error || '登入失敗'; errorDiv.classList.add('show')
+        UIHelpers.showError(errorDiv, { message: result.error || '登入失敗', variant: 'compact' });
         errorDiv.classList.add('show');
       }
     } catch (error) {
-      errorDiv.textContent = '登入時發生錯誤，請稍後再試';
+      // [Sprint7] 原始: errorDiv.textContent = '登入時發生錯誤，請稍後再試'; errorDiv.classList.add('show')
+      UIHelpers.showError(errorDiv, { message: '登入時發生錯誤，請稍後再試', variant: 'compact' });
       errorDiv.classList.add('show');
     } finally {
       resetSubmitBtn(submitBtn);


### PR DESCRIPTION
## Sprint 7 — login 模組遷移至 UIHelpers

### 替換摘要（4 處）

| 類型 | 位置 | 原始 | 新版 |
|------|------|------|------|
| Error | 變更密碼 result.error | `errorDiv.textContent = '變更密碼失敗'` | `UIHelpers.showError(errorDiv, { message, variant: 'compact' })` |
| Error | 變更密碼 catch | `errorDiv.textContent = '發生錯誤'` | `UIHelpers.showError(errorDiv, { message, variant: 'compact' })` |
| Error | 登入 result.error | `errorDiv.textContent = '登入失敗'` | `UIHelpers.showError(errorDiv, { message, variant: 'compact' })` |
| Error | 登入 catch | `errorDiv.textContent = '登入時發生錯誤'` | `UIHelpers.showError(errorDiv, { message, variant: 'compact' })` |

原始實作保留為註解以便回滾。