### PR TITLE
uiux(sprint7): migrate public to UIHelpers

### DIFF
--- a/frontend/js/public.js
+++ b/frontend/js/public.js
@@ -170,8 +170,11 @@
         loadingEl.style.display = 'none';
         contentEl.style.display = 'none';
         errorPageEl.style.display = 'flex';
-        errorTitleEl.textContent = title;
-        errorMessageEl.textContent = message;
+        // [Sprint7] 原始: errorTitleEl.textContent = title; errorMessageEl.textContent = message;
+        UIHelpers.showError(errorPageEl, { message: title, detail: message });
+        // 保留返回首頁連結
+        const homeLink = document.getElementById('home-link-error');
+        if (homeLink) errorPageEl.appendChild(homeLink);
     }
 
     /**


### PR DESCRIPTION
## Sprint 7 — public 模組遷移至 UIHelpers

### 替換摘要（1 處）

| 類型 | 位置 | 原始 | 新版 |
|------|------|------|------|
| Error | showError 函式 | `errorTitleEl.textContent = title; errorMessageEl.textContent = message` | `UIHelpers.showError(errorPageEl, { message: title, detail: message })` |

影響所有 7 處 showError() 呼叫（連結無效、連結過期、載入失敗等）。原始實作保留為註解以便回滾。