### PR TITLE
test: align 4 tests with main production code (fix CI)

### DIFF
--- a/backend/tests/test_api_telegram_router.py
+++ b/backend/tests/test_api_telegram_router.py
@@ -28,16 +28,17 @@ def test_get_adapter_paths(monkeypatch: pytest.MonkeyPatch) -> None:
     created = []
 
     class _FakeAdapter:
-        def __init__(self, token: str) -> None:
-            created.append(token)
+        def __init__(self, token: str, base_url: str | None = None) -> None:
+            created.append((token, base_url))
             self.bot = SimpleNamespace()
 
     monkeypatch.setattr(telegram_router.settings, "telegram_bot_token", "bot-token")
+    monkeypatch.setattr(telegram_router.settings, "telegram_local_api_url", "")
     monkeypatch.setattr(telegram_router, "TelegramBotAdapter", _FakeAdapter)
     first = telegram_router._get_adapter()
     second = telegram_router._get_adapter()
     assert first is second
-    assert created == ["bot-token"]
+    assert created == [("bot-token", None)]
 
 
 def test_telegram_webhook_paths(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_bot_line_file_handler.py
+++ b/backend/tests/test_bot_line_file_handler.py
@@ -93,7 +93,8 @@ async def test_save_record_download_and_guess(monkeypatch: pytest.MonkeyPatch) -
     assert file_handler.guess_mime_type(b"\x89PNG\r\n\x1a\nabc") == "image/png"
     assert file_handler.guess_mime_type(b"GIF89aabc") == "image/gif"
     assert file_handler.guess_mime_type(b"RIFFxxxxWEBP") == "image/webp"
-    assert file_handler.guess_mime_type(b"xxxxftypisom") == "audio/m4a"
+    assert file_handler.guess_mime_type(b"xxxxftypisom") == "video/mp4"
+    assert file_handler.guess_mime_type(b"xxxxftypM4A ") == "audio/m4a"
     assert file_handler.guess_mime_type(b"unknown") == "application/octet-stream"
 
 

--- a/backend/tests/test_bot_telegram_modules.py
+++ b/backend/tests/test_bot_telegram_modules.py
@@ -151,6 +151,7 @@ async def test_telegram_polling_paths(monkeypatch: pytest.MonkeyPatch) -> None:
     # 有 token，跑一輪更新後停止
     monkeypatch.setattr(polling.settings, "telegram_bot_token", "bot-token")
     monkeypatch.setattr(polling.settings, "telegram_admin_chat_id", "123")
+    monkeypatch.setattr(polling.settings, "telegram_local_api_url", "")
 
     fake_adapter = SimpleNamespace(
         ensure_bot_info=AsyncMock(),
@@ -159,11 +160,11 @@ async def test_telegram_polling_paths(monkeypatch: pytest.MonkeyPatch) -> None:
             send_message=AsyncMock(return_value=None),
         ),
     )
-    monkeypatch.setattr(polling, "TelegramBotAdapter", lambda token: fake_adapter)
+    monkeypatch.setattr(polling, "TelegramBotAdapter", lambda token, base_url=None: fake_adapter)
     monkeypatch.setattr(polling, "_notify_admin_startup", AsyncMock())
 
     class _PollBot:
-        def __init__(self, token=None, request=None) -> None:
+        def __init__(self, token=None, request=None, base_url=None) -> None:
             self.calls = 0
 
         async def delete_webhook(self):

--- a/backend/tests/test_script_runner_security.py
+++ b/backend/tests/test_script_runner_security.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from ching_tech_os.config import settings
 from ching_tech_os.skills import script_runner as script_runner_module
 from ching_tech_os.skills.script_runner import ScriptRunner
 
@@ -59,7 +60,8 @@ def test_build_command_variants(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
     txt_script = tmp_path / "run.txt"
 
     monkeypatch.setattr(script_runner_module.shutil, "which", lambda _cmd: "/usr/bin/uv")
-    assert runner._build_command(py_script) == ["uv", "run", str(py_script)]
+    backend_dir = str(Path(settings.project_root) / "backend")
+    assert runner._build_command(py_script) == ["uv", "run", "--project", backend_dir, str(py_script)]
 
     monkeypatch.setattr(script_runner_module.shutil, "which", lambda _cmd: None)
     assert runner._build_command(py_script) == ["python3", str(py_script)]


### PR DESCRIPTION
## 摘要

main 上 4 個 commit 改了 production code 但 test 沒跟著改，導致 Backend Test & Coverage CI 從 PR #145 起連續 fail（PR #146 也繼承）。本 PR 一次補齊 4 個 test 對齊現況。

## 4 個失敗 → 修正對應

| 失敗測試 | 對應 production commit | 修正 |
|---|---|---|
| \`test_bot_line_file_handler::test_save_record_download_and_guess\` | \`c2f7cb9\` MP4/M4A ftyp 判斷 | \`ftypisom\` 改期望 \`video/mp4\`；加 \`ftypM4A \` 正向案例 |
| \`test_script_runner_security::test_build_command_variants\` | \`84b623d\` uv run --project | 動態計算 \`backend_dir\` 對齊新命令 |
| \`test_api_telegram_router::test_get_adapter_paths\` | \`cd6a15d\` Telegram Local Bot API | \`_FakeAdapter\` 補 \`base_url=None\`；clamp \`telegram_local_api_url=""\` |
| \`test_bot_telegram_modules::test_telegram_polling_paths\` | 同上 | adapter mock lambda 支援 \`base_url\`；\`_PollBot\` 補 \`base_url\` |

## 本地驗證

\`\`\`
$ uv run pytest tests/test_bot_line_file_handler.py::test_save_record_download_and_guess \\
    tests/test_script_runner_security.py::test_build_command_variants \\
    tests/test_api_telegram_router.py::test_get_adapter_paths \\
    tests/test_bot_telegram_modules.py::test_telegram_polling_paths -v
============ 4 passed in 2.00s ============

$ uv run pytest -q
============ 1233 passed, 10 skipped in 1m47s ============
\`\`\`

純 test 改動，沒碰 production 一行。

## Test plan

- [x] 4 個目標 test 本地通過
- [x] 全套 1233 passed / 10 skipped / 0 failed
- [x] coverage 自然恢復（4 個 test 不再被中斷收 0 cov）
- [ ] CI 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)