### PR TITLE
perf: defer non-critical scripts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -110,12 +110,12 @@
     </nav>
   </div>
 
-  <!-- 外部 CDN 相依（非 module，同步載入以確保全域變數可用） -->
-  <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+  <!-- 外部 CDN 相依（defer 以避免阻塞解析；document-order 確保在 module script 前執行） -->
+  <script src="https://cdn.socket.io/4.7.5/socket.io.min.js" defer></script>
   <!-- xterm.js -->
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-web-links@0.11.0/lib/addon-web-links.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-web-links@0.11.0/lib/addon-web-links.min.js" defer></script>
 
   <!-- Vite 建置入口：所有本地 JS 已合併至 src/main.js -->
   <!-- 原始腳本已備份至 _legacy_scripts/ 目錄 -->

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -117,28 +117,29 @@
   <script src="js/login.js"></script>
   -->
   <script>
-    document.getElementById('iconAccount').innerHTML = getIcon('account');
-    document.getElementById('iconLock').innerHTML = getIcon('lock');
-    document.getElementById('iconLogin').innerHTML = getIcon('login');
-    document.getElementById('iconPasswordToggle').innerHTML = getIcon('eye-off');
-    document.getElementById('copyrightYear').textContent = new Date().getFullYear();
+    document.addEventListener('DOMContentLoaded', function () {
+      document.getElementById('iconAccount').innerHTML = getIcon('account');
+      document.getElementById('iconLock').innerHTML = getIcon('lock');
+      document.getElementById('iconLogin').innerHTML = getIcon('login');
+      document.getElementById('iconPasswordToggle').innerHTML = getIcon('eye-off');
+      document.getElementById('copyrightYear').textContent = new Date().getFullYear();
 
-    // 主題切換按鈕
-    const themeToggleBtn = document.getElementById('themeToggle');
-    const iconTheme = document.getElementById('iconTheme');
+      // 主題切換按鈕
+      var themeToggleBtn = document.getElementById('themeToggle');
+      var iconTheme = document.getElementById('iconTheme');
 
-    function updateThemeIcon() {
-      const theme = ThemeManager.getTheme();
-      iconTheme.innerHTML = theme === 'dark' ? getIcon('sun') : getIcon('moon');
-    }
+      function updateThemeIcon() {
+        var theme = ThemeManager.getTheme();
+        iconTheme.innerHTML = theme === 'dark' ? getIcon('sun') : getIcon('moon');
+      }
 
-    updateThemeIcon();
-
-    themeToggleBtn.addEventListener('click', () => {
-      ThemeManager.toggleTheme();
       updateThemeIcon();
-    });
 
+      themeToggleBtn.addEventListener('click', function () {
+        ThemeManager.toggleTheme();
+        updateThemeIcon();
+      });
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## 變更說明

將可安全延後執行的前端 `<script>` 標記為 `defer`，減少 HTML 解析阻塞，提升首屏渲染效能。

---

### 修改一覽

#### `frontend/index.html` — 延遲載入 CDN vendor scripts

socket.io 與 xterm.js 系列腳本加上 `defer`。這些腳本僅由後續 `type="module"` 的 `main.js` 使用，`defer` 保持 document-order 執行順序，在 module script 之前完成初始化，不影響功能。

| 修改前 | 修改後 |
|--------|--------|
| `<script src="...socket.io.min.js"></script>` | `<script src="...socket.io.min.js" defer></script>` |
| `<script src="...xterm.min.js"></script>` | `<script src="...xterm.min.js" defer></script>` |
| `<script src="...addon-fit.min.js"></script>` | `<script src="...addon-fit.min.js" defer></script>` |
| `<script src="...addon-web-links.min.js"></script>` | `<script src="...addon-web-links.min.js" defer></script>` |

#### `frontend/login.html` — 修正 inline script 與 deferred bundle 的執行順序

`login.bundle.js` 已於先前 PR 加上 `defer`，但其後的 inline script 仍立即執行，導致 `getIcon()` / `ThemeManager` 在 bundle 載入前被呼叫（潛在錯誤）。本次將 inline script 包裹於 `DOMContentLoaded`，確保在 deferred bundle 執行後才運行。

| 修改前 | 修改後 |
|--------|--------|
| `<script>` 直接呼叫 `getIcon()` 等函式 | `document.addEventListener('DOMContentLoaded', function () { ... })` 包裹 |

---

### 未修改項目（風險評估後保留）

- `index.html` 中 `marked.min.js`：已在先前 PR 加上 `defer` ✅
- `index.html` 中 `main.js`：`type="module"` 自帶延遲語意 ✅
- `login.html` 中 `login.bundle.js`：已在先前 PR 加上 `defer` ✅

### 檢查

- `node --check frontend/dist/login.bundle.js` → 通過 ✅