### PR TITLE
feat: SkillHub integration (backend only)

### DIFF
--- a/backend/src/ching_tech_os/api/skills.py
+++ b/backend/src/ching_tech_os/api/skills.py
@@ -43,7 +43,7 @@ def _hub_source_tag() -> str:
     return "skillhub" if _use_skillhub() else "clawhub"
 
 
-def _hub_error_class():
+def _hub_error_class() -> type[ClawHubError | SkillHubError]:
     return SkillHubError if _use_skillhub() else ClawHubError
 
 

--- a/backend/src/ching_tech_os/services/clawhub_client.py
+++ b/backend/src/ching_tech_os/services/clawhub_client.py
@@ -11,7 +11,6 @@ import re
 import shutil
 import tempfile
 import zipfile
-from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import Request
@@ -271,46 +270,15 @@ class ClawHubClient:
         version: str,
         owner: str | None = None,
     ) -> None:
-        """寫入 _meta.json 到 skill 目錄
-
-        Args:
-            dest: skill 目錄
-            slug: skill slug
-            version: 版本號
-            owner: 擁有者 handle
-        """
-        meta = {
-            "slug": slug,
-            "version": version,
-            "source": "clawhub",
-            "installed_at": datetime.now(timezone.utc).isoformat(),
-            "owner": owner or "",
-        }
-        meta_path = dest / "_meta.json"
-        meta_path.write_text(
-            json.dumps(meta, ensure_ascii=False, indent=2),
-            encoding="utf-8",
-        )
-        logger.info(f"寫入 _meta.json: {meta_path}")
+        """寫入 _meta.json 到 skill 目錄（委派給共用函式）"""
+        from .hub_meta import write_meta
+        write_meta(dest, slug, version, source="clawhub", owner=owner)
 
     @staticmethod
     def read_meta(skill_dir: Path) -> dict | None:
-        """讀取 skill 目錄中的 _meta.json
-
-        Args:
-            skill_dir: skill 目錄
-
-        Returns:
-            _meta.json 內容字典，或 None（檔案不存在）
-        """
-        meta_path = skill_dir / "_meta.json"
-        if not meta_path.exists():
-            return None
-        try:
-            return json.loads(meta_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as e:
-            logger.warning(f"讀取 _meta.json 失敗: {meta_path}: {e}")
-            return None
+        """讀取 skill 目錄中的 _meta.json（委派給共用函式）"""
+        from .hub_meta import read_meta
+        return read_meta(skill_dir)
 
 
 def get_clawhub_client_di(request: Request) -> ClawHubClient:

--- a/backend/src/ching_tech_os/services/hub_meta.py
+++ b/backend/src/ching_tech_os/services/hub_meta.py
@@ -1,0 +1,60 @@
+"""共用的 Hub meta 工具函式（ClawHub / SkillHub 共用）"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def write_meta(
+    dest: Path,
+    slug: str,
+    version: str,
+    source: str,
+    owner: str | None = None,
+) -> None:
+    """寫入 _meta.json 到 skill 目錄
+
+    Args:
+        dest: skill 目錄
+        slug: skill slug
+        version: 版本號
+        source: 來源標籤（"clawhub" 或 "skillhub"）
+        owner: 擁有者 handle
+    """
+    meta = {
+        "slug": slug,
+        "version": version,
+        "source": source,
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+        "owner": owner or "",
+    }
+    meta_path = dest / "_meta.json"
+    meta_path.write_text(
+        json.dumps(meta, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    logger.info(f"寫入 _meta.json: {meta_path}")
+
+
+def read_meta(skill_dir: Path) -> dict | None:
+    """讀取 skill 目錄中的 _meta.json
+
+    Args:
+        skill_dir: skill 目錄
+
+    Returns:
+        _meta.json 內容字典，或 None（檔案不存在）
+    """
+    meta_path = skill_dir / "_meta.json"
+    if not meta_path.exists():
+        return None
+    try:
+        return json.loads(meta_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning(f"讀取 _meta.json 失敗: {meta_path}: {e}")
+        return None


### PR DESCRIPTION
## SkillHub 後端整合

從 PR #90 cherry-pick 純後端改動，排除前端變更。

### 新增
- `services/skillhub_client.py` (399 行) — SkillHub index client
  - Feature flag: `SKILLHUB_ENABLED` env var
  - 搜尋、安裝、預覽 from SkillHub registry
  - ZIP 驗證（大小/檔案數限制）、SHA256 校驗
  - 關閉時 fallback 到 ClawHub

### 修改
- `api/skills.py` — 新增 SkillHub API routes（search/install/inspect）
- `main.py` — 掛載 SkillHub routes

### 雙來源支援
```
CTOS SkillManager
├── SkillHub（自建 registry，公司內部 skill）
├── ClawHub（公開社群 skill）
└── 本地（手動安裝的 skill）
```

### 注意
- 僅後端，不含前端 UI 變更
- 預設關閉（需設定 `SKILLHUB_ENABLED=true`）
- PR #90 可在此合併後關閉