### PR TITLE
perf: lazy-load images and list heavy assets

### DIFF
--- a/frontend/js/agent-settings.js
+++ b/frontend/js/agent-settings.js
@@ -1392,7 +1392,7 @@ const AgentSettingsApp = (function() {
               if (owner.handle) {
                 const avatarUrl = (owner.image || '').startsWith('http') ? owner.image : null;
                 const avatarHtml = avatarUrl
-                  ? `<img class="skill-hub-avatar-sm" src="${escapeHtml(avatarUrl)}" alt="${escapeHtml(owner.displayName || owner.handle)}">`
+                  ? `<img class="skill-hub-avatar-sm" src="${escapeHtml(avatarUrl)}" alt="${escapeHtml(owner.displayName || owner.handle)}" loading="lazy">`
                   : '';
                 addField('作者', `${avatarHtml}${escapeHtml(owner.displayName || owner.handle)}`, true);
               }

--- a/frontend/js/file-manager.js
+++ b/frontend/js/file-manager.js
@@ -1323,7 +1323,7 @@ const FileManagerModule = (function() {
     } else if (FileUtils.isImageFile(file.name)) {
       previewMainHTML = `
         <div class="fm-preview-image">
-          <img id="fmPreviewImage" alt="${file.name}" style="display: none;">
+          <img id="fmPreviewImage" alt="${file.name}" style="display: none;" loading="lazy">
         </div>
       `;
     } else if (FileUtils.isTextFile(file.name)) {
@@ -1429,7 +1429,7 @@ const FileManagerModule = (function() {
     if (FileUtils.isImageFile(file.name)) {
       previewMainHTML = `
         <div class="fm-mobile-preview-image">
-          <img id="fmMobilePreviewImage" alt="${file.name}" style="display: none;">
+          <img id="fmMobilePreviewImage" alt="${file.name}" style="display: none;" loading="lazy">
         </div>
       `;
     } else if (FileUtils.isTextFile(file.name)) {

--- a/frontend/js/linebot.js
+++ b/frontend/js/linebot.js
@@ -211,7 +211,7 @@ const LineBotApp = (function () {
                         <div class="linebot-binding-label">已綁定 ${platformName} 帳號</div>
                         <div class="linebot-binding-detail">
                             ${platformStatus.picture_url
-                                ? `<img class="linebot-binding-avatar" src="${platformStatus.picture_url}" alt="">`
+                                ? `<img class="linebot-binding-avatar" src="${platformStatus.picture_url}" alt="" loading="lazy">`
                                 : ''
                             }
                             <span>${platformStatus.display_name || `${platformName} 用戶`}</span>
@@ -476,7 +476,7 @@ const LineBotApp = (function () {
                  data-id="${group.id}">
                 <div class="linebot-group-avatar">
                     ${group.picture_url
-                        ? `<img src="${group.picture_url}" alt="${group.name || '群組'}">`
+                        ? `<img src="${group.picture_url}" alt="${group.name || '群組'}" loading="lazy">`
                         : '👥'
                     }
                 </div>
@@ -549,7 +549,7 @@ const LineBotApp = (function () {
             <div class="linebot-detail-header">
                 <div class="linebot-detail-avatar">
                     ${group.picture_url
-                        ? `<img src="${group.picture_url}" alt="${group.name || '群組'}">`
+                        ? `<img src="${group.picture_url}" alt="${group.name || '群組'}" loading="lazy">`
                         : '👥'
                     }
                 </div>
@@ -639,7 +639,7 @@ const LineBotApp = (function () {
             <div class="linebot-message ${msg.is_from_bot ? 'from-bot' : ''}">
                 <div class="linebot-message-avatar">
                     ${msg.user_picture_url
-                        ? `<img src="${msg.user_picture_url}" alt="">`
+                        ? `<img src="${msg.user_picture_url}" alt="" loading="lazy">`
                         : (msg.is_from_bot ? '🤖' : '👤')
                     }
                 </div>
@@ -680,7 +680,7 @@ const LineBotApp = (function () {
             <div class="linebot-user-card" data-id="${user.id}">
                 <div class="linebot-user-avatar">
                     ${user.picture_url
-                        ? `<img src="${user.picture_url}" alt="${user.display_name || '用戶'}">`
+                        ? `<img src="${user.picture_url}" alt="${user.display_name || '用戶'}" loading="lazy">`
                         : '👤'
                     }
                 </div>
@@ -722,7 +722,7 @@ const LineBotApp = (function () {
             <div class="linebot-message ${msg.is_from_bot ? 'from-bot' : ''}">
                 <div class="linebot-message-avatar">
                     ${msg.user_picture_url
-                        ? `<img src="${msg.user_picture_url}" alt="">`
+                        ? `<img src="${msg.user_picture_url}" alt="" loading="lazy">`
                         : (msg.is_from_bot ? '🤖' : '👤')
                     }
                 </div>

--- a/frontend/js/memory-manager.js
+++ b/frontend/js/memory-manager.js
@@ -212,7 +212,7 @@ const MemoryManagerApp = (function() {
            data-id="${user.id}">
         <div class="mm-sidebar-item-avatar">
           ${user.picture_url
-            ? `<img src="${escapeHtml(user.picture_url)}" alt="">`
+            ? `<img src="${escapeHtml(user.picture_url)}" alt="" loading="lazy">`
             : icon('account')}
         </div>
         <div class="mm-sidebar-item-info">

--- a/frontend/public.html
+++ b/frontend/public.html
@@ -138,7 +138,7 @@
         <div class="image-modal-backdrop"></div>
         <div class="image-modal-content">
             <button class="image-modal-close">&times;</button>
-            <img id="image-modal-img" src="" alt="">
+            <img id="image-modal-img" src="" alt="" loading="lazy">
         </div>
     </div>
 


### PR DESCRIPTION
## 變更說明

### 圖片 Lazy Loading
為所有 below-fold 的 `<img>` 標籤加上 `loading="lazy"` 屬性，改善首次載入效能：

| 檔案 | 修改數量 | 說明 |
|------|---------|------|
| `frontend/public.html` | 1 | 圖片預覽 modal 中的 img |
| `frontend/js/linebot.js` | 7 | 頭像、群組圖片 |
| `frontend/js/memory-manager.js` | 1 | 使用者頭像 |
| `frontend/js/agent-settings.js` | 1 | Skill Hub 作者頭像 |
| `frontend/js/file-manager.js` | 2 | 檔案預覽圖片 |

**跳過（above-fold / Logo）：**
- `index.html` — header logo（首屏可見）
- `login.html` — login logo（首屏可見）
- `public.html` — header logo（首屏可見）

### 重檔案清單與壓縮建議

| 檔案 | 大小 | 建議策略 | 預期收益 |
|------|------|---------|---------|
| `frontend/assets/images/logo.png` | 1.07 MB | 轉 WebP (品質 70) + resize 至 512px | ~95% → ~50 KB |
| `frontend/assets/images/wallpaper.png` | 726 KB | 轉 WebP (品質 70) + resize 至 1920px | ~90% → ~70 KB |

> ⚠️ 本 PR 僅加入 lazy loading 屬性，不執行實際圖片轉換（依限制要求）。壓縮建議供後續處理參考。

### background-image 分析
CSS 中的 `background-image` 均為 inline SVG data URI 或小型 SVG 檔案（< 6 KB），無需 lazy loading 處理。