### PR TITLE
feat(ui): Sprint8 — user-profile 採用 UIHelpers 統一回饋狀態

### DIFF
--- a/frontend/js/user-profile.js
+++ b/frontend/js/user-profile.js
@@ -168,18 +168,18 @@ const UserProfileModule = (function() {
 
       // Validation
       if (hasPassword && !currentPassword) {
-        messageEl.className = 'user-profile-message error';
-        messageEl.textContent = '請輸入目前密碼';
+        // [Sprint8] 原: messageEl.className = 'user-profile-message error'; messageEl.textContent = '請輸入目前密碼'
+        UIHelpers.showError(messageEl, { message: '請輸入目前密碼', variant: 'compact' });
         return;
       }
       if (!newPassword || newPassword.length < 8) {
-        messageEl.className = 'user-profile-message error';
-        messageEl.textContent = '新密碼至少需要 8 個字元';
+        // [Sprint8] 原: messageEl.className = 'user-profile-message error'; messageEl.textContent = '新密碼至少需要 8 個字元'
+        UIHelpers.showError(messageEl, { message: '新密碼至少需要 8 個字元', variant: 'compact' });
         return;
       }
       if (newPassword !== confirmPassword) {
-        messageEl.className = 'user-profile-message error';
-        messageEl.textContent = '兩次輸入的密碼不一致';
+        // [Sprint8] 原: messageEl.className = 'user-profile-message error'; messageEl.textContent = '兩次輸入的密碼不一致'
+        UIHelpers.showError(messageEl, { message: '兩次輸入的密碼不一致', variant: 'compact' });
         return;
       }
 


### PR DESCRIPTION
## Sprint8: user-profile UIHelpers 遷移

### 變更摘要
密碼變更表單的驗證錯誤訊息改用 UIHelpers.showError（compact），與 Sprint7 API 錯誤處理保持一致。

### old → new 程式碼片段

```diff
- messageEl.className = 'user-profile-message error';
- messageEl.textContent = '請輸入目前密碼';
+ UIHelpers.showError(messageEl, { message: '請輸入目前密碼', variant: 'compact' });

- messageEl.className = 'user-profile-message error';
- messageEl.textContent = '新密碼至少需要 8 個字元';
+ UIHelpers.showError(messageEl, { message: '新密碼至少需要 8 個字元', variant: 'compact' });

- messageEl.className = 'user-profile-message error';
- messageEl.textContent = '兩次輸入的密碼不一致';
+ UIHelpers.showError(messageEl, { message: '兩次輸入的密碼不一致', variant: 'compact' });
```
