### PR TITLE
uiux(fix): suppress console errors on load

### DIFF
--- a/frontend/js/icons.js
+++ b/frontend/js/icons.js
@@ -192,3 +192,7 @@ function getIcon(name, className = '') {
   }
   return svg;
 }
+
+// 將 getIcon 掛載至 window，確保 Vite/Rollup 不會 tree-shake，
+// 且 src/main.js 在 bundle 頂層呼叫時可正確存取。
+window.getIcon = getIcon;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -15,10 +15,11 @@ import './js/entry-compat.js';
 
 // ─── 初始化 Header Icons ───
 // 原本位於 index.html 的 inline <script>
-document.getElementById('iconClock').innerHTML = getIcon('clock-outline');
-document.getElementById('iconMessages').innerHTML = getIcon('bell-outline');
-document.getElementById('iconUser').innerHTML = getIcon('account-circle');
-document.getElementById('iconLogout').innerHTML = getIcon('logout');
+// 使用 window.getIcon 確保在 Vite bundle 中可正確存取
+document.getElementById('iconClock').innerHTML = window.getIcon('clock-outline');
+document.getElementById('iconMessages').innerHTML = window.getIcon('bell-outline');
+document.getElementById('iconUser').innerHTML = window.getIcon('account-circle');
+document.getElementById('iconLogout').innerHTML = window.getIcon('logout');
 
 // ─── DOMContentLoaded 初始化 ───
 // 原本位於 index.html 的 inline <script>


### PR DESCRIPTION
## 修正 Lighthouse「Browser errors were logged to the console」

### 問題
Lighthouse `errors-in-console` 審計失敗（score=0），頁面載入時拋出：
```
ReferenceError: getIcon is not defined
```

### 原因
`js/icons.js` 中的 `getIcon` 函數是頂層 function declaration，Vite/Rollup 在打包時將其 tree-shake 移除（因未掛載至 `window` 或 export），但 `src/main.js` 在 bundle 頂層仍有呼叫 `getIcon()`，導致 ReferenceError。

### 修正（最小變更）
1. **`frontend/js/icons.js`**：新增 `window.getIcon = getIcon;` 掛載至全域，防止 tree-shake
2. **`frontend/src/main.js`**：將 `getIcon()` 改為 `window.getIcon()`，明確存取全域函數

### 驗證
- `node --check` 語法檢查通過
- Vite rebuild 成功，新 bundle 中已包含 Icons SVG 資料與 `window.getIcon` 賦值