### PR TITLE
fix(linebot): exclude current message when detecting image-edit refs

### DIFF
--- a/backend/src/ching_tech_os/services/image_edit_detection.py
+++ b/backend/src/ching_tech_os/services/image_edit_detection.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 from typing import Protocol
+from uuid import UUID
 
 from .bot_line.file_handler import (
     ensure_temp_image,
@@ -58,6 +59,7 @@ async def _detect_image_edit_references(
     group_id: str | None,
     quoted_message_id: str | None,
     text: str,
+    current_message_uuid: UUID | None = None,
 ) -> list[str]:
     """Return absolute temp paths of reference images to attach to this turn.
 
@@ -69,6 +71,11 @@ async def _detect_image_edit_references(
         quoted_message_id:     LINE quotedMessageId or Telegram reply-to message
                                id (string); None when the user didn't reply
         text:                  the user's text message content (pre-cleanup)
+        current_message_uuid:  bot_messages.id of the *current* text turn — must
+                               be excluded from the anchor lookup. LINE persists
+                               the message before AI processing; without this,
+                               MAX(created_at) returns the current message and
+                               the image lookup always comes back empty.
 
     Returns:
         List of temp paths in chronological order (oldest first). Empty list
@@ -90,69 +97,41 @@ async def _detect_image_edit_references(
     if not any(kw in text for kw in _IMAGE_EDIT_KEYWORDS):
         return []
 
-    # Find the user's previous text-message timestamp (anchor for the batch)
-    if group_id is not None:
-        last_text_at = await conn.fetchval(
-            """
-            SELECT COALESCE(MAX(m.created_at), '1970-01-01'::timestamptz)
-            FROM bot_messages m
-            JOIN bot_users u ON m.bot_user_id = u.id
-            WHERE m.bot_group_id = $1
-              AND u.platform_user_id = $2
-              AND m.is_from_bot = false
-              AND m.message_type = 'text'
-              AND m.content IS NOT NULL
-              AND m.content <> ''
-            """,
-            group_id, user_id,
-        )
-        rows = await conn.fetch(
-            """
-            SELECT m.message_id as line_message_id, f.nas_path
-            FROM bot_messages m
-            JOIN bot_files f ON f.message_id = m.id
-            JOIN bot_users u ON m.bot_user_id = u.id
-            WHERE m.bot_group_id = $1
-              AND u.platform_user_id = $2
-              AND m.is_from_bot = false
-              AND m.message_type = 'image'
-              AND f.file_type = 'image'
-              AND m.created_at > $3
-            ORDER BY m.created_at ASC
-            """,
-            group_id, user_id, last_text_at,
-        )
-    else:
-        last_text_at = await conn.fetchval(
-            """
-            SELECT COALESCE(MAX(m.created_at), '1970-01-01'::timestamptz)
-            FROM bot_messages m
-            JOIN bot_users u ON m.bot_user_id = u.id
-            WHERE m.bot_group_id IS NULL
-              AND u.platform_user_id = $1
-              AND m.is_from_bot = false
-              AND m.message_type = 'text'
-              AND m.content IS NOT NULL
-              AND m.content <> ''
-            """,
-            user_id,
-        )
-        rows = await conn.fetch(
-            """
-            SELECT m.message_id as line_message_id, f.nas_path
-            FROM bot_messages m
-            JOIN bot_files f ON f.message_id = m.id
-            JOIN bot_users u ON m.bot_user_id = u.id
-            WHERE m.bot_group_id IS NULL
-              AND u.platform_user_id = $1
-              AND m.is_from_bot = false
-              AND m.message_type = 'image'
-              AND f.file_type = 'image'
-              AND m.created_at > $2
-            ORDER BY m.created_at ASC
-            """,
-            user_id, last_text_at,
-        )
+    # Find the user's previous text-message timestamp (anchor for the batch).
+    # `IS NOT DISTINCT FROM` handles NULL group_id in a single query; the
+    # `($4::uuid IS NULL OR m.id <> $4)` clause excludes the *current* message
+    # which LINE has already saved before reaching the detector.
+    last_text_at = await conn.fetchval(
+        """
+        SELECT COALESCE(MAX(m.created_at), '1970-01-01'::timestamptz)
+        FROM bot_messages m
+        JOIN bot_users u ON m.bot_user_id = u.id
+        WHERE m.bot_group_id IS NOT DISTINCT FROM $1
+          AND u.platform_user_id = $2
+          AND m.is_from_bot = false
+          AND m.message_type = 'text'
+          AND m.content IS NOT NULL
+          AND m.content <> ''
+          AND ($3::uuid IS NULL OR m.id <> $3)
+        """,
+        group_id, user_id, current_message_uuid,
+    )
+    rows = await conn.fetch(
+        """
+        SELECT m.message_id as line_message_id, f.nas_path
+        FROM bot_messages m
+        JOIN bot_files f ON f.message_id = m.id
+        JOIN bot_users u ON m.bot_user_id = u.id
+        WHERE m.bot_group_id IS NOT DISTINCT FROM $1
+          AND u.platform_user_id = $2
+          AND m.is_from_bot = false
+          AND m.message_type = 'image'
+          AND f.file_type = 'image'
+          AND m.created_at > $3
+        ORDER BY m.created_at ASC
+        """,
+        group_id, user_id, last_text_at,
+    )
 
     if not rows:
         return []

--- a/backend/src/ching_tech_os/services/linebot_ai.py
+++ b/backend/src/ching_tech_os/services/linebot_ai.py
@@ -870,6 +870,7 @@ async def process_message_with_ai(
                 group_id=str(line_group_id) if line_group_id else None,
                 quoted_message_id=quoted_message_id,
                 text=content,
+                current_message_uuid=message_uuid,
             )
         if reference_image_paths:
             logger.info(

--- a/backend/tests/test_image_edit_detection.py
+++ b/backend/tests/test_image_edit_detection.py
@@ -197,3 +197,50 @@ class TestDetectImageEditReferences:
                 text="改一下",
             )
         assert result == ["/tmp/test/MSG_OK.jpg", "/tmp/test/MSG_OK2.jpg"]
+
+    async def test_current_message_uuid_passed_into_anchor_query(
+        self, mock_conn, patch_ensure_temp_image,
+    ):
+        """偵測器必須把 current_message_uuid 排除在「上一則文字」錨點 SQL 外。
+
+        LINE 流程會先把當前文字訊息寫進 bot_messages 再呼叫偵測器，若
+        anchor 查詢沒排除它，MAX(created_at) 永遠指向當前訊息，圖片
+        清單會回空陣列（PR #145 review high-priority bug）。
+        """
+        current_uuid = uuid4()
+        mock_conn.fetchval = AsyncMock(
+            return_value=datetime(2026, 5, 20, tzinfo=timezone.utc)
+        )
+        mock_conn.fetch = AsyncMock(return_value=[])
+        await _detect_image_edit_references(
+            mock_conn,
+            user_id="USR_X",
+            group_id=None,
+            quoted_message_id=None,
+            text="合成",
+            current_message_uuid=current_uuid,
+        )
+        # 驗證 SQL 參數含當前訊息 UUID
+        anchor_call = mock_conn.fetchval.await_args
+        assert current_uuid in anchor_call.args, (
+            f"current_message_uuid 必須傳進 anchor SQL；實際 args={anchor_call.args}"
+        )
+
+    async def test_current_message_uuid_optional_back_compat(
+        self, mock_conn, patch_ensure_temp_image,
+    ):
+        """不傳 current_message_uuid 也要能跑（Telegram handler 沒這個值）。"""
+        mock_conn.fetchval = AsyncMock(
+            return_value=datetime(2026, 5, 20, tzinfo=timezone.utc)
+        )
+        mock_conn.fetch = AsyncMock(return_value=[
+            {"line_message_id": "MSG_A", "nas_path": "/nas/a.jpg"},
+        ])
+        result = await _detect_image_edit_references(
+            mock_conn,
+            user_id="USR_X",
+            group_id=None,
+            quoted_message_id=None,
+            text="合成",
+        )
+        assert result == ["/tmp/test/MSG_A.jpg"]


### PR DESCRIPTION
## 背景

LINE handler 在呼叫 \`_detect_image_edit_references\` **前**就會把當前文字訊息寫進 \`bot_messages\`。原本的 anchor SQL：

\`\`\`sql
SELECT MAX(m.created_at) FROM bot_messages m
WHERE ... AND message_type = 'text' ...
\`\`\`

永遠取到當前那筆 → 後續 \`created_at > anchor\` 過濾出的圖片清單永遠空。使用者打「合成這幾張圖」「組合一下」之類關鍵字時，AI 拿不到參考圖。

對應 PR #145 review 的 high-priority finding。

## 改動

- \`_detect_image_edit_references\` 新增 \`current_message_uuid\` 參數，anchor SQL 加 \`($3::uuid IS NULL OR m.id <> $3)\` 排除當前訊息
- \`linebot_ai.process_message_with_ai\` 呼叫時帶 \`message_uuid\`
- 順手把原本 \`if group_id else\` 兩條幾乎相同的 SQL 用 \`IS NOT DISTINCT FROM\` 合一
- Telegram handler 不傳 uuid 仍可運作（向下相容）

## Test plan

- [x] 新增 \`test_current_message_uuid_passed_into_anchor_query\` 驗證 uuid 進 SQL
- [x] 新增 \`test_current_message_uuid_optional_back_compat\` 驗證未傳時仍能跑（Telegram path）
- [x] 本地 \`tests/test_image_edit_detection.py\` 10 個全綠
- [ ] CI 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)