### PR TITLE
fix(ai-router): use database user_id instead of hash workaround

### DIFF
--- a/backend/src/ching_tech_os/api/ai_router.py
+++ b/backend/src/ching_tech_os/api/ai_router.py
@@ -19,21 +19,20 @@ router = APIRouter(prefix="/api/ai", tags=["AI"])
 async def get_current_user_id(request: Request) -> int:
     """從 session 取得當前使用者 ID
 
-    TODO: 實作完整的使用者認證後，這裡應該從 DB 查詢 user_id
-    目前暫時使用 session token 的 hash 作為 user_id
+    需從 session 中的資料庫 user_id 取得，若驗證失敗則回傳 401。
     """
     token = request.cookies.get("session_token")
     if not token:
-        # 開發模式：允許未登入使用，使用預設 user_id
-        return 1
+        raise HTTPException(status_code=401, detail="未登入或 session 已過期")
 
     session = await session_manager.get_session(token)
     if not session:
         raise HTTPException(status_code=401, detail="未登入或 session 已過期")
 
-    # TODO: 從 DB 查詢 user_id
-    # 暫時使用 username 的 hash 作為 user_id
-    return hash(session.username) % 1000000
+    if session.user_id is None:
+        raise HTTPException(status_code=401, detail="未登入或 session 已過期")
+
+    return session.user_id
 
 
 @router.get("/chats", response_model=list[ChatResponse])

--- a/backend/tests/test_ai_chat_and_routes.py
+++ b/backend/tests/test_ai_chat_and_routes.py
@@ -255,17 +255,27 @@ async def test_ai_router_routes_and_auth_helper(monkeypatch: pytest.MonkeyPatch)
     # get_current_user_id: 無 cookie
     scope = {"type": "http", "headers": [], "query_string": b""}
     req = Request(scope)
-    assert await ai_router.get_current_user_id(req) == 1
+    with pytest.raises(ai_router.HTTPException) as no_cookie_exc:
+        await ai_router.get_current_user_id(req)
+    assert no_cookie_exc.value.status_code == 401
 
-    # 有 cookie 且 session 有效
     req2 = Request({"type": "http", "headers": [(b"cookie", b"session_token=abc")], "query_string": b""})
-    monkeypatch.setattr(ai_router.session_manager, "get_session", AsyncMock(return_value=SimpleNamespace(username="u1")))
-    assert isinstance(await ai_router.get_current_user_id(req2), int)
 
-    # session 失效
+    # session 過期 / 無效
     monkeypatch.setattr(ai_router.session_manager, "get_session", AsyncMock(return_value=None))
-    with pytest.raises(Exception):
+    with pytest.raises(ai_router.HTTPException) as expired_exc:
         await ai_router.get_current_user_id(req2)
+    assert expired_exc.value.status_code == 401
+
+    # session 缺少 user_id
+    monkeypatch.setattr(ai_router.session_manager, "get_session", AsyncMock(return_value=SimpleNamespace(username="u1", user_id=None)))
+    with pytest.raises(ai_router.HTTPException) as missing_user_id_exc:
+        await ai_router.get_current_user_id(req2)
+    assert missing_user_id_exc.value.status_code == 401
+
+    # 正常 session 回傳資料庫 user_id
+    monkeypatch.setattr(ai_router.session_manager, "get_session", AsyncMock(return_value=SimpleNamespace(username="u1", user_id=42)))
+    assert await ai_router.get_current_user_id(req2) == 42
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 修復內容

移除 AI Router 的臨時認證邏輯，改用資料庫真實 user_id。

## 變更項目

- ✅ 移除 `hash(session.username) % 1000000` workaround（避免 user_id 碰撞）
- ✅ 移除匿名模式 `user_id=1` fallback
- ✅ 所有 AI Router endpoints 都要求有效的 `session.user_id`
- ✅ 未登入/session 過期/缺少 user_id → 統一回傳 401
- ✅ 新增測試覆蓋 4 種情境：無 cookie、session 過期、缺少 user_id、正常登入

## 測試結果

- ✅ `pytest tests/test_ai_chat_and_routes.py` - 通過
- ✅ `pytest tests/` - 全部通過

## 安全性提升

- 對話資料可穩定綁定到正確使用者
- 避免 user_id 碰撞風險
- 強制要求登入（符合生產環境）

Closes #115