### PR TITLE
feat(a11y): T3.2 動畫降頻與 data-animations 開關

### DIFF
--- a/frontend/css/header.css
+++ b/frontend/css/header.css
@@ -294,7 +294,7 @@
 
 /* data-animations="off" 支援 */
 html[data-animations="off"] .header-logo,
-html[data-animations="off"] :root[data-theme="light"] .header-logo {
+html[data-animations="off"][data-theme="light"] .header-logo {
   animation: none;
 }
 

--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -1500,9 +1500,10 @@ html[data-animations="off"] *::after {
   animation-duration: 0.01ms !important;
   animation-iteration-count: 1 !important;
   transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
 }
 
-/* 保留必要的 loading spinner */
+/* 停用 loading spinner 動畫 */
 html[data-animations="off"] .ui-state--loading .ui-state-icon svg,
 html[data-animations="off"] .login-btn .spin {
   animation: none !important;

--- a/frontend/js/matrix-rain.js
+++ b/frontend/js/matrix-rain.js
@@ -129,7 +129,7 @@ const MatrixRain = (function() {
       return;
     }
 
-    // 監聯設定變化（使用者可能在執行期間切換）
+    // 監聽設定變化（使用者可能在執行期間切換）
     window.matchMedia('(prefers-reduced-motion: reduce)')
       .addEventListener('change', (e) => {
         if (e.matches) {


### PR DESCRIPTION
## Sprint 3 — T3.2 降低手機動畫負擔

### 變更
- `main.css`: 新增 `html[data-animations="off"]` 全域 CSS 動畫停用規則
- `header.css`: logo 呼吸動畫補齊 `prefers-reduced-motion` + `data-animations` 支援
- `matrix-rain.js`: 啟動時檢查 `data-animations` 屬性，並用 MutationObserver 即時監聽

### 使用方式
```js
// 手動停用所有裝飾性動畫
document.documentElement.setAttribute('data-animations', 'off');
// 恢復
document.documentElement.removeAttribute('data-animations');
```

### 測試
- `npm run build` 通過