### PR TITLE
uiux(Sprint1-T1.1): 移除所有 CSS fallback 硬編碼色值

### DIFF
--- a/frontend/css/agent-settings.css
+++ b/frontend/css/agent-settings.css
@@ -428,7 +428,7 @@
 
 .agent-settings-tab.active {
   color: var(--text-primary);
-  border-bottom-color: var(--color-accent, var(--primary, #6c9fff));
+  border-bottom-color: var(--color-accent);
 }
 
 .agent-settings-tab-content {
@@ -468,7 +468,7 @@
 
 .skill-badge-tool {
   background: rgba(108, 159, 255, 0.15);
-  color: var(--color-accent, #6c9fff);
+  color: var(--color-accent);
 }
 
 .skill-detail {
@@ -552,7 +552,7 @@
 .skill-sub-tab:hover { color: var(--text-primary); }
 .skill-sub-tab.active {
   color: var(--text-primary);
-  border-bottom-color: var(--color-accent, #6c9fff);
+  border-bottom-color: var(--color-accent);
 }
 
 /* Skill 區域按鈕預設樣式（深色主題相容） */
@@ -567,7 +567,7 @@
 }
 .skill-settings .btn-primary {
   background-color: var(--color-primary);
-  color: var(--btn-text-on-primary, #fff);
+  color: var(--btn-text-on-primary);
   border-color: transparent;
 }
 .skill-settings .btn-danger {
@@ -664,7 +664,7 @@
 }
 
 .skill-edit-modal {
-  background: var(--bg-secondary, #1e1e1e);
+  background: var(--bg-secondary);
   border: 1px solid var(--border-subtle);
   border-radius: 12px;
   width: 480px;
@@ -743,7 +743,7 @@
   line-height: 1;
 }
 
-.skill-chip-remove:hover { color: var(--color-error, #ff4444); }
+.skill-chip-remove:hover { color: var(--color-error); }
 
 .skill-chip-input {
   font-size: 13px !important;
@@ -1082,7 +1082,7 @@
 .skill-preview-content {
   margin-top: 8px;
   padding: 12px;
-  background: var(--bg-secondary, #f5f5f5);
+  background: var(--bg-secondary);
   border-radius: 6px;
   font-size: 13px;
   line-height: 1.5;
@@ -1093,7 +1093,7 @@
 }
 
 [data-theme="dark"] .skill-preview-content {
-  background: var(--bg-tertiary, #2a2a2a);
+  background: var(--bg-tertiary);
 }
 
 /* Hub 搜尋結果：作者 */

--- a/frontend/css/header.css
+++ b/frontend/css/header.css
@@ -300,7 +300,7 @@
   top: calc(100% + 6px);
   right: 0;
   min-width: 180px;
-  background: var(--bg-elevated, #1e293b);
+  background: var(--bg-elevated);
   border: 1px solid var(--interactive-border, rgba(255,255,255,0.1));
   border-radius: var(--radius-md, 8px);
   padding: var(--spacing-xs, 6px) 0;
@@ -326,7 +326,7 @@
   padding: var(--spacing-sm, 8px) var(--spacing-md, 16px);
   background: none;
   border: none;
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
   font-size: var(--font-size-sm, 14px);
   cursor: pointer;
   transition: all var(--transition-fast, 0.15s);
@@ -335,7 +335,7 @@
 
 .header-user-menu-item:hover {
   background: var(--interactive-hover, rgba(255,255,255,0.06));
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 .header-user-menu-item .icon svg {

--- a/frontend/css/linebot.css
+++ b/frontend/css/linebot.css
@@ -642,7 +642,7 @@
 
 .linebot-file-icon-wrapper.video {
     background: var(--tag-bg-purple, rgba(156, 39, 176, 0.15));
-    color: var(--tag-color-purple, #9c27b0);
+    color: var(--tag-color-purple);
 }
 
 .linebot-file-icon-wrapper.audio {

--- a/frontend/css/login.css
+++ b/frontend/css/login.css
@@ -281,19 +281,19 @@
   display: block;
   min-height: 1.2em;
   font-size: var(--font-size-xs, 12px);
-  color: var(--color-error, #e65050);
+  color: var(--color-error);
   margin-top: 4px;
 }
 .form-validation-hints {
   min-height: 1.2em;
   font-size: var(--font-size-xs, 12px);
-  color: var(--color-error, #e65050);
+  color: var(--color-error);
   text-align: center;
   margin-bottom: var(--spacing-xs, 4px);
 }
 .input--invalid {
-  border-color: var(--color-error, #e65050) !important;
-  box-shadow: 0 0 0 1px var(--color-error, #e65050);
+  border-color: var(--color-error) !important;
+  box-shadow: 0 0 0 1px var(--color-error);
 }
 
 /* ── Submit loading 旋轉動畫 ── */

--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -1225,7 +1225,7 @@ input {
   width: 40px;
   height: 40px;
   border: 3px solid var(--border-medium, rgba(255, 255, 255, 0.15));
-  border-top-color: var(--color-primary, #0891b2);
+  border-top-color: var(--color-primary);
   border-radius: 50%;
   animation: skeleton-spin 0.8s linear infinite;
 }
@@ -1236,7 +1236,7 @@ input {
 
 /* 載入文字 */
 .skeleton-label {
-  color: var(--text-secondary, #a0a0a0);
+  color: var(--text-secondary);
   font-size: 14px;
   letter-spacing: 0.5px;
 }
@@ -1255,7 +1255,7 @@ input {
 
   .skeleton::after {
     animation: none !important;
-    background: var(--bg-tertiary, #e0e0e0) !important;
+    background: var(--bg-tertiary) !important;
   }
 
   .spinner {
@@ -1271,7 +1271,7 @@ input {
 .skeleton {
   position: relative;
   overflow: hidden;
-  background: var(--bg-tertiary, #e0e0e0);
+  background: var(--bg-tertiary);
   border-radius: var(--radius-sm, 6px);
   color: transparent !important;
   pointer-events: none;
@@ -1341,8 +1341,8 @@ input {
   display: inline-block;
   width: 24px;
   height: 24px;
-  border: 3px solid var(--border-color, #ccc);
-  border-top-color: var(--accent-primary, #5b7ff5);
+  border: 3px solid var(--border-color);
+  border-top-color: var(--accent-primary);
   border-radius: 50%;
   animation: spinner-rotate 0.8s linear infinite;
 }
@@ -1368,7 +1368,7 @@ input {
   gap: var(--spacing-sm, 8px);
   padding: var(--spacing-lg, 24px);
   text-align: center;
-  color: var(--text-secondary, #a0a0a0);
+  color: var(--text-secondary);
   font-size: var(--font-size-sm, 13px);
   min-height: 120px;
   width: 100%;
@@ -1434,7 +1434,7 @@ input {
 
 /* ── Empty 狀態 ── */
 .ui-state--empty {
-  color: var(--text-muted, #888888);
+  color: var(--text-muted);
 }
 
 .ui-state--empty .ui-state-text {
@@ -1445,17 +1445,17 @@ input {
 /* ── Error 狀態 ── */
 .ui-state--error .ui-state-icon svg {
   opacity: 0.6;
-  color: var(--color-error, #dc2626);
+  color: var(--color-error);
 }
 
 .ui-state--error .ui-state-text {
-  color: var(--color-error, #dc2626);
+  color: var(--color-error);
   opacity: 0.85;
 }
 
 .ui-state--error .ui-state-detail {
   font-size: var(--font-size-xs, 12px);
-  color: var(--text-muted, #888888);
+  color: var(--text-muted);
   max-width: 320px;
   word-break: break-word;
 }
@@ -1467,7 +1467,7 @@ input {
   border: 1px solid var(--border-light, rgba(255, 255, 255, 0.1));
   border-radius: var(--radius-sm, 6px);
   background: var(--bg-surface, rgba(0, 0, 0, 0.1));
-  color: var(--text-secondary, #a0a0a0);
+  color: var(--text-secondary);
   font-size: var(--font-size-xs, 12px);
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease;
@@ -1476,7 +1476,7 @@ input {
 .ui-state-retry:hover {
   background: var(--hover-bg, rgba(255, 255, 255, 0.1));
   border-color: var(--border-medium, rgba(255, 255, 255, 0.15));
-  color: var(--text-primary, #f0f0f0);
+  color: var(--text-primary);
 }
 
 /* ── Reduced Motion ── */

--- a/frontend/css/notification.css
+++ b/frontend/css/notification.css
@@ -15,7 +15,7 @@
 }
 
 .notification-toast {
-  background: var(--window-bg, #252525);
+  background: var(--window-bg);
   border: 1px solid var(--border-light, rgba(255, 255, 255, 0.1));
   border-radius: var(--radius-md, 8px);
   padding: 12px 16px;
@@ -46,7 +46,7 @@
   width: 24px;
   height: 24px;
   flex-shrink: 0;
-  color: var(--color-primary, #0891b2);
+  color: var(--color-primary);
 }
 
 .notification-content {
@@ -55,13 +55,13 @@
 
 .notification-title {
   font-weight: 600;
-  color: var(--text-primary, #f0f0f0);
+  color: var(--text-primary);
   margin-bottom: 2px;
 }
 
 .notification-message {
   font-size: 13px;
-  color: var(--text-secondary, #a0a0a0);
+  color: var(--text-secondary);
 }
 
 .notification-close {
@@ -73,7 +73,7 @@
   border: none;
   border-radius: var(--radius-sm, 4px);
   cursor: pointer;
-  color: var(--text-secondary, #a0a0a0);
+  color: var(--text-secondary);
   opacity: 0.6;
   transition: opacity var(--transition-normal);
   flex-shrink: 0;

--- a/frontend/css/onboarding.css
+++ b/frontend/css/onboarding.css
@@ -54,11 +54,11 @@
   z-index: 10002;
   width: 340px;
   max-width: calc(100vw - 32px);
-  background: var(--bg-elevated, #1e293b);
+  background: var(--bg-elevated);
   border: 1px solid var(--interactive-border, rgba(255,255,255,0.1));
   border-radius: var(--radius-lg, 12px);
   padding: var(--spacing-lg, 20px);
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4),
               0 0 1px rgba(255, 255, 255, 0.1);
   opacity: 0;
@@ -78,7 +78,7 @@
   position: absolute;
   width: 12px;
   height: 12px;
-  background: var(--bg-elevated, #1e293b);
+  background: var(--bg-elevated);
   border-top: 1px solid var(--interactive-border, rgba(255,255,255,0.1));
   border-left: 1px solid var(--interactive-border, rgba(255,255,255,0.1));
   transform: rotate(45deg);
@@ -106,7 +106,7 @@
   gap: var(--spacing-xs, 6px);
   margin-bottom: var(--spacing-sm, 8px);
   font-size: 12px;
-  color: var(--color-primary, #21d4fd);
+  color: var(--color-primary);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -116,7 +116,7 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--color-primary, #21d4fd);
+  background: var(--color-primary);
   display: inline-block;
 }
 
@@ -124,13 +124,13 @@
   font-size: var(--font-size-lg, 18px);
   font-weight: 700;
   margin-bottom: var(--spacing-sm, 8px);
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
   line-height: 1.3;
 }
 
 .onboarding-tooltip-body {
   font-size: var(--font-size-sm, 14px);
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
   line-height: 1.6;
   margin-bottom: var(--spacing-md, 16px);
 }
@@ -151,13 +151,13 @@
 }
 
 .onboarding-dot.active {
-  background: var(--color-primary, #21d4fd);
+  background: var(--color-primary);
   width: 20px;
   border-radius: 4px;
 }
 
 .onboarding-dot.completed {
-  background: var(--color-primary, #21d4fd);
+  background: var(--color-primary);
   opacity: 0.5;
 }
 
@@ -181,12 +181,12 @@
 }
 
 .onboarding-btn:focus-visible {
-  outline: 2px solid var(--color-primary, #21d4fd);
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
 
 .onboarding-btn-primary {
-  background: var(--color-primary, #21d4fd);
+  background: var(--color-primary);
   color: #0f172a;
 }
 
@@ -197,18 +197,18 @@
 
 .onboarding-btn-ghost {
   background: transparent;
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
   border: 1px solid var(--border-light, rgba(255,255,255,0.12));
 }
 
 .onboarding-btn-ghost:hover {
   background: var(--interactive-hover, rgba(255,255,255,0.06));
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 .onboarding-btn-link {
   background: transparent;
-  color: var(--text-muted, #64748b);
+  color: var(--text-muted);
   font-size: 12px;
   padding: var(--spacing-xs, 6px) var(--spacing-sm, 8px);
   text-decoration: underline;
@@ -216,7 +216,7 @@
 }
 
 .onboarding-btn-link:hover {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 /* ── 無障礙：Reduced Motion ── */

--- a/frontend/css/taskbar.css
+++ b/frontend/css/taskbar.css
@@ -65,7 +65,7 @@
 }
 
 .taskbar-icon .icon {
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   transition: color var(--transition-fast, 0.15s) ease;
 }
 
@@ -75,7 +75,7 @@
 }
 
 .taskbar-icon:hover .icon {
-  color: var(--color-primary, #00d4aa);
+  color: var(--color-primary);
 }
 
 /* ── Tooltip ── */
@@ -89,7 +89,7 @@
   background-color: var(--bg-tooltip, rgba(0,0,0,0.85));
   border-radius: var(--radius-sm, 6px);
   font-size: var(--font-size-xs, 12px);
-  color: var(--tooltip-text, #fff);
+  color: var(--tooltip-text);
   white-space: nowrap;
   opacity: 0;
   visibility: hidden;
@@ -125,7 +125,7 @@
 .taskbar-icon .indicator-dot {
   width: 4px;
   height: 4px;
-  background-color: var(--color-accent, #00d4aa);
+  background-color: var(--color-accent);
   border-radius: 50%;
 }
 
@@ -156,7 +156,7 @@
   border-radius: var(--radius-sm, 6px);
   cursor: pointer;
   font-size: var(--font-size-sm, 13px);
-  color: var(--text-primary, #eee);
+  color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -168,7 +168,7 @@
 }
 
 .taskbar-window-menu-item.minimized {
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   font-style: italic;
 }
 


### PR DESCRIPTION
## 變更說明
移除 8 個 CSS 檔案中共 55 個 `var(--xxx, #hex)` fallback 值。

依專案 CSS 規範，所有色值應由 CSS 變數控制，不使用 fallback 硬編碼色值。

### 影響檔案
| 檔案 | 移除數量 |
|------|---------|
| main.css | 13 |
| onboarding.css | 15 |
| agent-settings.css | 8 |
| taskbar.css | 6 |
| notification.css | 5 |
| login.css | 4 |
| header.css | 3 |
| linebot.css | 1 |

### 驗證
- [x] `npm run build` 通過
- [ ] Lighthouse 報告待產生