### PR TITLE
feat(ui): Sprint8 — settings 採用 UIHelpers 統一回饋狀態

### DIFF
--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -650,8 +650,13 @@ const SettingsApp = (function () {
   function showBotStatus(container, platform, message, isError = false) {
     const el = container.querySelector(`.bot-status-msg[data-platform="${platform}"]`);
     if (el) {
-      el.textContent = message;
-      el.className = `bot-status-msg ${isError ? 'bot-status-error' : 'bot-status-success'}`;
+      // [Sprint8] 原: el.textContent = message; el.className = `bot-status-msg ${isError ? 'bot-status-error' : 'bot-status-success'}`
+      if (isError) {
+        UIHelpers.showError(el, { message, variant: 'compact' });
+      } else {
+        el.textContent = message;
+        el.className = 'bot-status-msg bot-status-success';
+      }
       setTimeout(() => { el.textContent = ''; el.className = 'bot-status-msg'; }, 5000);
     }
   }


### PR DESCRIPTION
## Sprint8: settings UIHelpers 遷移

### 變更摘要
Bot 設定狀態訊息的錯誤分支改用 UIHelpers.showError（compact）。

### old → new 程式碼片段

```diff
- el.textContent = message;
- el.className = \`bot-status-msg \${isError ? 'bot-status-error' : 'bot-status-success'}\`;
+ if (isError) {
+   UIHelpers.showError(el, { message, variant: 'compact' });
+ } else {
+   el.textContent = message;
+   el.className = 'bot-status-msg bot-status-success';
+ }
```
