### PR TITLE
fix(security): restrict codex_image_tool reference paths to allowed roots

### DIFF
--- a/backend/src/ching_tech_os/services/mcp/codex_image_tools.py
+++ b/backend/src/ching_tech_os/services/mcp/codex_image_tools.py
@@ -22,6 +22,19 @@ from ...config import settings
 _VALID_ASPECT_RATIOS = {"1:1", "4:3", "3:4", "16:9", "9:16", "21:9"}
 _PER_IMAGE_BYTE_LIMIT = 10 * 1024 * 1024   # 10 MB / image (OOM defence)
 
+# LINE / Telegram 下載圖片的固定暫存區（detector 回傳的路徑會在此）。
+# 跟 services/bot/media.py 的 TEMP_IMAGE_DIR 對齊。
+_BOT_TEMP_IMAGE_DIR = Path("/tmp/bot-images")
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """Pathlib.is_relative_to() 在 3.9+ 才有；用 try/except 兼容語意。"""
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
 
 @mcp.tool()
 async def codex_image_tool(
@@ -65,15 +78,25 @@ async def codex_image_tool(
 
     reference_bytes_list: list[bytes] | None = None
     if reference_images:
+        # AI 可能被 prompt-injection 騙著傳系統路徑（/etc/passwd 等），所以
+        # 只允許 NAS 根目錄與 bot 暫存區兩個 root，其餘一律拒絕。
+        allowed_roots = [
+            Path(settings.linebot_local_path).resolve(),
+            _BOT_TEMP_IMAGE_DIR.resolve(),
+        ]
         resolved_paths: list[Path] = []
         for raw in reference_images:
             p = Path(raw)
-            if not p.is_file():
-                nas_path = Path(settings.linebot_local_path) / raw.lstrip("/")
-                if nas_path.is_file():
-                    p = nas_path
-                else:
-                    return f"reference 圖檔不存在：{raw}"
+            if p.is_absolute():
+                p = p.resolve()
+            else:
+                p = (Path(settings.linebot_local_path) / raw.lstrip("/")).resolve()
+
+            if not p.is_file() or not any(
+                _is_within(p, root) for root in allowed_roots
+            ):
+                return f"reference 圖檔不存在或非法路徑：{raw}"
+
             if p.stat().st_size > _PER_IMAGE_BYTE_LIMIT:
                 return f"reference 圖 {raw} 超過 10 MB"
             resolved_paths.append(p)

--- a/backend/tests/test_codex_image_tools.py
+++ b/backend/tests/test_codex_image_tools.py
@@ -152,3 +152,66 @@ async def test_legacy_tool_names_no_longer_exported():
     from ching_tech_os.services.mcp import codex_image_tools
     assert not hasattr(codex_image_tools, "codex_generate_image_tool")
     assert not hasattr(codex_image_tools, "codex_edit_image_tool")
+
+
+@pytest.mark.asyncio
+async def test_absolute_path_outside_allowed_roots_rejected(
+    codex_enabled, tmp_path, monkeypatch,
+):
+    """系統檔案絕對路徑（/etc/passwd 等）必須被拒絕，避免 LFI。
+
+    PR #145 review security-high：reference_images 沒檢查路徑是否
+    在允許範圍內，AI 若被 prompt-injection 騙著傳系統路徑，
+    程式會 read_bytes() 整個檔案再上傳給 OpenAI。
+    """
+    # 設好 NAS 根目錄（讓 settings.linebot_local_path 指向 tmp_path）
+    monkeypatch.setattr("ching_tech_os.config.settings.ctos_mount_path", str(tmp_path))
+    monkeypatch.setattr("ching_tech_os.config.settings.line_files_nas_path", "")
+
+    # 在禁區建一個真實檔案：tmp_path 上一層
+    forbidden_dir = tmp_path.parent / "forbidden_root"
+    forbidden_dir.mkdir(exist_ok=True)
+    secret = forbidden_dir / "secret.png"
+    secret.write_bytes(b"\x89PNG\r\n\x1a\nSECRET")
+
+    from ching_tech_os.services.mcp.codex_image_tools import codex_image_tool
+    with patch(
+        "ching_tech_os.services.mcp.codex_image_tools.generate_image_with_codex",
+        new=AsyncMock(),
+    ) as gen:
+        result = await codex_image_tool(
+            prompt="edit",
+            reference_images=[str(secret)],
+        )
+    gen.assert_not_awaited()
+    assert "非法路徑" in result or "不存在" in result
+
+
+@pytest.mark.asyncio
+async def test_bot_images_temp_dir_accepted(codex_enabled, tmp_path, monkeypatch):
+    """`/tmp/bot-images/` 是 bot 下載 LINE/Telegram 圖片的固定暫存區，
+    必須被視為合法 root（detector 回傳的就是這條路徑）。"""
+    monkeypatch.setattr("ching_tech_os.config.settings.ctos_mount_path", str(tmp_path))
+    monkeypatch.setattr("ching_tech_os.config.settings.line_files_nas_path", "")
+
+    # 假裝 bot 已把圖片下載到 /tmp/bot-images（用 monkeypatch 改路徑常數，避免污染真實 /tmp）
+    fake_bot_dir = tmp_path / "fake-bot-images"
+    fake_bot_dir.mkdir()
+    img = fake_bot_dir / "618.jpg"
+    img.write_bytes(b"\x89PNG\r\n\x1a\nA")
+    monkeypatch.setattr(
+        "ching_tech_os.services.mcp.codex_image_tools._BOT_TEMP_IMAGE_DIR",
+        fake_bot_dir,
+    )
+
+    from ching_tech_os.services.mcp.codex_image_tools import codex_image_tool
+    with patch(
+        "ching_tech_os.services.mcp.codex_image_tools.generate_image_with_codex",
+        new=AsyncMock(return_value=("ai-images/x.png", None)),
+    ) as gen:
+        result = await codex_image_tool(
+            prompt="edit",
+            reference_images=[str(img)],
+        )
+    gen.assert_awaited_once()
+    assert "圖片已生成" in result


### PR DESCRIPTION
## 背景

\`codex_image_tool\` 的 \`reference_images\` 原本接受任意絕對路徑：

\`\`\`python
p = Path(raw)
if not p.is_file():
    nas_path = Path(settings.linebot_local_path) / raw.lstrip(\"/\")
    if nas_path.is_file():
        p = nas_path
    else:
        return f\"reference 圖檔不存在：{raw}\"
\`\`\`

只檢查存在、沒檢查路徑範圍。AI 若被 prompt-injection 騙著傳 \`/etc/passwd\` 或任何系統路徑，程式會 \`read_bytes()\` 整個檔案再上傳給 OpenAI Images API（LFI 漏洞）。

對應 PR #145 review 的 **security-high** finding。

## 改動

- 定義 \`allowed_roots = [linebot_local_path, /tmp/bot-images]\`（後者是 LINE/Telegram 下載圖片的固定暫存區，detector 回傳的就是這條路徑）
- 任何路徑先 \`resolve()\`，不在白名單下的一律拒絕（錯誤訊息「非法路徑」）
- 加 \`_is_within(path, root)\` helper：用 \`try/except\` 模擬 \`Path.is_relative_to\`（3.9+ 才有）
- 相對路徑沿用原邏輯掛在 NAS root 下

## Test plan

- [x] \`test_absolute_path_outside_allowed_roots_rejected\` — \`tmp_path.parent\` 下的圖被拒、generate 未被呼叫
- [x] \`test_bot_images_temp_dir_accepted\` — bot 暫存區（透過 monkeypatch \`_BOT_TEMP_IMAGE_DIR\`）的圖被接受
- [x] 本地 \`tests/test_codex_image_tools.py\` 10 個全綠
- [ ] CI 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)