### PR TITLE
feat(ui): Sprint8 — window 採用 UIHelpers 統一回饋狀態

### DIFF
--- a/frontend/js/window.js
+++ b/frontend/js/window.js
@@ -256,6 +256,12 @@ const WindowModule = (function() {
     // Add to DOM
     desktopArea.appendChild(windowEl);
 
+    // [Sprint8] UIHelpers: 當 content 為空時，預設顯示載入狀態
+    if (!content || !content.trim()) {
+      const contentArea = windowEl.querySelector('.window-content');
+      if (contentArea) UIHelpers.showLoading(contentArea, { text: '載入中…' });
+    }
+
     // Store window info
     windows[windowId] = {
       element: windowEl,


### PR DESCRIPTION
## Sprint8: window UIHelpers 新增採用

### 變更摘要
當視窗建立時未提供 content（空字串），在 window-content 容器中預設顯示 UIHelpers.showLoading。

### old → new 程式碼片段

```diff
  desktopArea.appendChild(windowEl);
+
+ // [Sprint8] UIHelpers: 當 content 為空時，預設顯示載入狀態
+   const contentArea = windowEl.querySelector('.window-content');
+   if (contentArea) UIHelpers.showLoading(contentArea, { text: '載入中…' });
+ }
```
