### PR TITLE
feat(cli): ctos CLI 遠端存取知識庫/圖書館 + ctos-kb skill

### DIFF
--- a/.claude/skills/ctos-kb/SKILL.md
+++ b/.claude/skills/ctos-kb/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: ctos-kb
+description: 透過 ctos CLI 遠端讀取 ching-tech-os（CTOS）知識庫與圖書館。當使用者提到 kb-NNN 編號、要查 CTOS 知識庫 / 圖書館資料、或說「我要開發 kb-XXX 的功能」需要先取得背景資料時使用。
+---
+
+# CTOS 知識庫 / 圖書館查詢
+
+CTOS 知識庫條目以 `kb-NNN` 編號（如 kb-182），存放在部署機上，透過 `ctos` CLI 以 HTTP API 遠端讀取。
+
+## 前置確認
+
+```bash
+ctos --version    # 沒裝：見 cli/README.md（uv tool install）
+ctos whoami       # 沒登入或 token 過期：請使用者執行 ctos login（互動式，需帳密，Claude 不能代跑）
+```
+
+`ctos login` 需要互動輸入帳號密碼，請使用者自己在終端機執行（在 Claude Code 中可用 `! ctos login`）。
+
+## 常用指令
+
+```bash
+# 讀取單一條目（人類可讀格式；--json 完整欄位；--content-only 只要 Markdown 內文）
+ctos kb get kb-182
+ctos kb get kb-182 --json
+
+# 全文搜尋（空白分隔關鍵字 = AND；ripgrep 後端）
+ctos kb search "AI 升級"
+ctos kb search 補助 --scope global --topic CTOS
+
+# 附件
+ctos kb attachments kb-182                  # 列出
+ctos kb attachments kb-182 --download tmp/  # 全部下載到 tmp/
+
+# 圖書館（規格書、型錄、教育訓練等原始檔案）
+ctos lib ls                  # 根目錄分類
+ctos lib ls 技術文件          # 瀏覽子目錄
+ctos lib get 技術文件/規格書.pdf --out tmp/
+```
+
+## 開發工作流（使用者說「我要開發 kb-182 的某功能」時）
+
+1. `ctos kb get kb-182` 取得條目全文與附件清單
+2. 從內容提取關鍵字，`ctos kb search` 找相關條目（規格、決策記錄、先前討論）
+3. 需要規格書 / 型錄時 `ctos lib ls` 瀏覽圖書館
+4. 有 docx / pdf 附件時下載後再讀（docx 可用 officecli 或 python-docx 解析）
+5. 彙整背景後才開始規劃實作
+
+## 注意事項
+
+- **scope 權限**：`scope: personal` 的條目只有 owner 看得到，API 回 404 不代表條目不存在。請使用者確認該條目是否為 global / project scope，或請 owner 調整。
+- token 預設唯讀（不能寫入知識庫）且只有 knowledge-base scope，效期 180 天。401 錯誤＝token 過期，請使用者重新 `ctos login`。
+- 搜尋結果的 `snippet` 是 ripgrep 匹配片段，要全文請再 `kb get`。
+- 服務網址等設定存於 `~/.ctos/config.json`，可用環境變數 `CTOS_URL` / `CTOS_TOKEN` 覆寫（CI / 自動化情境）。

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ ching-tech-os/
 │   └── pyproject.toml
 ├── docker/
 │   └── docker-compose.yml  # PostgreSQL、code-server
+├── cli/                    # ctos CLI（知識庫/圖書館遠端存取）
 ├── data/
 │   └── knowledge/          # 知識庫資料
 ├── docs/                   # 技術文件
@@ -218,6 +219,23 @@ ching-tech-os/
     ├── project.md          # 專案規範
     ├── specs/              # 功能規格
     └── changes/            # 變更提案
+```
+
+## Dev Tools（同事遠端開發）
+
+讓團隊成員在自己的開發機（含 Windows）上讀取 CTOS 資料並參與開發：
+
+| 工具 | 說明 |
+|------|------|
+| [cli/](cli/README.md) | `ctos` CLI — 登入一次換發長效 API token，遠端讀知識庫（`ctos kb get kb-182`）與圖書館（`ctos lib ls`） |
+| [.claude/skills/ctos-kb](.claude/skills/ctos-kb/SKILL.md) | Claude Code skill — 讓 Claude 自動用 ctos CLI 查知識庫，clone repo 即生效 |
+| `Authorization: Bearer ctos_pat_xxx` | 長效 API token（PAT）機制，詳見 [docs/backend.md](docs/backend.md) 的 API Token 章節 |
+
+```bash
+# 同事機器上的最小設定
+uv tool install "git+https://github.com/yazelin/ching-tech-os.git#subdirectory=cli"
+ctos login --url https://ching-tech.ddns.net/ctos
+ctos kb search "關鍵字"
 ```
 
 ## 文件

--- a/backend/src/ching_tech_os/api/files.py
+++ b/backend/src/ching_tech_os/api/files.py
@@ -10,9 +10,11 @@
 API 格式：
 - GET  /api/files/{zone}/{path:path}          - 讀取/預覽檔案
 - GET  /api/files/{zone}/{path:path}/download - 下載檔案
+- GET  /api/files/{zone}/{path:path}/list     - 列出目錄內容（不支援 NAS zone）
 """
 
 import mimetypes
+from datetime import datetime
 from pathlib import Path
 from urllib.parse import quote
 
@@ -20,6 +22,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, status
 from fastapi.responses import Response
 
 from ..models.auth import ErrorResponse, SessionData
+from ..models.files import DirectoryFile, DirectoryListResponse
 from ..services.path_manager import path_manager, StorageZone
 from ..services.smb import (
     create_smb_service,
@@ -273,8 +276,85 @@ async def _read_file_content(
     return content, filename, mime_type
 
 
-# 注意：/download 路由必須放在 /{path:path} 之前，
-# 否則 path:path 會貪婪匹配到 /download
+# 注意：/list、/download 路由必須放在 /{path:path} 之前，
+# 否則 path:path 會貪婪匹配到 /list、/download
+@router.get(
+    "/{zone}/{path:path}/list",
+    response_model=DirectoryListResponse,
+    responses={
+        400: {"model": ErrorResponse, "description": "無效的請求"},
+        401: {"model": ErrorResponse, "description": "未授權"},
+        404: {"model": ErrorResponse, "description": "目錄不存在"},
+    },
+)
+async def list_directory(
+    zone: str,
+    path: str,
+    session: SessionData = Depends(get_session_from_token_or_query),
+) -> DirectoryListResponse:
+    """列出目錄內容（不支援 NAS zone）
+
+    供 CLI 與自動化工具瀏覽 shared://library 等本機掛載區域。
+
+    Args:
+        zone: 儲存區域 (ctos, shared, temp, local)
+        path: 目錄相對路徑（如 library 或 library/技術文件）
+
+    Returns:
+        子目錄與檔案清單（隱藏檔排除）
+    """
+    storage_zone = _validate_zone(zone)
+    _check_path_traversal(path)
+
+    if storage_zone == StorageZone.NAS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="NAS zone 不支援目錄列表",
+        )
+    if not path:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="請指定目錄路徑",
+        )
+
+    try:
+        dir_path = _get_file_path(storage_zone, path)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+    if not dir_path.exists() or not dir_path.is_dir():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"目錄不存在：{path}",
+        )
+
+    dirs: list[str] = []
+    files: list[DirectoryFile] = []
+    for entry in sorted(dir_path.iterdir(), key=lambda p: p.name):
+        if entry.name.startswith("."):
+            continue
+        try:
+            if entry.is_dir():
+                dirs.append(entry.name)
+            else:
+                stat = entry.stat()
+                files.append(
+                    DirectoryFile(
+                        name=entry.name,
+                        size=stat.st_size,
+                        modified_at=datetime.fromtimestamp(stat.st_mtime),
+                    )
+                )
+        except OSError:
+            # 壞掉的 symlink 等異常項目直接略過
+            continue
+
+    return DirectoryListResponse(zone=zone, path=path, dirs=dirs, files=files)
+
+
 @router.get(
     "/{zone}/{path:path}/download",
     responses={

--- a/backend/src/ching_tech_os/models/files.py
+++ b/backend/src/ching_tech_os/models/files.py
@@ -1,0 +1,23 @@
+"""檔案 API 資料模型"""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class DirectoryFile(BaseModel):
+    """目錄中的檔案項目"""
+
+    name: str
+    size: int
+    modified_at: datetime
+
+
+class DirectoryListResponse(BaseModel):
+    """目錄列表回應"""
+
+    success: bool = True
+    zone: str
+    path: str
+    dirs: list[str]
+    files: list[DirectoryFile]

--- a/backend/tests/test_files_list_directory.py
+++ b/backend/tests/test_files_list_directory.py
@@ -1,0 +1,91 @@
+"""Files API 目錄列表端點測試"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from ching_tech_os.api.files import list_directory
+from ching_tech_os.models.auth import SessionData
+
+
+def _session() -> SessionData:
+    now = datetime.now()
+    return SessionData(
+        username="u1",
+        password="",
+        nas_host="h",
+        user_id=1,
+        created_at=now,
+        expires_at=now + timedelta(hours=1),
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_directory_success(tmp_path) -> None:
+    (tmp_path / "技術文件").mkdir()
+    (tmp_path / "產品資料").mkdir()
+    (tmp_path / "規格書.pdf").write_bytes(b"pdf-content")
+    (tmp_path / ".hidden").write_text("x")  # 隱藏檔應排除
+
+    with patch(
+        "ching_tech_os.api.files._get_file_path", return_value=tmp_path
+    ):
+        resp = await list_directory("shared", "library", session=_session())
+
+    assert resp.success is True
+    assert resp.dirs == ["技術文件", "產品資料"] or sorted(resp.dirs) == [
+        "技術文件",
+        "產品資料",
+    ]
+    assert [f.name for f in resp.files] == ["規格書.pdf"]
+    assert resp.files[0].size == len(b"pdf-content")
+
+
+@pytest.mark.asyncio
+async def test_list_directory_errors(tmp_path) -> None:
+    # NAS zone 不支援
+    with pytest.raises(HTTPException) as e:
+        await list_directory("nas", "share/folder", session=_session())
+    assert e.value.status_code == 400
+
+    # 空路徑
+    with pytest.raises(HTTPException) as e:
+        await list_directory("shared", "", session=_session())
+    assert e.value.status_code == 400
+
+    # 路徑穿越
+    with pytest.raises(HTTPException) as e:
+        await list_directory("shared", "library/../etc", session=_session())
+    assert e.value.status_code == 400
+
+    # 目錄不存在
+    with patch(
+        "ching_tech_os.api.files._get_file_path",
+        return_value=tmp_path / "nope",
+    ):
+        with pytest.raises(HTTPException) as e:
+            await list_directory("shared", "library/nope", session=_session())
+    assert e.value.status_code == 404
+
+    # 路徑解析失敗（無效的 shared 來源）
+    with patch(
+        "ching_tech_os.api.files._get_file_path",
+        side_effect=ValueError("無效的共享來源"),
+    ):
+        with pytest.raises(HTTPException) as e:
+            await list_directory("shared", "bogus", session=_session())
+    assert e.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_list_directory_path_is_file(tmp_path) -> None:
+    f = tmp_path / "file.txt"
+    f.write_text("x")
+    with patch("ching_tech_os.api.files._get_file_path", return_value=f):
+        with pytest.raises(HTTPException) as e:
+            await list_directory("shared", "library/file.txt", session=_session())
+    assert e.value.status_code == 404

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,68 @@
+# ctos CLI
+
+ching-tech-os 知識庫 / 圖書館遠端存取 CLI。讓同事在自己的開發機（Windows / macOS / Linux）上讀取 CTOS 的知識庫條目與圖書館檔案，也供 Claude Code 等 AI 工具透過 `ctos-kb` skill 使用。
+
+純 Python 標準函式庫實作，無任何第三方依賴。
+
+## 安裝
+
+需要 Python 3.10+。建議用 [uv](https://docs.astral.sh/uv/)：
+
+```bash
+# 從 clone 下來的 repo 安裝
+uv tool install ./cli
+
+# 或不 clone，直接從 GitHub 安裝（需有 repo 權限）
+uv tool install "git+https://github.com/yazelin/ching-tech-os.git#subdirectory=cli"
+
+# 更新
+uv tool upgrade ctos-cli
+```
+
+沒有 uv 的話 `pipx install ./cli` 也可以。
+
+## 快速開始
+
+```bash
+# 首次設定：登入並換發長效 API token（預設唯讀、knowledge-base scope、180 天）
+ctos login --url https://ching-tech.ddns.net/ctos
+
+# 之後直接用
+ctos whoami
+ctos kb get kb-182
+ctos kb search "AI 升級"
+ctos kb attachments kb-182 --download
+ctos lib ls
+ctos lib get 技術文件/規格書.pdf
+```
+
+`ctos login` 會以帳號密碼登入一次，換發 PAT（personal access token）後立即登出 session；本機只保存 PAT（`~/.ctos/config.json`，權限 600），不保存密碼。
+
+## 指令一覽
+
+| 指令 | 說明 |
+|------|------|
+| `ctos login [--url URL] [--name 名稱] [--expires-days N] [--scope APP]... [--read-write]` | 登入並換發 API token |
+| `ctos logout` | 清除本機 token（伺服器端 token 需另行撤銷） |
+| `ctos whoami` | 顯示目前身份與 token 資訊 |
+| `ctos token list` | 列出自己的 API token（需重新輸入帳密） |
+| `ctos token revoke <id>` | 撤銷 API token（需重新輸入帳密） |
+| `ctos kb get <kb-id> [--json] [--content-only]` | 讀取知識條目 |
+| `ctos kb search <關鍵字> [--scope] [--type] [--category] [--project] [--topic]... [--json]` | 全文搜尋 |
+| `ctos kb attachments <kb-id> [--download [目錄]]` | 列出 / 下載附件 |
+| `ctos lib ls [子路徑] [--json]` | 瀏覽圖書館目錄 |
+| `ctos lib get <路徑> [--out 檔名或目錄]` | 下載圖書館檔案 |
+
+## 環境變數
+
+| 變數 | 說明 |
+|------|------|
+| `CTOS_URL` | 覆寫服務網址 |
+| `CTOS_TOKEN` | 覆寫 API token（CI / 自動化用） |
+| `CTOS_CONFIG` | 覆寫設定檔路徑（預設 `~/.ctos/config.json`） |
+
+## 安全說明
+
+- token 預設唯讀（伺服器端強制：非 GET 請求一律 403）、scope 只含 knowledge-base
+- token 外洩時：`ctos token revoke <id>`，或請管理者把帳號停用
+- `scope: personal` 的知識條目只有 owner 本人讀得到

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "ctos-cli"
+version = "0.1.0"
+description = "ching-tech-os 知識庫 / 圖書館遠端存取 CLI"
+requires-python = ">=3.10"
+readme = "README.md"
+dependencies = []
+
+[project.scripts]
+ctos = "ctos_cli.main:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ctos_cli"]

--- a/cli/src/ctos_cli/__init__.py
+++ b/cli/src/ctos_cli/__init__.py
@@ -1,0 +1,3 @@
+"""ctos CLI — ching-tech-os 知識庫 / 圖書館遠端存取工具"""
+
+__version__ = "0.1.0"

--- a/cli/src/ctos_cli/api.py
+++ b/cli/src/ctos_cli/api.py
@@ -1,0 +1,90 @@
+"""CTOS HTTP API 客戶端（純 stdlib）"""
+
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+class ApiError(Exception):
+    """API 錯誤"""
+
+    def __init__(self, status: int, detail: str):
+        self.status = status
+        self.detail = detail
+        super().__init__(f"HTTP {status}: {detail}")
+
+
+def request(
+    url: str,
+    path: str,
+    *,
+    method: str = "GET",
+    token: str | None = None,
+    json_body: dict | None = None,
+    params: dict | None = None,
+    raw: bool = False,
+):
+    """送出 API 請求
+
+    Args:
+        url: 服務基底網址（如 https://ching-tech.ddns.net/ctos）
+        path: API 路徑（如 /api/knowledge/kb-182）
+        method: HTTP 方法
+        token: Bearer token
+        json_body: JSON request body
+        params: query 參數（值為 list 時展開為重複參數）
+        raw: True 時回傳 bytes，否則解析 JSON
+
+    Returns:
+        dict（JSON）或 bytes（raw=True）
+
+    Raises:
+        ApiError: HTTP 錯誤
+    """
+    full = url.rstrip("/") + path
+    if params:
+        pairs = []
+        for key, value in params.items():
+            if value is None:
+                continue
+            if isinstance(value, (list, tuple)):
+                pairs.extend((key, v) for v in value)
+            else:
+                pairs.append((key, value))
+        if pairs:
+            full += "?" + urllib.parse.urlencode(pairs)
+
+    # 路徑可能含中文，先做百分比編碼（保留 :/?&= 等結構字元）
+    full = urllib.parse.quote(full, safe=":/?&=%+")
+
+    headers = {"Accept": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    data = None
+    if json_body is not None:
+        data = json.dumps(json_body, ensure_ascii=False).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(full, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as e:
+        try:
+            payload = json.loads(e.read().decode("utf-8"))
+            detail = payload.get("detail") or payload.get("error") or str(payload)
+        except Exception:
+            detail = e.reason or str(e)
+        raise ApiError(e.code, detail) from None
+    except urllib.error.URLError as e:
+        print(f"連線失敗：{e.reason}（檢查網址或網路）", file=sys.stderr)
+        sys.exit(2)
+
+    if raw:
+        return body
+    if not body:
+        return {}
+    return json.loads(body.decode("utf-8"))

--- a/cli/src/ctos_cli/config.py
+++ b/cli/src/ctos_cli/config.py
@@ -1,0 +1,64 @@
+"""CLI 設定檔管理
+
+設定存於 ~/.ctos/config.json（chmod 600），可用環境變數覆寫：
+- CTOS_URL：服務網址
+- CTOS_TOKEN：API token
+- CTOS_CONFIG：設定檔路徑
+"""
+
+import json
+import os
+import stat
+from pathlib import Path
+
+
+def config_path() -> Path:
+    """取得設定檔路徑"""
+    custom = os.environ.get("CTOS_CONFIG")
+    if custom:
+        return Path(custom).expanduser()
+    return Path.home() / ".ctos" / "config.json"
+
+
+def load_config() -> dict:
+    """載入設定檔，不存在時回傳空 dict"""
+    path = config_path()
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return {}
+
+
+def save_config(cfg: dict) -> None:
+    """寫入設定檔並限制權限為 600"""
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(cfg, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    try:
+        path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        # Windows 上 chmod 行為有限，略過
+        pass
+
+
+def get_url(cfg: dict | None = None) -> str | None:
+    """取得服務網址（環境變數優先）"""
+    env = os.environ.get("CTOS_URL")
+    if env:
+        return env.rstrip("/")
+    cfg = cfg if cfg is not None else load_config()
+    url = cfg.get("url")
+    return url.rstrip("/") if url else None
+
+
+def get_token(cfg: dict | None = None) -> str | None:
+    """取得 API token（環境變數優先）"""
+    env = os.environ.get("CTOS_TOKEN")
+    if env:
+        return env
+    cfg = cfg if cfg is not None else load_config()
+    return cfg.get("token")

--- a/cli/src/ctos_cli/main.py
+++ b/cli/src/ctos_cli/main.py
@@ -1,0 +1,416 @@
+"""ctos CLI 主程式
+
+用法總覽：
+  ctos login                          登入並換發長效 API token
+  ctos logout                         清除本機 token
+  ctos whoami                         顯示目前身份
+  ctos token list / revoke <id>      管理 API token（需重新輸入帳密）
+  ctos kb get <kb-id>                 讀取知識庫條目
+  ctos kb search <關鍵字>             全文搜尋知識庫
+  ctos kb attachments <kb-id>         列出 / 下載附件
+  ctos lib ls [路徑]                  瀏覽圖書館
+  ctos lib get <路徑>                 下載圖書館檔案
+"""
+
+import argparse
+import getpass
+import json
+import socket
+import sys
+from pathlib import Path
+
+from . import __version__
+from .api import ApiError, request
+from .config import get_token, get_url, load_config, save_config
+
+LIBRARY_ROOT = "library"
+
+
+def _die(msg: str, code: int = 1) -> None:
+    print(msg, file=sys.stderr)
+    sys.exit(code)
+
+
+def _require_url() -> str:
+    url = get_url()
+    if not url:
+        _die("尚未設定服務網址，請先執行：ctos login --url <網址>")
+    return url
+
+
+def _require_token() -> str:
+    token = get_token()
+    if not token:
+        _die("尚未登入，請先執行：ctos login")
+    return token
+
+
+def _api(path: str, **kwargs):
+    """帶 token 的 API 請求，401 時提示重新登入"""
+    url = _require_url()
+    token = _require_token()
+    try:
+        return request(url, path, token=token, **kwargs)
+    except ApiError as e:
+        if e.status == 401:
+            _die("token 無效或已過期，請重新執行：ctos login")
+        _die(f"API 錯誤（HTTP {e.status}）：{e.detail}")
+
+
+def _session_login(url: str) -> tuple[str, str]:
+    """互動式登入，回傳 (session_token, username)"""
+    username = input("帳號：").strip()
+    password = getpass.getpass("密碼：")
+    resp = request(
+        url,
+        "/api/auth/login",
+        method="POST",
+        json_body={"username": username, "password": password},
+    )
+    if not resp.get("success"):
+        _die(f"登入失敗：{resp.get('error', '帳號或密碼錯誤')}")
+    if resp.get("must_change_password"):
+        print("注意：此帳號被要求變更密碼，請先到 web 介面變更後再使用 CLI。")
+    return resp["token"], username
+
+
+def _session_logout(url: str, session_token: str) -> None:
+    try:
+        request(url, "/api/auth/logout", method="POST", token=session_token)
+    except ApiError:
+        pass  # 登出失敗不影響流程
+
+
+# ============================================================
+# auth 子命令
+# ============================================================
+
+
+def cmd_login(args: argparse.Namespace) -> None:
+    cfg = load_config()
+    url = (args.url or get_url(cfg) or input("服務網址（如 https://ching-tech.ddns.net/ctos）：")).strip().rstrip("/")
+    if not url:
+        _die("未提供服務網址")
+
+    session_token, username = _session_login(url)
+
+    default_name = f"{getpass.getuser()}@{socket.gethostname()}"
+    name = args.name or default_name
+    try:
+        resp = request(
+            url,
+            "/api/auth/tokens",
+            method="POST",
+            token=session_token,
+            json_body={
+                "name": name,
+                "scopes": args.scope or ["knowledge-base"],
+                "expires_days": args.expires_days,
+                "read_only": not args.read_write,
+            },
+        )
+    except ApiError as e:
+        _session_logout(url, session_token)
+        _die(f"換發 API token 失敗（HTTP {e.status}）：{e.detail}")
+    finally:
+        _session_logout(url, session_token)
+
+    pat = resp["token"]
+    info = resp.get("info", {})
+    save_config(
+        {
+            "url": url,
+            "token": pat,
+            "username": username,
+            "token_name": info.get("name", name),
+            "token_id": info.get("id"),
+        }
+    )
+    expires = info.get("expires_at") or "永不過期"
+    print(f"登入成功：{username}")
+    print(f"已換發 API token「{info.get('name', name)}」並存入設定檔（效期至 {expires}）")
+    print("之後可直接使用 ctos kb / ctos lib 等指令。")
+
+
+def cmd_logout(_args: argparse.Namespace) -> None:
+    cfg = load_config()
+    if not cfg.get("token"):
+        print("本機沒有已儲存的 token。")
+        return
+    token_id = cfg.get("token_id")
+    cfg.pop("token", None)
+    save_config(cfg)
+    print("已清除本機 token。")
+    if token_id is not None:
+        print(f"注意：伺服器端 token（id={token_id}）仍有效，要撤銷請執行：ctos token revoke {token_id}")
+
+
+def cmd_whoami(_args: argparse.Namespace) -> None:
+    me = _api("/api/user/me")
+    cfg = load_config()
+    print(f"帳號：{me.get('username', cfg.get('username', '?'))}")
+    if me.get("display_name"):
+        print(f"名稱：{me['display_name']}")
+    if me.get("role"):
+        print(f"角色：{me['role']}")
+    print(f"服務：{get_url() or '?'}")
+    if cfg.get("token_name"):
+        print(f"token：{cfg['token_name']}（id={cfg.get('token_id', '?')}）")
+
+
+def cmd_token_list(_args: argparse.Namespace) -> None:
+    url = _require_url()
+    print("管理 API token 需要帳號密碼登入。")
+    session_token, _ = _session_login(url)
+    try:
+        resp = request(url, "/api/auth/tokens", token=session_token)
+        tokens = resp.get("tokens", [])
+        if not tokens:
+            print("沒有任何 API token。")
+            return
+        print(f"{'id':>4}  {'名稱':<30} {'唯讀':<4} {'效期':<22} 最後使用")
+        for t in tokens:
+            ro = "是" if t.get("read_only") else "否"
+            print(
+                f"{t['id']:>4}  {t['name']:<30} {ro:<4} "
+                f"{(t.get('expires_at') or '永久'):<22} {t.get('last_used_at') or '-'}"
+            )
+    finally:
+        _session_logout(url, session_token)
+
+
+def cmd_token_revoke(args: argparse.Namespace) -> None:
+    url = _require_url()
+    print("管理 API token 需要帳號密碼登入。")
+    session_token, _ = _session_login(url)
+    try:
+        request(
+            url,
+            f"/api/auth/tokens/{args.token_id}",
+            method="DELETE",
+            token=session_token,
+        )
+        print(f"已撤銷 token id={args.token_id}")
+    except ApiError as e:
+        _die(f"撤銷失敗（HTTP {e.status}）：{e.detail}")
+    finally:
+        _session_logout(url, session_token)
+
+
+# ============================================================
+# kb 子命令
+# ============================================================
+
+
+def _attachment_api_path(att_path: str) -> str | None:
+    """把知識附件的儲存路徑轉成 API 路徑"""
+    for prefix in ("local://knowledge/", "ctos://knowledge/", "nas://knowledge/"):
+        if att_path.startswith(prefix):
+            return "/api/knowledge/" + att_path[len(prefix):]
+    if att_path.startswith("../assets/"):
+        return "/api/knowledge/assets/" + att_path[len("../assets/"):]
+    return None
+
+
+def cmd_kb_get(args: argparse.Namespace) -> None:
+    kb = _api(f"/api/knowledge/{args.kb_id}")
+    if args.json:
+        print(json.dumps(kb, ensure_ascii=False, indent=2))
+        return
+    if args.content_only:
+        print(kb.get("content", ""))
+        return
+
+    tags = kb.get("tags") or {}
+    print(f"# {kb['id']}: {kb['title']}")
+    print(
+        f"類型 {kb.get('type')} / 分類 {kb.get('category')} / 範圍 {kb.get('scope')}"
+        + (f"（owner: {kb['owner']}）" if kb.get("owner") else "")
+    )
+    if tags.get("topics"):
+        print(f"主題：{', '.join(tags['topics'])}")
+    print(f"作者 {kb.get('author')}；建立 {kb.get('created_at')}；更新 {kb.get('updated_at')}")
+    attachments = kb.get("attachments") or []
+    if attachments:
+        print(f"附件 {len(attachments)} 個（ctos kb attachments {kb['id']} 查看）")
+    print("-" * 60)
+    print(kb.get("content", ""))
+
+
+def cmd_kb_search(args: argparse.Namespace) -> None:
+    params = {
+        "q": args.query,
+        "scope": args.scope,
+        "type": args.type,
+        "category": args.category,
+        "project": args.project,
+        "topics": args.topic or None,
+    }
+    resp = _api("/api/knowledge", params=params)
+    if args.json:
+        print(json.dumps(resp, ensure_ascii=False, indent=2))
+        return
+    items = resp.get("items", [])
+    if not items:
+        print("沒有符合的知識條目。")
+        return
+    print(f"共 {resp.get('total', len(items))} 筆：")
+    for item in items:
+        scope = item.get("scope", "global")
+        owner = f"/{item['owner']}" if item.get("owner") else ""
+        print(f"  {item['id']:<8} [{scope}{owner}] {item['title']}")
+        if item.get("snippet"):
+            snippet = item["snippet"].replace("\n", " ").strip()
+            print(f"           {snippet[:100]}")
+
+
+def cmd_kb_attachments(args: argparse.Namespace) -> None:
+    kb = _api(f"/api/knowledge/{args.kb_id}")
+    attachments = kb.get("attachments") or []
+    if not attachments:
+        print("此條目沒有附件。")
+        return
+
+    if not args.download:
+        for i, att in enumerate(attachments):
+            size = f"（{att['size']}）" if att.get("size") else ""
+            print(f"  [{i}] {att.get('type', 'file')}: {att['path']}{size}")
+        print(f"下載：ctos kb attachments {args.kb_id} --download [目錄]")
+        return
+
+    out_dir = Path(args.download if args.download is not True else ".")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for att in attachments:
+        api_path = _attachment_api_path(att["path"])
+        if api_path is None:
+            print(f"略過（無法辨識路徑格式）：{att['path']}")
+            continue
+        filename = att["path"].split("/")[-1]
+        target = out_dir / filename
+        content = _api(api_path, raw=True)
+        target.write_bytes(content)
+        print(f"已下載：{target}（{len(content)} bytes）")
+
+
+# ============================================================
+# lib 子命令
+# ============================================================
+
+
+def cmd_lib_ls(args: argparse.Namespace) -> None:
+    sub = (args.path or "").strip("/")
+    full = f"{LIBRARY_ROOT}/{sub}" if sub else LIBRARY_ROOT
+    resp = _api(f"/api/files/shared/{full}/list")
+    if args.json:
+        print(json.dumps(resp, ensure_ascii=False, indent=2))
+        return
+    if not resp.get("dirs") and not resp.get("files"):
+        print("（空目錄）")
+        return
+    for d in resp.get("dirs", []):
+        print(f"  {d}/")
+    for f in resp.get("files", []):
+        size_kb = f["size"] / 1024
+        print(f"  {f['name']}  ({size_kb:.1f} KB)")
+
+
+def cmd_lib_get(args: argparse.Namespace) -> None:
+    sub = args.path.strip("/")
+    content = _api(f"/api/files/shared/{LIBRARY_ROOT}/{sub}", raw=True)
+    filename = sub.split("/")[-1]
+    out = Path(args.out) if args.out else Path(filename)
+    if out.is_dir():
+        out = out / filename
+    out.write_bytes(content)
+    print(f"已下載：{out}（{len(content)} bytes）")
+
+
+# ============================================================
+# argparse
+# ============================================================
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ctos",
+        description="ching-tech-os 知識庫 / 圖書館遠端存取 CLI",
+    )
+    parser.add_argument("--version", action="version", version=f"ctos {__version__}")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_login = sub.add_parser("login", help="登入並換發長效 API token")
+    p_login.add_argument("--url", help="服務網址（如 https://ching-tech.ddns.net/ctos）")
+    p_login.add_argument("--name", help="token 名稱（預設 使用者@主機名）")
+    p_login.add_argument("--expires-days", type=int, default=180, help="token 效期天數（預設 180）")
+    p_login.add_argument("--scope", action="append", help="token scope（可重複，預設 knowledge-base）")
+    p_login.add_argument("--read-write", action="store_true", help="允許寫入（預設唯讀）")
+    p_login.set_defaults(func=cmd_login)
+
+    sub.add_parser("logout", help="清除本機 token").set_defaults(func=cmd_logout)
+    sub.add_parser("whoami", help="顯示目前身份").set_defaults(func=cmd_whoami)
+
+    p_token = sub.add_parser("token", help="管理 API token")
+    token_sub = p_token.add_subparsers(dest="token_command", required=True)
+    token_sub.add_parser("list", help="列出 API token").set_defaults(func=cmd_token_list)
+    p_revoke = token_sub.add_parser("revoke", help="撤銷 API token")
+    p_revoke.add_argument("token_id", type=int)
+    p_revoke.set_defaults(func=cmd_token_revoke)
+
+    p_kb = sub.add_parser("kb", help="知識庫")
+    kb_sub = p_kb.add_subparsers(dest="kb_command", required=True)
+
+    p_get = kb_sub.add_parser("get", help="讀取知識條目")
+    p_get.add_argument("kb_id", help="知識 ID（如 kb-182）")
+    p_get.add_argument("--json", action="store_true", help="輸出完整 JSON")
+    p_get.add_argument("--content-only", action="store_true", help="只輸出 Markdown 內容")
+    p_get.set_defaults(func=cmd_kb_get)
+
+    p_search = kb_sub.add_parser("search", help="全文搜尋")
+    p_search.add_argument("query", help="關鍵字（空白分隔 = AND）")
+    p_search.add_argument("--scope", help="global / personal / project")
+    p_search.add_argument("--type", help="knowledge / context / operations / reference")
+    p_search.add_argument("--category", help="technical / business / management")
+    p_search.add_argument("--project", help="專案過濾")
+    p_search.add_argument("--topic", action="append", help="主題過濾（可重複）")
+    p_search.add_argument("--json", action="store_true")
+    p_search.set_defaults(func=cmd_kb_search)
+
+    p_att = kb_sub.add_parser("attachments", help="列出 / 下載附件")
+    p_att.add_argument("kb_id")
+    p_att.add_argument(
+        "--download",
+        nargs="?",
+        const=True,
+        default=None,
+        metavar="目錄",
+        help="下載全部附件到指定目錄（預設目前目錄）",
+    )
+    p_att.set_defaults(func=cmd_kb_attachments)
+
+    p_lib = sub.add_parser("lib", help="圖書館")
+    lib_sub = p_lib.add_subparsers(dest="lib_command", required=True)
+
+    p_ls = lib_sub.add_parser("ls", help="瀏覽圖書館目錄")
+    p_ls.add_argument("path", nargs="?", default="", help="子路徑（如 技術文件）")
+    p_ls.add_argument("--json", action="store_true")
+    p_ls.set_defaults(func=cmd_lib_ls)
+
+    p_lget = lib_sub.add_parser("get", help="下載圖書館檔案")
+    p_lget.add_argument("path", help="檔案路徑（如 技術文件/規格書.pdf）")
+    p_lget.add_argument("--out", help="輸出檔名或目錄")
+    p_lget.set_defaults(func=cmd_lib_get)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_parser().parse_args(argv)
+    try:
+        args.func(args)
+    except KeyboardInterrupt:
+        print("\n已取消。", file=sys.stderr)
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 目的

接續 #151（PAT 機制），交付同事端工具：`ctos` CLI 與 Claude Code skill，完成「同事在自己電腦上讓 Claude 讀 CTOS 知識庫/圖書館」的完整鏈。

## 變更內容

### `cli/` — ctos CLI（純 stdlib，無第三方依賴）
- `ctos login`：帳密登入一次 → 自動換發唯讀 PAT（scope=knowledge-base、180 天）→ 立即登出 session；本機只存 PAT（`~/.ctos/config.json`，chmod 600），不存密碼
- `ctos kb get/search/attachments`：讀條目、ripgrep 全文搜尋、附件下載（四種附件路徑格式都能映射）
- `ctos lib ls/get`：圖書館瀏覽與下載
- `ctos token list/revoke`：token 管理（伺服器端政策：PAT 不能管 PAT，所以這兩個指令會重新要帳密）
- `ctos whoami` / `logout`；環境變數 `CTOS_URL` / `CTOS_TOKEN` / `CTOS_CONFIG` 覆寫
- 安裝：`uv tool install ./cli` 或 `uv tool install "git+...#subdirectory=cli"`（已實測 entry point 可用）

### 後端 — 目錄列表端點
- `GET /api/files/{zone}/{path:path}/list`（放在貪婪路由之前）：列出本機掛載 zone 的目錄，供 `ctos lib ls` 用；NAS zone 不支援；隱藏檔排除；認證與既有 read/download 相同（`get_session_from_token_or_query`）

### `.claude/skills/ctos-kb`
- 使用者提到 kb-NNN / 要查 CTOS 知識庫時引導 Claude 用 ctos CLI；含「login 是互動式要使用者自己跑」「personal scope 條目別人看到 404」等注意事項

### README
- 新增 Dev Tools 章節（同事機器最小設定三行指令）

## 測試
- 後端：新增 `test_files_list_directory.py`；全套 1198 passed；coverage 85.18%（gate 85%）
- CLI：`uv tool install` 實測、`--version`/`--help` smoke test、附件路徑映射單元驗證（四種格式）

🤖 Generated with [Claude Code](https://claude.com/claude-code)