### PR TITLE
feat(ui): Sprint8 — terminal 採用 UIHelpers 統一回饋狀態

### DIFF
--- a/frontend/js/terminal.js
+++ b/frontend/js/terminal.js
@@ -70,6 +70,10 @@ const TerminalApp = (function() {
      * @param {HTMLElement} container
      */
     init(container) {
+      // [Sprint8] UIHelpers: 在 xterm 初始化前顯示載入狀態
+      UIHelpers.showLoading(container, { text: '終端機載入中…' });
+
+      try {
       // Create terminal instance with theme from CSS variables
       this.terminal = new Terminal({
         cursorBlink: true,
@@ -114,6 +118,10 @@ const TerminalApp = (function() {
 
       // Check for recoverable sessions or create new
       this.checkAndConnect();
+      } catch (err) {
+        // [Sprint8] UIHelpers: xterm 初始化失敗時顯示錯誤
+        UIHelpers.showError(container, { message: '終端機載入失敗', detail: err.message });
+      }
     }
 
     /**


### PR DESCRIPTION
## Sprint8: terminal UIHelpers 新增採用

### 變更摘要
新增 UIHelpers 採用：xterm 初始化前顯示載入狀態，初始化失敗時顯示錯誤狀態。

### old → new 程式碼片段

```diff
  init(container) {
+   // [Sprint8] UIHelpers: 在 xterm 初始化前顯示載入狀態
+   UIHelpers.showLoading(container, { text: '終端機載入中…' });
+
+   try {
    // Create terminal instance...
    this.terminal.open(container);
    ...
    this.checkAndConnect();
+   } catch (err) {
+     // [Sprint8] UIHelpers: xterm 初始化失敗時顯示錯誤
+     UIHelpers.showError(container, { message: '終端機載入失敗', detail: err.message });
+   }
  }
```
