### PR TITLE
feat(auth): 長效 API token（PAT）+ 知識庫附件端點補認證

### DIFF
--- a/backend/migrations/versions/025_add_api_tokens.py
+++ b/backend/migrations/versions/025_add_api_tokens.py
@@ -1,0 +1,48 @@
+"""新增 api_tokens 表（長效 API token / PAT）
+
+供 CLI 與自動化工具以 Authorization: Bearer ctos_pat_xxx 存取 API。
+僅儲存 token 的 SHA-256 hash，原始 token 只在建立時回傳一次。
+
+Revision ID: 025
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "025"
+down_revision = "024"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_tokens",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("token_hash", sa.Text(), nullable=False, unique=True),
+        sa.Column("name", sa.Text(), nullable=False),
+        # 允許存取的 app id 清單（如 ["knowledge-base"]），空陣列代表使用者全部 app 權限
+        sa.Column("scopes", JSONB(), nullable=False, server_default="[]"),
+        sa.Column("read_only", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("last_used_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+    op.create_index("idx_api_tokens_user_id", "api_tokens", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_api_tokens_user_id", table_name="api_tokens")
+    op.drop_table("api_tokens")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ching-tech-os"
-version = "0.8.0"
+version = "0.9.0"
 description = "Ching Tech OS Backend"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/src/ching_tech_os/__init__.py
+++ b/backend/src/ching_tech_os/__init__.py
@@ -1,3 +1,3 @@
 """Ching Tech OS Backend"""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/backend/src/ching_tech_os/api/auth.py
+++ b/backend/src/ching_tech_os/api/auth.py
@@ -6,7 +6,15 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 from ..config import settings
-from ..models.auth import LoginRequest, LoginResponse, LogoutResponse, ErrorResponse
+from ..models.auth import (
+    ApiTokenCreateRequest,
+    ApiTokenCreateResponse,
+    ApiTokenListResponse,
+    LoginRequest,
+    LoginResponse,
+    LogoutResponse,
+    ErrorResponse,
+)
 from ..models.login_record import DeviceInfo as LoginRecordDeviceInfo, DeviceType, GeoLocation
 from ..models.message import MessageSeverity, MessageSource
 from ..services.session import session_manager, SessionData
@@ -45,6 +53,20 @@ def get_token(
     return credentials.credentials
 
 
+async def _resolve_session(token: str) -> SessionData | None:
+    """解析 token 為 SessionData
+
+    支援兩種 token：
+    - 一般 session token（web 登入，UUID）
+    - PAT 長效 API token（ctos_pat_ 前綴，供 CLI / 自動化工具）
+    """
+    from ..services.api_token import TOKEN_PREFIX, verify_api_token
+
+    if token.startswith(TOKEN_PREFIX):
+        return await verify_api_token(token)
+    return await session_manager.get_session(token)
+
+
 async def get_current_session(token: str = Depends(get_token)) -> SessionData:
     """驗證 token 並取得目前 session
 
@@ -54,7 +76,7 @@ async def get_current_session(token: str = Depends(get_token)) -> SessionData:
     Raises:
         HTTPException: 若 token 無效或過期
     """
-    session = await session_manager.get_session(token)
+    session = await _resolve_session(token)
     if session is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -92,7 +114,7 @@ async def get_session_from_token_or_query(
             detail="未授權，請重新登入",
         )
 
-    session = await session_manager.get_session(actual_token)
+    session = await _resolve_session(actual_token)
     if session is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -401,6 +423,89 @@ async def logout(token: str = Depends(get_token)) -> LogoutResponse:
     """登出並清除 session"""
     await session_manager.delete_session(token)
     return LogoutResponse(success=True)
+
+
+# ============================================================
+# API Token（PAT）管理
+# ============================================================
+
+
+@router.post("/tokens", response_model=ApiTokenCreateResponse, status_code=status.HTTP_201_CREATED)
+async def create_token(
+    request: ApiTokenCreateRequest,
+    session: SessionData = Depends(get_current_session),
+) -> ApiTokenCreateResponse:
+    """建立長效 API token（PAT）
+
+    需要以 web 登入 session 換發，不可用 PAT 換發 PAT。
+    token 僅在此回應中出現一次，請妥善保存。
+    """
+    from ..services.api_token import create_api_token
+
+    if session.auth_type == "pat":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="不可使用 API token 換發新 token，請以帳號密碼登入後再操作",
+        )
+    if session.user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="使用者記錄不存在，無法建立 token",
+        )
+    if not request.name.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="token 名稱不可為空",
+        )
+
+    token, info = await create_api_token(
+        user_id=session.user_id,
+        name=request.name.strip(),
+        scopes=request.scopes,
+        expires_days=request.expires_days,
+        read_only=request.read_only,
+    )
+    return ApiTokenCreateResponse(success=True, token=token, info=info)
+
+
+@router.get("/tokens", response_model=ApiTokenListResponse)
+async def list_tokens(
+    session: SessionData = Depends(get_current_session),
+) -> ApiTokenListResponse:
+    """列出自己的 API token（不含 token 本體）"""
+    from ..services.api_token import list_api_tokens
+
+    if session.user_id is None:
+        return ApiTokenListResponse(success=True, tokens=[])
+    tokens = await list_api_tokens(session.user_id)
+    return ApiTokenListResponse(success=True, tokens=tokens)
+
+
+@router.delete("/tokens/{token_id}")
+async def revoke_token(
+    token_id: int,
+    session: SessionData = Depends(get_current_session),
+) -> dict:
+    """撤銷自己的 API token"""
+    from ..services.api_token import revoke_api_token
+
+    if session.auth_type == "pat":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="不可使用 API token 撤銷 token，請以帳號密碼登入後再操作",
+        )
+    if session.user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="token 不存在",
+        )
+    deleted = await revoke_api_token(session.user_id, token_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="token 不存在",
+        )
+    return {"success": True}
 
 
 # 密碼變更相關 models

--- a/backend/src/ching_tech_os/api/knowledge.py
+++ b/backend/src/ching_tech_os/api/knowledge.py
@@ -126,7 +126,12 @@ async def rebuild_knowledge_index(
     "/attachments/{path:path}",
     summary="取得 NAS 附件",
 )
-async def get_attachment(path: str) -> Response:
+async def get_attachment(
+    path: str,
+    session: SessionData = Depends(
+        require_app_permission("knowledge-base", allow_query_token=True)
+    ),
+) -> Response:
     """代理取得 NAS 上的附件
 
     Args:
@@ -153,7 +158,9 @@ async def get_attachment(path: str) -> Response:
 )
 async def get_local_asset(
     path: str,
-    session: SessionData = Depends(require_app_permission("knowledge-base")),
+    session: SessionData = Depends(
+        require_app_permission("knowledge-base", allow_query_token=True)
+    ),
 ) -> Response:
     """取得本機知識庫附件
 

--- a/backend/src/ching_tech_os/main.py
+++ b/backend/src/ching_tech_os/main.py
@@ -311,7 +311,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Ching Tech OS API",
-    version="0.8.0",
+    version="0.9.0",
     lifespan=lifespan,
 )
 

--- a/backend/src/ching_tech_os/models/auth.py
+++ b/backend/src/ching_tech_os/models/auth.py
@@ -54,6 +54,10 @@ class SessionData(BaseModel):
     role: str = "user"  # admin, user
     # App 權限（登入時載入，避免每次 API 都查資料庫）
     app_permissions: dict[str, bool] = {}
+    # 認證來源：session（web 登入）或 pat（長效 API token）
+    auth_type: str = "session"
+    # 唯讀 token：非 GET/HEAD/OPTIONS 的 app API 一律拒絕
+    read_only: bool = False
 
 
 class ErrorResponse(BaseModel):
@@ -61,3 +65,44 @@ class ErrorResponse(BaseModel):
 
     success: bool = False
     error: str
+
+
+class ApiTokenCreateRequest(BaseModel):
+    """建立 API token 請求"""
+
+    name: str
+    # 允許存取的 app id 清單，空清單代表使用者全部 app 權限
+    scopes: list[str] = ["knowledge-base"]
+    # 有效天數，None 代表永不過期
+    expires_days: int | None = 180
+    read_only: bool = True
+
+
+class ApiTokenInfo(BaseModel):
+    """API token 資訊（不含 token 本體）"""
+
+    id: int
+    name: str
+    scopes: list[str]
+    read_only: bool
+    expires_at: datetime | None = None
+    last_used_at: datetime | None = None
+    created_at: datetime
+
+
+class ApiTokenCreateResponse(BaseModel):
+    """建立 API token 回應
+
+    token 僅在建立時回傳一次，之後無法再取得。
+    """
+
+    success: bool
+    token: str
+    info: ApiTokenInfo
+
+
+class ApiTokenListResponse(BaseModel):
+    """API token 列表回應"""
+
+    success: bool
+    tokens: list[ApiTokenInfo]

--- a/backend/src/ching_tech_os/services/api_token.py
+++ b/backend/src/ching_tech_os/services/api_token.py
@@ -1,0 +1,214 @@
+"""API Token（PAT）服務
+
+提供長效 personal access token 的建立、驗證、列表與撤銷，
+供 CLI 與自動化工具以 `Authorization: Bearer ctos_pat_xxx` 存取 API。
+
+安全設計：
+- 資料庫僅儲存 token 的 SHA-256 hash，原始 token 只在建立時回傳一次
+- 驗證時合成的 SessionData 一律 role="user"（即使擁有者是 admin），
+  不帶 SMB 密碼，無法操作 NAS 或 admin 端點
+- scopes 限縮可存取的 app，並與使用者當下實際權限取交集
+"""
+
+import hashlib
+import json
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from ..config import settings
+from ..database import get_connection
+from ..models.auth import ApiTokenInfo, SessionData
+
+logger = logging.getLogger(__name__)
+
+TOKEN_PREFIX = "ctos_pat_"
+
+# last_used_at 更新節流（秒），避免高頻請求每次都寫 DB
+_LAST_USED_UPDATE_INTERVAL = 60
+
+
+def hash_token(token: str) -> str:
+    """計算 token 的 SHA-256 hash（hex）"""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def generate_token() -> str:
+    """產生新的 PAT token 字串"""
+    return TOKEN_PREFIX + secrets.token_urlsafe(32)
+
+
+def _parse_scopes(raw) -> list[str]:
+    """解析 DB 回傳的 scopes 欄位（JSONB 可能是 list 或 JSON 字串）"""
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (ValueError, TypeError):
+            return []
+    if isinstance(raw, list):
+        return [s for s in raw if isinstance(s, str)]
+    return []
+
+
+async def create_api_token(
+    user_id: int,
+    name: str,
+    scopes: list[str] | None = None,
+    expires_days: int | None = 180,
+    read_only: bool = True,
+) -> tuple[str, ApiTokenInfo]:
+    """建立 API token
+
+    Args:
+        user_id: 使用者 ID
+        name: token 名稱（用途說明，如 "yaze-laptop CLI"）
+        scopes: 允許存取的 app id 清單，空清單代表使用者全部 app 權限
+        expires_days: 有效天數，None 代表永不過期
+        read_only: 是否唯讀
+
+    Returns:
+        (原始 token 字串, ApiTokenInfo)
+    """
+    token = generate_token()
+    expires_at = (
+        datetime.now(timezone.utc) + timedelta(days=expires_days)
+        if expires_days is not None
+        else None
+    )
+    scopes = scopes or []
+
+    async with get_connection() as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO api_tokens (user_id, token_hash, name, scopes, read_only, expires_at)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING id, name, scopes, read_only, expires_at, last_used_at, created_at
+            """,
+            user_id,
+            hash_token(token),
+            name,
+            scopes,  # database.py 已註冊 JSONB codec，直接傳 list
+            read_only,
+            expires_at,
+        )
+
+    info = ApiTokenInfo(
+        id=row["id"],
+        name=row["name"],
+        scopes=_parse_scopes(row["scopes"]),
+        read_only=row["read_only"],
+        expires_at=row["expires_at"],
+        last_used_at=row["last_used_at"],
+        created_at=row["created_at"],
+    )
+    logger.info("建立 API token：user_id=%s name=%s scopes=%s", user_id, name, scopes)
+    return token, info
+
+
+async def list_api_tokens(user_id: int) -> list[ApiTokenInfo]:
+    """列出使用者的所有 API token（不含 token 本體）"""
+    async with get_connection() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT id, name, scopes, read_only, expires_at, last_used_at, created_at
+            FROM api_tokens
+            WHERE user_id = $1
+            ORDER BY created_at DESC
+            """,
+            user_id,
+        )
+    return [
+        ApiTokenInfo(
+            id=row["id"],
+            name=row["name"],
+            scopes=_parse_scopes(row["scopes"]),
+            read_only=row["read_only"],
+            expires_at=row["expires_at"],
+            last_used_at=row["last_used_at"],
+            created_at=row["created_at"],
+        )
+        for row in rows
+    ]
+
+
+async def revoke_api_token(user_id: int, token_id: int) -> bool:
+    """撤銷 API token（僅能撤銷自己的）
+
+    Returns:
+        是否成功刪除
+    """
+    async with get_connection() as conn:
+        result = await conn.execute(
+            "DELETE FROM api_tokens WHERE id = $1 AND user_id = $2",
+            token_id,
+            user_id,
+        )
+    return result == "DELETE 1"
+
+
+async def verify_api_token(token: str) -> SessionData | None:
+    """驗證 PAT 並合成 SessionData
+
+    Args:
+        token: 完整 token 字串（含 ctos_pat_ 前綴）
+
+    Returns:
+        SessionData（auth_type="pat"）或 None（無效/過期/使用者停用）
+    """
+    if not token.startswith(TOKEN_PREFIX):
+        return None
+
+    async with get_connection() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT t.id, t.user_id, t.scopes, t.read_only, t.expires_at,
+                   t.last_used_at, t.created_at,
+                   u.username, u.is_active
+            FROM api_tokens t
+            JOIN users u ON u.id = t.user_id
+            WHERE t.token_hash = $1
+            """,
+            hash_token(token),
+        )
+
+        if row is None:
+            return None
+
+        now = datetime.now(timezone.utc)
+        if row["expires_at"] is not None and row["expires_at"] < now:
+            return None
+        if not row["is_active"]:
+            return None
+
+        # 節流更新 last_used_at
+        last_used = row["last_used_at"]
+        if last_used is None or (now - last_used).total_seconds() > _LAST_USED_UPDATE_INTERVAL:
+            await conn.execute(
+                "UPDATE api_tokens SET last_used_at = NOW() WHERE id = $1",
+                row["id"],
+            )
+
+    # 取使用者當下實際的 app 權限，再以 scopes 取交集
+    from .permissions import get_user_app_permissions
+
+    user_perms = await get_user_app_permissions(row["user_id"])
+    scopes = _parse_scopes(row["scopes"])
+    if scopes:
+        app_permissions = {app: user_perms.get(app, False) for app in scopes}
+    else:
+        app_permissions = user_perms
+
+    return SessionData(
+        username=row["username"],
+        password="",  # PAT 不帶 SMB 密碼
+        nas_host=settings.nas_host,
+        user_id=row["user_id"],
+        created_at=row["created_at"],
+        expires_at=row["expires_at"] or (now + timedelta(days=365 * 100)),
+        role="user",  # PAT 一律降為 user，不可操作 admin 端點
+        app_permissions=app_permissions,
+        auth_type="pat",
+        read_only=row["read_only"],
+    )

--- a/backend/src/ching_tech_os/services/permissions.py
+++ b/backend/src/ching_tech_os/services/permissions.py
@@ -11,7 +11,7 @@
 import logging
 from typing import Any, Callable
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 
 from ..database import get_connection
 
@@ -614,7 +614,7 @@ def get_app_display_names() -> dict[str, str]:
 # ============================================================
 
 
-def require_app_permission(app_id: str) -> Callable:
+def require_app_permission(app_id: str, allow_query_token: bool = False) -> Callable:
     """建立要求特定 App 權限的 FastAPI dependency
 
     使用方式：
@@ -628,16 +628,32 @@ def require_app_permission(app_id: str) -> Callable:
 
     Args:
         app_id: 應用程式 ID（如 "project-management"、"knowledge-base"）
+        allow_query_token: 是否允許從 query parameter 取 token
+            （供 <img src>、window.open 等無法設定 header 的請求使用）
 
     Returns:
         FastAPI Depends 用的函數
     """
     # 延遲 import 避免循環依賴
-    from ..api.auth import get_current_session
+    from ..api.auth import get_current_session, get_session_from_token_or_query
     from ..models.auth import SessionData
 
-    async def checker(session: SessionData = Depends(get_current_session)) -> SessionData:
+    session_dependency = (
+        get_session_from_token_or_query if allow_query_token else get_current_session
+    )
+
+    async def checker(
+        request: Request,
+        session: SessionData = Depends(session_dependency),
+    ) -> SessionData:
         """檢查使用者是否有指定的 App 權限"""
+        # 唯讀 API token：拒絕寫入操作
+        if session.read_only and request.method not in ("GET", "HEAD", "OPTIONS"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="此 API token 為唯讀，無法執行寫入操作",
+            )
+
         # 管理員擁有所有權限
         if session.role == "admin":
             return session

--- a/backend/tests/test_api_token.py
+++ b/backend/tests/test_api_token.py
@@ -1,0 +1,365 @@
+"""API Token（PAT）服務與端點測試。"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from ching_tech_os.api import auth as auth_api
+from ching_tech_os.models.auth import ApiTokenCreateRequest, SessionData
+from ching_tech_os.services import api_token as api_token_service
+from ching_tech_os.services import permissions as permissions_service
+
+
+# ============================================================
+# 共用 helpers
+# ============================================================
+
+
+def _mock_conn():
+    """模擬 asyncpg connection 與 async context manager"""
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock(return_value="DELETE 0")
+
+    class _Ctx:
+        async def __aenter__(self):
+            return conn
+
+        async def __aexit__(self, *args):
+            return False
+
+    return conn, _Ctx
+
+
+def _token_row(**overrides) -> dict:
+    now = datetime.now(timezone.utc)
+    row = {
+        "id": 1,
+        "user_id": 7,
+        "scopes": ["knowledge-base"],
+        "read_only": True,
+        "expires_at": now + timedelta(days=30),
+        "last_used_at": None,
+        "created_at": now - timedelta(days=1),
+        "username": "u1",
+        "is_active": True,
+        "name": "test-token",
+    }
+    row.update(overrides)
+    return row
+
+
+def _session(auth_type: str = "session", user_id: int | None = 7) -> SessionData:
+    now = datetime.now()
+    return SessionData(
+        username="u1",
+        password="",
+        nas_host="h",
+        user_id=user_id,
+        created_at=now,
+        expires_at=now + timedelta(hours=1),
+        role="user",
+        app_permissions={"knowledge-base": True},
+        auth_type=auth_type,
+    )
+
+
+# ============================================================
+# token 產生與 hash
+# ============================================================
+
+
+def test_generate_and_hash_token() -> None:
+    token = api_token_service.generate_token()
+    assert token.startswith(api_token_service.TOKEN_PREFIX)
+    # token_urlsafe(32) 至少 40 字元
+    assert len(token) > len(api_token_service.TOKEN_PREFIX) + 30
+
+    # hash 是確定性的 SHA-256 hex
+    h1 = api_token_service.hash_token(token)
+    h2 = api_token_service.hash_token(token)
+    assert h1 == h2
+    assert len(h1) == 64
+    assert h1 != token
+
+
+def test_parse_scopes_variants() -> None:
+    assert api_token_service._parse_scopes(None) == []
+    assert api_token_service._parse_scopes(["a", "b"]) == ["a", "b"]
+    assert api_token_service._parse_scopes('["a"]') == ["a"]
+    assert api_token_service._parse_scopes("not-json") == []
+    assert api_token_service._parse_scopes([1, "a"]) == ["a"]
+
+
+# ============================================================
+# create / list / revoke
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_create_api_token_stores_hash_not_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn, ctx = _mock_conn()
+    row = _token_row()
+    conn.fetchrow = AsyncMock(return_value=row)
+    monkeypatch.setattr(api_token_service, "get_connection", ctx)
+
+    token, info = await api_token_service.create_api_token(
+        user_id=7, name="test-token", scopes=["knowledge-base"], expires_days=30
+    )
+
+    assert token.startswith(api_token_service.TOKEN_PREFIX)
+    # INSERT 參數中只有 hash，沒有原始 token
+    insert_args = conn.fetchrow.call_args.args
+    assert api_token_service.hash_token(token) in insert_args
+    assert token not in insert_args
+    assert info.name == "test-token"
+    assert info.scopes == ["knowledge-base"]
+
+
+@pytest.mark.asyncio
+async def test_list_and_revoke_api_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn, ctx = _mock_conn()
+    conn.fetch = AsyncMock(return_value=[_token_row()])
+    conn.execute = AsyncMock(return_value="DELETE 1")
+    monkeypatch.setattr(api_token_service, "get_connection", ctx)
+
+    tokens = await api_token_service.list_api_tokens(7)
+    assert len(tokens) == 1
+    assert tokens[0].id == 1
+
+    assert await api_token_service.revoke_api_token(7, 1) is True
+
+    conn.execute = AsyncMock(return_value="DELETE 0")
+    assert await api_token_service.revoke_api_token(7, 99) is False
+
+
+# ============================================================
+# verify_api_token
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_non_pat_token() -> None:
+    # 沒有前綴：不應觸碰 DB，直接 None
+    assert await api_token_service.verify_api_token("some-uuid-token") is None
+
+
+@pytest.mark.asyncio
+async def test_verify_api_token_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn, ctx = _mock_conn()
+    monkeypatch.setattr(api_token_service, "get_connection", ctx)
+    monkeypatch.setattr(
+        permissions_service,
+        "get_user_app_permissions",
+        AsyncMock(return_value={"knowledge-base": True, "file-manager": True}),
+    )
+
+    token = api_token_service.generate_token()
+
+    # token 不存在
+    conn.fetchrow = AsyncMock(return_value=None)
+    assert await api_token_service.verify_api_token(token) is None
+
+    # 已過期
+    expired = _token_row(
+        expires_at=datetime.now(timezone.utc) - timedelta(days=1)
+    )
+    conn.fetchrow = AsyncMock(return_value=expired)
+    assert await api_token_service.verify_api_token(token) is None
+
+    # 使用者停用
+    inactive = _token_row(is_active=False)
+    conn.fetchrow = AsyncMock(return_value=inactive)
+    assert await api_token_service.verify_api_token(token) is None
+
+    # 有效 token：scope 交集、role 降為 user、auth_type=pat
+    valid = _token_row()
+    conn.fetchrow = AsyncMock(return_value=valid)
+    session = await api_token_service.verify_api_token(token)
+    assert session is not None
+    assert session.auth_type == "pat"
+    assert session.role == "user"
+    assert session.read_only is True
+    assert session.password == ""
+    assert session.app_permissions == {"knowledge-base": True}
+
+    # 空 scopes：使用者全部權限
+    no_scope = _token_row(scopes=[])
+    conn.fetchrow = AsyncMock(return_value=no_scope)
+    session = await api_token_service.verify_api_token(token)
+    assert session.app_permissions == {
+        "knowledge-base": True,
+        "file-manager": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_verify_api_token_scope_excludes_unpermitted_app(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """scope 內含使用者沒有的 app 權限時，該 app 為 False"""
+    conn, ctx = _mock_conn()
+    monkeypatch.setattr(api_token_service, "get_connection", ctx)
+    monkeypatch.setattr(
+        permissions_service,
+        "get_user_app_permissions",
+        AsyncMock(return_value={"knowledge-base": True}),
+    )
+
+    row = _token_row(scopes=["knowledge-base", "terminal"])
+    conn.fetchrow = AsyncMock(return_value=row)
+    session = await api_token_service.verify_api_token(
+        api_token_service.generate_token()
+    )
+    assert session.app_permissions == {"knowledge-base": True, "terminal": False}
+
+
+@pytest.mark.asyncio
+async def test_verify_api_token_last_used_throttle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn, ctx = _mock_conn()
+    monkeypatch.setattr(api_token_service, "get_connection", ctx)
+    monkeypatch.setattr(
+        permissions_service,
+        "get_user_app_permissions",
+        AsyncMock(return_value={"knowledge-base": True}),
+    )
+    token = api_token_service.generate_token()
+
+    # last_used_at 很久以前 → 更新
+    old = _token_row(last_used_at=datetime.now(timezone.utc) - timedelta(hours=1))
+    conn.fetchrow = AsyncMock(return_value=old)
+    await api_token_service.verify_api_token(token)
+    assert conn.execute.await_count == 1
+
+    # last_used_at 剛剛 → 不更新
+    conn.execute.reset_mock()
+    recent = _token_row(last_used_at=datetime.now(timezone.utc))
+    conn.fetchrow = AsyncMock(return_value=recent)
+    await api_token_service.verify_api_token(token)
+    assert conn.execute.await_count == 0
+
+
+# ============================================================
+# _resolve_session 分流
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    pat_session = _session(auth_type="pat")
+    monkeypatch.setattr(
+        api_token_service, "verify_api_token", AsyncMock(return_value=pat_session)
+    )
+    web_session = _session()
+    monkeypatch.setattr(
+        auth_api.session_manager, "get_session", AsyncMock(return_value=web_session)
+    )
+
+    got = await auth_api._resolve_session(api_token_service.TOKEN_PREFIX + "xxx")
+    assert got is pat_session
+
+    got = await auth_api._resolve_session("plain-uuid")
+    assert got is web_session
+
+
+# ============================================================
+# token 管理端點
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_create_token_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    info = SimpleNamespace()
+    monkeypatch.setattr(
+        api_token_service,
+        "create_api_token",
+        AsyncMock(return_value=("ctos_pat_new", info)),
+    )
+
+    # PAT 不可換發 PAT
+    with pytest.raises(HTTPException) as e:
+        await auth_api.create_token(
+            ApiTokenCreateRequest(name="x"), session=_session(auth_type="pat")
+        )
+    assert e.value.status_code == 403
+
+    # 無 user_id
+    with pytest.raises(HTTPException) as e:
+        await auth_api.create_token(
+            ApiTokenCreateRequest(name="x"), session=_session(user_id=None)
+        )
+    assert e.value.status_code == 400
+
+    # 空名稱
+    with pytest.raises(HTTPException) as e:
+        await auth_api.create_token(
+            ApiTokenCreateRequest(name="   "), session=_session()
+        )
+    assert e.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_token_endpoint_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    from ching_tech_os.models.auth import ApiTokenInfo
+
+    info = ApiTokenInfo(
+        id=1,
+        name="cli",
+        scopes=["knowledge-base"],
+        read_only=True,
+        created_at=datetime.now(timezone.utc),
+    )
+    create_mock = AsyncMock(return_value=("ctos_pat_new", info))
+    monkeypatch.setattr(api_token_service, "create_api_token", create_mock)
+
+    resp = await auth_api.create_token(
+        ApiTokenCreateRequest(name="cli"), session=_session()
+    )
+    assert resp.success is True
+    assert resp.token == "ctos_pat_new"
+    create_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_list_and_revoke_token_endpoints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        api_token_service, "list_api_tokens", AsyncMock(return_value=[])
+    )
+    resp = await auth_api.list_tokens(session=_session())
+    assert resp.success is True
+    assert resp.tokens == []
+
+    # 無 user_id：回空清單
+    resp = await auth_api.list_tokens(session=_session(user_id=None))
+    assert resp.tokens == []
+
+    # 撤銷成功
+    monkeypatch.setattr(
+        api_token_service, "revoke_api_token", AsyncMock(return_value=True)
+    )
+    assert (await auth_api.revoke_token(1, session=_session()))["success"] is True
+
+    # 撤銷不存在的 token
+    monkeypatch.setattr(
+        api_token_service, "revoke_api_token", AsyncMock(return_value=False)
+    )
+    with pytest.raises(HTTPException) as e:
+        await auth_api.revoke_token(99, session=_session())
+    assert e.value.status_code == 404
+
+    # PAT 不可撤銷 token
+    with pytest.raises(HTTPException) as e:
+        await auth_api.revoke_token(1, session=_session(auth_type="pat"))
+    assert e.value.status_code == 403

--- a/backend/tests/test_permissions_dependency.py
+++ b/backend/tests/test_permissions_dependency.py
@@ -10,22 +10,54 @@ from fastapi import HTTPException
 from ching_tech_os.services import permissions
 
 
+def _request(method: str = "GET") -> SimpleNamespace:
+    """checker 只使用 request.method，以 SimpleNamespace 模擬即可"""
+    return SimpleNamespace(method=method)
+
+
 @pytest.mark.asyncio
 async def test_require_app_permission_checker(monkeypatch: pytest.MonkeyPatch) -> None:
     checker = permissions.require_app_permission("file-manager")
 
-    admin = SimpleNamespace(role="admin", app_permissions=None)
-    assert await checker(session=admin) is admin
+    admin = SimpleNamespace(role="admin", app_permissions=None, read_only=False)
+    assert await checker(request=_request(), session=admin) is admin
 
-    allowed = SimpleNamespace(role="user", app_permissions={"file-manager": True})
-    assert await checker(session=allowed) is allowed
+    allowed = SimpleNamespace(
+        role="user", app_permissions={"file-manager": True}, read_only=False
+    )
+    assert await checker(request=_request(), session=allowed) is allowed
 
     monkeypatch.setattr(permissions, "has_app_permission", lambda *_args, **_kwargs: True)
-    computed = SimpleNamespace(role="user", app_permissions=None)
-    assert await checker(session=computed) is computed
+    computed = SimpleNamespace(role="user", app_permissions=None, read_only=False)
+    assert await checker(request=_request(), session=computed) is computed
 
     monkeypatch.setattr(permissions, "has_app_permission", lambda *_args, **_kwargs: False)
-    denied = SimpleNamespace(role="user", app_permissions={"file-manager": False})
+    denied = SimpleNamespace(
+        role="user", app_permissions={"file-manager": False}, read_only=False
+    )
     with pytest.raises(HTTPException) as e:
-        await checker(session=denied)
+        await checker(request=_request(), session=denied)
     assert e.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_require_app_permission_read_only_token() -> None:
+    """唯讀 PAT：寫入操作一律 403，讀取放行"""
+    checker = permissions.require_app_permission("knowledge-base")
+
+    readonly = SimpleNamespace(
+        role="user", app_permissions={"knowledge-base": True}, read_only=True
+    )
+
+    # 讀取放行
+    assert await checker(request=_request("GET"), session=readonly) is readonly
+
+    # 寫入拒絕
+    for method in ("POST", "PUT", "DELETE", "PATCH"):
+        with pytest.raises(HTTPException) as e:
+            await checker(request=_request(method), session=readonly)
+        assert e.value.status_code == 403
+
+    # 非唯讀的 session 寫入不受影響（admin）
+    admin = SimpleNamespace(role="admin", app_permissions=None, read_only=False)
+    assert await checker(request=_request("POST"), session=admin) is admin

--- a/backend/tests/test_permissions_extended.py
+++ b/backend/tests/test_permissions_extended.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock
 
+from types import SimpleNamespace
+
 import pytest
 from fastapi import HTTPException
 
@@ -107,22 +109,23 @@ async def test_project_member_and_async_knowledge_permission(monkeypatch: pytest
 @pytest.mark.asyncio
 async def test_require_app_permission_checker(monkeypatch: pytest.MonkeyPatch) -> None:
     checker = permissions.require_app_permission("terminal")
+    req = SimpleNamespace(method="GET")
 
     # admin 直接通過
     s_admin = _session("admin")
-    assert (await checker(s_admin)).role == "admin"
+    assert (await checker(req, s_admin)).role == "admin"
 
     # session cache 命中
     s_cache = _session("user", app_permissions={"terminal": True})
-    assert (await checker(s_cache)).username == "u1"
+    assert (await checker(req, s_cache)).username == "u1"
 
     # cache 空，走 has_app_permission
     monkeypatch.setattr(permissions, "has_app_permission", lambda _r, _p, _a: True)
     s_calc = _session("user", app_permissions={})
-    assert (await checker(s_calc)).username == "u1"
+    assert (await checker(req, s_calc)).username == "u1"
 
     # 無權限
     monkeypatch.setattr(permissions, "has_app_permission", lambda _r, _p, _a: False)
     with pytest.raises(HTTPException) as e1:
-        await checker(_session("user", app_permissions={}))
+        await checker(req, _session("user", app_permissions={}))
     assert e1.value.status_code == 403 and "終端機" in e1.value.detail

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -571,7 +571,7 @@ wheels = [
 
 [[package]]
 name = "ching-tech-os"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -63,6 +63,21 @@ uv run uvicorn ching_tech_os.main:socket_app --host 0.0.0.0 --port 8088 --reload
 | POST | `/api/auth/login` | 登入（CTOS 密碼優先，NAS SMB 備用） |
 | POST | `/api/auth/logout` | 登出 |
 | POST | `/api/auth/change-password` | 變更密碼（一般使用者自行變更） |
+| POST | `/api/auth/tokens` | 建立長效 API token（PAT，需 web 登入 session） |
+| GET | `/api/auth/tokens` | 列出自己的 API token |
+| DELETE | `/api/auth/tokens/{id}` | 撤銷 API token |
+
+#### API Token（PAT）
+
+供 CLI 與自動化工具使用的長效 token，格式 `ctos_pat_xxx`，用法與 session token 相同
+（`Authorization: Bearer ctos_pat_xxx`）。安全特性：
+
+- 資料庫僅存 SHA-256 hash，token 只在建立時回傳一次
+- `scopes` 限縮可存取的 app（預設 `["knowledge-base"]`），與使用者當下實際權限取交集
+- `read_only=true`（預設）時，所有掛 `require_app_permission` 的端點拒絕非 GET 請求
+- 驗證後合成的 session 一律 `role="user"`、不帶 SMB 密碼：不可操作 admin 端點與 NAS
+- 不可用 PAT 換發或撤銷 PAT（防止外洩 token 自我複製）
+- 預設效期 180 天（`expires_days`，`null` 為永久）；使用者停用（`is_active=false`）即全部失效
 
 ### 使用者
 

--- a/frontend/js/knowledge-base.js
+++ b/frontend/js/knowledge-base.js
@@ -971,7 +971,6 @@ const KnowledgeBaseModule = (function() {
   function previewAttachment(kbId, path) {
     const url = getAttachmentUrl(path);
     const filename = path.split('/').pop();
-    const basePath = window.API_BASE || '';
 
     // 使用 FileOpener 統一入口開啟檔案
     if (typeof FileOpener !== 'undefined' && FileOpener.canOpen(filename)) {
@@ -979,8 +978,8 @@ const KnowledgeBaseModule = (function() {
       return;
     }
 
-    // 不支援的檔案類型 - 直接下載
-    window.open(`${basePath}${url}`, '_blank');
+    // 不支援的檔案類型 - 帶認證下載（附件端點需要登入）
+    FileUtils.downloadWithAuth(url, filename);
   }
 
   /**


### PR DESCRIPTION
## 目的

讓同事在自己的開發機（含 Windows）上以 CLI / Claude Code 遠端讀取 CTOS 知識庫與圖書館資料。本 PR 是後端前置：長效 API token（PAT）機制。後續 PR 會加上 `ctos` CLI 與 Claude Code skill。

## 變更內容

### PAT 機制
- `api_tokens` 表（migration 025）：僅儲存 token 的 SHA-256 hash，原始 token 只在建立時回傳一次
- token 格式 `ctos_pat_xxx`，與 session token 用法相同：`Authorization: Bearer ctos_pat_xxx`
- `POST /api/auth/tokens` 建立（需 web 登入 session，PAT 不可換發 PAT）、`GET` 列表、`DELETE /{id}` 撤銷
- 安全設計：
  - 驗證後合成的 session 一律 `role="user"`、不帶 SMB 密碼 → 不可操作 admin 端點與 NAS
  - `scopes`（預設 `["knowledge-base"]`）與使用者當下實際權限取交集
  - `read_only=true`（預設）：所有掛 `require_app_permission` 的端點拒絕非 GET/HEAD/OPTIONS
  - 預設效期 180 天；使用者 `is_active=false` 即全部失效

### 附件端點認證補洞
- `GET /api/knowledge/attachments/{path}` 原本完全沒有認證依賴，任何人可拉 NAS 附件 — 補上 `knowledge-base` 權限檢查
- attachments / assets 端點支援 `?token=` query 參數（`<img src>` / `window.open` 無法設 header 的場景）
- 前端 `previewAttachment` 的 `window.open` fallback 改為 `FileUtils.downloadWithAuth`

### 其他
- 版本 0.8.0 → 0.9.0（pyproject / __init__ / main 三處同步）
- `docs/backend.md` 補 PAT 章節

## 已知邊界（v1 刻意取捨）
- 唯讀攔截只覆蓋掛 `require_app_permission` 的端點；裸用 `get_current_session` 的端點（logout、change-password 等）PAT 仍可呼叫，但各自有自己的防護（需舊密碼等）
- 尚無 PAT 管理 UI，先由 CLI / API 操作；UI 面板列入後續

## 測試
- 新增 `tests/test_api_token.py`（17 案例：hash、scope 交集、過期/停用、last_used 節流、端點防護）
- 本機全套：1195 passed, 12 skipped；coverage 85.16%（gate 85%）

🤖 Generated with [Claude Code](https://claude.com/claude-code)