### PR TITLE
perf: preload hero & critical css

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,9 +9,101 @@
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="assets/images/logo.svg">
 
-  <!-- [Perf] Preload 關鍵 CSS 與字型，加速首屏渲染 -->
+  <!-- [Perf] Preload 關鍵 CSS、字型與 LCP hero（logo），加速首屏渲染 -->
   <link rel="preload" href="dist/index.bundle.css" as="style">
   <link rel="preload" href="fonts/JetBrainsMonoNerdFont-Regular.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="assets/images/logo-cyan-static.svg" as="image" type="image/svg+xml">
+
+  <!-- [Perf] Critical CSS — 內聯首屏渲染所需最小樣式，避免 FOUC 並加速 LCP -->
+  <style>
+    /* === Critical CSS: 首屏 header + desktop 骨架 === */
+    :root {
+      --color-primary: #0891b2;
+      --color-background: #1a1a1a;
+      --text-primary: #f0f0f0;
+      --text-secondary: #a0a0a0;
+      --bg-glass: rgba(26, 26, 26, 0.95);
+      --interactive-border: rgba(255, 255, 255, 0.08);
+      --interactive-hover: rgba(255, 255, 255, 0.08);
+      --border-light: rgba(255, 255, 255, 0.1);
+      --font-primary: -apple-system, BlinkMacSystemFont, 'Ubuntu', 'Segoe UI', 'Microsoft JhengHei', 'Noto Sans CJK TC', sans-serif;
+      --font-size-sm: 0.875rem;
+      --header-height: 40px;
+      --spacing-xs: 4px;
+      --spacing-sm: 8px;
+      --spacing-md: 16px;
+      --spacing-lg: 24px;
+      --radius-sm: 4px;
+      --radius-md: 8px;
+      --transition-fast: 150ms ease;
+      --color-primary-rgb: 8, 145, 178;
+      --accent-border: rgba(8, 145, 178, 0.3);
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    html { font-size: 16px; -webkit-font-smoothing: antialiased; }
+    body {
+      font-family: var(--font-primary);
+      color: var(--text-primary);
+      background-color: var(--color-background);
+      min-height: 100vh;
+      overflow: hidden;
+      margin: 0;
+      padding: 0;
+    }
+    .desktop-container {
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+      width: 100%;
+      overflow: hidden;
+      background-color: var(--color-background);
+      position: relative;
+    }
+    .header-bar {
+      position: fixed;
+      top: 0; left: 0; right: 0;
+      height: var(--header-height);
+      background-color: var(--bg-glass);
+      border-bottom: 1px solid var(--interactive-border);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 var(--spacing-md);
+      z-index: 100;
+      backdrop-filter: blur(8px);
+      user-select: none;
+    }
+    .header-left {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-sm);
+    }
+    .header-logo {
+      width: 24px;
+      height: 24px;
+      border-radius: var(--radius-sm);
+    }
+    .header-title {
+      font-size: var(--font-size-sm);
+      font-weight: 600;
+      color: var(--color-primary);
+      text-shadow: 0 0 10px rgba(var(--color-primary-rgb), 0.5), 0 0 20px var(--accent-border);
+    }
+    .header-title-os {
+      color: var(--text-primary);
+      text-shadow: 0 0 10px rgba(255,255,255,0.5), 0 0 20px rgba(255,255,255,0.3);
+    }
+    .header-center, .header-right {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-md);
+    }
+    .desktop-area {
+      flex: 1;
+      padding: var(--spacing-lg);
+      padding-top: calc(var(--header-height) + var(--spacing-lg));
+    }
+  </style>
 
   <!-- [P3 Performance] 合併壓縮後的 CSS bundle（由 npm run build 產生） -->
   <link rel="stylesheet" href="dist/index.bundle.css">


### PR DESCRIPTION
## 變更摘要

### 目標
最佳化 LCP（Largest Contentful Paint）與首屏渲染速度。

### 改動內容
1. **Preload LCP hero image** — 新增 `<link rel="preload" as="image">` 預載 header logo（`logo-cyan-static.svg`），讓瀏覽器儘早發起請求。
2. **內聯 Critical CSS（~2.7KB）** — 將首屏渲染所需的最小樣式內聯至 `<head>`：
   - `:root` 關鍵 CSS 變數（色彩、字型、間距）
   - `html`/`body` 基礎樣式
   - `.desktop-container` 佈局骨架
   - `.header-bar`、`.header-left`、`.header-logo`、`.header-title` 定位與排版
   - `.desktop-area` 基礎 padding

### 預期效果
- 消除首屏 FOUC（Flash of Unstyled Content）
- LCP 預估改善 **100–300ms**（視網路延遲而定）
- 瀏覽器在外部 CSS bundle 載入前即可正確渲染 header 佈局與背景色

### 安全性
- 僅修改 `frontend/index.html`（1 個檔案）
- 不影響 JS 行為、不新增 build 步驟
- Critical CSS 為外部 CSS 的子集，不會造成樣式衝突