### PR TITLE
Sprint2 T2.2: 通知關閉按鈕放大至 WCAG AA 觸控目標

### DIFF
--- a/frontend/css/notification.css
+++ b/frontend/css/notification.css
@@ -65,13 +65,14 @@
 }
 
 .notification-close {
-  width: 32px;
-  height: 32px;
-  min-width: 32px;
-  min-height: 32px;
+  width: 36px;
+  height: 36px;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 4px;
   background: none;
   border: none;
-  border-radius: var(--radius-sm, 4px);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   color: var(--text-secondary);
   opacity: 0.6;


### PR DESCRIPTION
## 變更說明
- 通知關閉按鈕從 32×32px 放大，min-width/min-height 設為 44px 以符合 WCAG AA 觸控目標最低要求
- 移除 border-radius 的 CSS fallback 硬編碼值
- 已有 aria 屬性（aria-live, role=alert, aria-label）無需額外修改

## 測試
- 確認通知彈出時關閉按鈕可正常點擊
- 確認行動裝置上觸控區域充足