### PR TITLE
perf: avoid bfcache prevention by refactoring unload handlers

### DIFF
--- a/frontend/public.html
+++ b/frontend/public.html
@@ -24,9 +24,19 @@
         }
         return '';
       })();
-      // 動態載入 favicon 和 CSS
-      document.write('<link rel="icon" type="image/svg+xml" href="' + window.PUBLIC_BASE + '/assets/images/logo.svg">');
-      document.write('<link rel="stylesheet" href="' + window.PUBLIC_BASE + '/css/public.css">');
+      // 動態載入 favicon 和 CSS（使用 DOM API 以避免 document.write 阻止 bfcache）
+      (function() {
+        var favicon = document.createElement('link');
+        favicon.rel = 'icon';
+        favicon.type = 'image/svg+xml';
+        favicon.href = window.PUBLIC_BASE + '/assets/images/logo.svg';
+        document.head.appendChild(favicon);
+
+        var css = document.createElement('link');
+        css.rel = 'stylesheet';
+        css.href = window.PUBLIC_BASE + '/css/public.css';
+        document.head.appendChild(css);
+      })();
     </script>
     <!-- Markdown 渲染 -->
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
@@ -132,6 +142,13 @@
         </div>
     </div>
 
-    <script>document.write('<script src="' + window.PUBLIC_BASE + '/js/public.js"><\/script>');</script>
+    <script>
+      // 動態載入 public.js（使用 DOM API 以避免 document.write 阻止 bfcache）
+      (function() {
+        var s = document.createElement('script');
+        s.src = window.PUBLIC_BASE + '/js/public.js';
+        document.body.appendChild(s);
+      })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## 摘要

將 `frontend/public.html` 中的 `document.write()` 呼叫改為 DOM API（`createElement` + `appendChild`），以移除已知的 BFCache 阻止因素。

## 問題

Lighthouse 報告指出 **"Page prevented back/forward cache restoration"**。`document.write()` 是瀏覽器 BFCache 的已知阻止因素（documented blocker），會導致使用者按下瀏覽器返回鍵時無法從 bfcache 恢復頁面，必須重新載入。

## 修改內容

| 位置 | 修改前 | 修改後 |
|------|--------|--------|
| L28-29 | `document.write('<link ...>')` 載入 favicon/CSS | `document.createElement('link')` + `document.head.appendChild()` |
| L135 | `document.write('<script ...>')` 載入 public.js | `document.createElement('script')` + `document.body.appendChild()` |

## 驗證方式

1. 在 Chrome DevTools → Application → Back/forward cache 面板測試
2. 瀏覽 `/public.html` 頁面 → 導航到其他頁面 → 按返回鍵
3. 確認頁面從 bfcache 恢復（而非重新載入）
4. 確認公開分享頁面功能正常（favicon、CSS、JS 均正確載入）

## 備註

- Lighthouse 另外報告的 `Cache-Control: no-store` 問題屬於後端 HTTP header 設定，本次不修改
- 最小變更原則：僅修改 1 個檔案，無新增套件