### PR TITLE
docs: ctos-architecture skill + dev-onboarding 指南

### DIFF
--- a/.claude/skills/ctos-architecture/SKILL.md
+++ b/.claude/skills/ctos-architecture/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: ctos-architecture
+description: CTOS（ching-tech-os）架構導覽與改動定位指南。當使用者要在 ching-tech-os 加新功能、新前端 App、新後端內建模組、extends 外部模組，或新增 CTOS AI Skill 時使用。提供「改哪一層」決策樹、內建 App 逐檔 checklist、contributes.yaml 四種貢獻規格，以及 CTOS AI Skill 與 Claude Code skill 的區分。
+---
+
+# CTOS 架構與功能擴充指南
+
+CTOS 是 FastAPI + PostgreSQL（asyncpg + Alembic）+ 原生 JS（IIFE，無框架）的內部平台。
+加功能前先用下面的決策樹定位「要動哪一層」，再照對應 checklist 逐檔處理。
+本 skill 只給骨架；**細節以 repo 內文件為準**，動手前先讀「必讀文件」一節列的檔案。
+
+## 1. 決策樹：功能該放哪一層
+
+```
+這個需求是？
+├─ 修改/擴充既有功能（加欄位、加端點、改 UI）
+│   → 直接改既有模組。先查 docs/module-index.md 的
+│     「常見修改場景速查」定位檔案，不要新開模組。
+│
+├─ 全新的平台功能，所有部署都該有（如知識庫、分享管理這類）
+│   → 內建新 App：在 backend/src/ching_tech_os/modules.py 的
+│     BUILTIN_MODULES 加 entry。見第 2 節 checklist。
+│
+├─ 需要獨立授權 / 獨立版控 / 客戶特定（如 his、law、erpnext）
+│   → extends 外部模組：git submodule + contributes.yaml 宣告，
+│     不修改主系統任何程式碼。見第 3 節。
+│
+└─ 要給 CTOS 的 AI（Bot / AI 助手）新能力（prompt + 工具 + 可選前端 App）
+    → CTOS AI Skill：SKILL.md（frontmatter 含 metadata.ctos /
+      contributes），由 SkillManager 掃描載入。見第 4 節。
+```
+
+判斷補充：
+
+- 模組啟停由 `.env` 的 `ENABLED_MODULES` 控制（`*` 全開，或逗號分隔清單；`core` 永遠啟用）。`modules.py` 的 `is_module_enabled()` 是判斷點。
+- extends 模組裡的工具有三種提供方式（in-process `mcp_tools` / 外部 `mcp_servers` / Skill Script），選擇矩陣在 `docs/extends-module.md` 的「三種工具提供方式的選擇」表格，別憑感覺選。
+
+## 2. 內建新 App 逐檔 checklist
+
+### 2.1 後端
+
+- [ ] `backend/src/ching_tech_os/modules.py`：在 `BUILTIN_MODULES` 加 entry。欄位依 `ModuleInfo` TypedDict：
+  - `id`（必填，模組 ID，同時是 `ENABLED_MODULES` 的 key）
+  - `source: "builtin"`（必填）
+  - `routers`：`RouterSpec` 清單，每筆 `{"module": ".api.xxx", "attr": "router", "kwargs": {...}}`，由 `main.py` 動態註冊
+  - `mcp_module`：如 `".services.mcp.xxx_tools"`（有 MCP 工具才填）
+  - `app_ids` + `app_manifest`：前端 App 清單，每個 app `{"id", "name", "icon"}`，會經 `/api/config/apps` 餵給前端
+  - 視需求：`permission_defaults`、`permission_display_names`、`scheduler_jobs`、`lifespan_startup`
+- [ ] `api/xxx.py`（路由）、`services/xxx.py`（業務邏輯）、`models/xxx.py`（Pydantic 模型）
+- [ ] Migration：`backend/migrations/versions/00X_description.py`（schema 變更一律走 Alembic；`docker/init.sql` 已停用），套用：`cd backend && uv run alembic upgrade head`
+
+### 2.2 前端
+
+- [ ] `frontend/js/xxx.js`：IIFE 模組，需暴露 `open()`（desktop.js lazy-load 後以 `window[globalName].open()` 開啟）
+- [ ] `frontend/css/xxx.css`：樣式。**先讀 `frontend/css/main.css` 的變數定義**，用 `--text-*` / `--bg-*` / `--color-*` 變數，禁止硬編碼色值與 fallback 值
+- [ ] `frontend/js/desktop.js`：
+  - `fallbackApplications` 加 `{ id, name, icon }`（API 失敗時的 fallback；正式清單來自 `/api/config/apps`，由 modules.py 的 `app_manifest` 生成）
+  - `fallbackAppLoaders` 加 `{ src: './js/xxx.js', globalName: 'XxxApp' }`（lazy-load 查表）
+- [ ] `frontend/index.html`（和 `login.html`）：引入 CSS。注意：僅靜態內建資源需引入；lazy-load 的 JS 由 desktop.js 動態注入，不需 `<script>` 標籤。路徑後**不要**加 `?v=` 版本號
+- [ ] `frontend/js/icons.js`：如需新圖示，在 `Icons` 物件加 SVG（Material Design Icons）。使用時 `getIcon()` 必須包在 `<span class="icon">` 內
+
+### 2.3 收尾
+
+- [ ] `docs/module-index.md`：更新模組地圖（後端/前端對應表）
+- [ ] 子路徑部署檢查：HTML 屬性裡的 `/api/...`（`href` / `src` / `window.open`）要加 `${window.API_BASE || ''}`，詳見 CLAUDE.md「子路徑部署」一節
+- [ ] 版本號如要 bump，三處同步：`backend/pyproject.toml`、`src/ching_tech_os/__init__.py`、`main.py` 的 FastAPI `version`
+
+## 3. extends 外部模組：contributes.yaml 四種貢獻
+
+主系統啟動時掃描 `extends/*/contributes.yaml` 自動整合，模組**不需要也不應該**改主系統程式碼。`module_id` 對應 `ENABLED_MODULES`；不設定則永遠啟用。
+
+### 3.1 四種貢獻的精確 YAML 規格
+
+```yaml
+module_id: my-module
+
+# (1) in-process MCP 工具：路徑相對模組根目錄，
+#     檔內用 @mcp.tool() 向主系統 FastMCP 註冊；
+#     需 DB 時先 await ensure_db_connection()
+mcp_tools: core/mcp_tools.py
+
+# (2) 外部 MCP Server：獨立進程、stdio 通訊，
+#     ${PROJECT_ROOT} 自動替換為專案根目錄
+mcp_servers:
+  server-name:
+    command: bash
+    args: ["-c", "set -a && source ${PROJECT_ROOT}/.env && set +a && uvx some-mcp"]
+
+# (3) 生命週期：主系統啟動/關閉時執行，
+#     callable 是相對模組根目錄的 import 路徑（sync/async 皆可），
+#     kwargs 的 ${ENV_VAR} 自動替換環境變數
+lifespan:
+  startup:
+    callable: core.some_module.start
+    kwargs:
+      param1: ${ENV_VAR}
+      param2: 30
+  shutdown:
+    callable: core.some_module.stop
+
+# (4) API 路由：把模組的 FastAPI Router 註冊進主系統，
+#     module 是 import 路徑（模組根目錄已在 sys.path）
+routers:
+  - module: my_router
+    attr: router
+    kwargs:
+      prefix: /api/my-module
+      tags: [my-module]
+```
+
+### 3.2 現成範例模組對照表
+
+| 模組 | 使用欄位 | 工具提供方式 | 參考重點 |
+|------|---------|------------|---------|
+| `extends/voice` | `module_id` + `lifespan` + `routers` | 主系統 in-process MCP 工具 | lifespan 預載 Whisper 模型；routers 掛 `/api/voice` TTS 下載 API |
+| `extends/printer` | `module_id` + `mcp_servers` | 外部 MCP Server（`uvx printer-mcp`） | 最小 mcp_servers 範例 |
+| `extends/his` | `module_id` + `lifespan`（含 `${CTHIS_DATA_PATH}` kwargs） | Skill Script（不用 in-process MCP） | lifespan 背景輪詢 DBF + `skills/*/SKILL.md` 帶前端 App 貢獻 |
+
+另：`extends/law` 是 `module_id` + `mcp_tools`（in-process）的範例，見 `docs/extends-module.md` 的「現有模組參考」表。
+
+注意：模組**根目錄**的 SKILL.md 只是說明文件，SkillManager 不掃描；會被載入的是 `extends/{module}/skills/{name}/SKILL.md`。
+
+## 4. CTOS AI Skill 不是 Claude Code skill
+
+兩者同名 SKILL.md，是**完全不同的東西**，別混：
+
+| | CTOS AI Skill | Claude Code skill |
+|---|---|---|
+| 給誰用 | CTOS 平台內的 AI（Bot、AI 助手） | 開發者本機的 Claude Code |
+| 位置 | `backend/.../skills/`、`extends/*/skills/{name}/`、外部 `~/SDD/external-skills/` | `.claude/skills/`（本檔就是一個） |
+| 載入者 | CTOS 的 SkillManager | Claude Code CLI |
+
+CTOS AI Skill 的 frontmatter（規格見 `docs/extends-module.md`）：
+
+```yaml
+---
+name: skill-name
+description: 一句話描述
+allowed-tools: "tool_a tool_b"        # 空格分隔，控制此 Skill 可用哪些已註冊 MCP 工具
+metadata:
+  ctos:
+    requires_app: app-id              # 需要的前端 App 權限（null = 不需要）
+    mcp_servers: ""                   # 需要的外部 MCP Server（空格分隔）
+  contributes:                        # 可選：向主系統貢獻前端 App / 權限
+    app:
+      id: app-id
+      name: 顯示名稱
+      icon: mdi-xxx
+      loader:
+        src: frontend/xxx-app.js      # 相對 skill 目錄，由 modules.py 轉成 /api/skills/... 路徑
+        globalName: XxxApp
+      css: frontend/xxx-app.css
+    permissions:
+      app-id:
+        default: false
+        display_name: 顯示名稱
+---
+```
+
+分工：`contributes.yaml` 的 `mcp_tools` 負責**載入註冊**工具；SKILL.md 的 `allowed-tools` 負責控制 AI 在該情境**可以用哪些**。一個模組可有多個 Skill，各開放不同工具子集。實例參考 `extends/his/skills/his-integration/SKILL.md`（contributes.app + permissions 完整範例）。
+
+## 5. 必讀文件指引
+
+| 時機 | 讀什麼 |
+|------|--------|
+| 動任何功能前（定位檔案） | `docs/module-index.md` |
+| 開發 extends 模組 / CTOS AI Skill | `docs/extends-module.md`（contributes.yaml 完整規格、Skill Script 模式、多租戶、驗證指令、常見問題） |
+| 寫程式前的專案規範（migration、版本號三處同步、CSS 變數、子路徑部署、圖示規則） | 根目錄 `CLAUDE.md` |
+| 測試與 CI 門檻 | `docs/testing-ci.md`、`.github/workflows/backend-tests.yml` |
+
+本 skill 刻意精簡——上表文件才是單一事實來源，規格細節（完整欄位、錯誤排查）一律回到 repo 文件查證，不要憑本 skill 的摘要硬寫。

--- a/docs/dev-onboarding.md
+++ b/docs/dev-onboarding.md
@@ -1,0 +1,195 @@
+# 開發環境上手指南（Dev Onboarding）
+
+> 給新加入 CTOS 開發的同事。目標：從零到本機跑起後端 + 資料庫 + 前端。
+> 本文件只講「跑起來」；架構與改動定位請接著讀 `docs/module-index.md` 與 `docs/extends-module.md`。
+
+## 1. 系統需求
+
+CTOS 的開發腳本（`scripts/*.sh`）與工具鏈以 Linux 為準：
+
+- **Windows 機器**：請使用 **WSL2**（建議 Ubuntu）+ **Docker Desktop**（設定中開啟 WSL2 backend 與對應 distro 的 WSL Integration）。所有指令都在 WSL2 終端機內執行。
+- **原生 Linux（Ubuntu/Debian）**：直接照 README 安裝。
+
+必要工具（版本依 `README.md`）：
+
+| 工具 | 最低版本 | 用途 |
+|------|---------|------|
+| Git | latest | 版本控制（含 submodule） |
+| Python | 3.11+ | 後端（由 uv 管理） |
+| uv | latest | Python 套件管理 |
+| Node.js | 20+（建議 nvm 裝） | 前端建置（esbuild） |
+| Docker + Compose v2 | latest | PostgreSQL 16、code-server 容器 |
+
+可選但建議：`gh`（GitHub CLI）。NAS 相關功能另需系統套件 `cifs-utils`、`smbclient`、`ripgrep`、`psmisc`（見 README「系統套件」一節；開發機沒接公司 NAS 也能跑主系統，相關功能不可用而已）。
+
+安裝指令請直接照根目錄 `README.md` 的「安裝指令」區塊執行（uv、nvm、Docker、Claude Code 等）。
+
+## 2. Clone 專案與 submodule
+
+```bash
+git clone --recurse-submodules https://github.com/yazelin/ching-tech-os.git
+cd ching-tech-os
+```
+
+### 沒有 private submodule 權限怎麼辦
+
+`.gitmodules` 中有三個 **private** submodule：
+
+- `extends/his`（ching-tech-his）
+- `extends/erpnext`（ching-tech-erpnext）
+- `extends/law`（ching-tech-law）
+
+沒有權限時 `--recurse-submodules` 會對拿不到的 repo 報錯。改成先普通 clone，再**逐個**初始化拿得到的：
+
+```bash
+git clone https://github.com/yazelin/ching-tech-os.git
+cd ching-tech-os
+# 有哪個 repo 的權限就初始化哪個，沒有的直接跳過
+git submodule update --init extends/his
+git submodule update --init extends/law
+git submodule update --init extends/erpnext
+```
+
+**跳過拿不到的 submodule 不影響主系統**：主系統啟動時掃描 `extends/*/contributes.yaml`，目錄是空的就不會載入該模組；另外 `.env` 的 `ENABLED_MODULES` 也能明確控制啟用哪些模組（見下一節）。`extends/voice` 與 `extends/printer` 是主 repo 內的原生目錄，不是 submodule，所有人都拿得到。
+
+## 3. `.env` 設定
+
+```bash
+cp .env.example .env
+```
+
+**最小可跑的必填項**（資料庫連線，需與 `docker/docker-compose.yml` 的環境變數一致）：
+
+```bash
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=ching_tech
+DB_PASSWORD=（自訂一組本機開發密碼）
+DB_NAME=ching_tech_os
+```
+
+docker compose 會用同一份 `.env` 的 `DB_USER` / `DB_PASSWORD` / `DB_NAME` 初始化 PostgreSQL 容器，所以後端與容器自然一致。
+
+其餘項目首次上手**可以維持範本值或留空**，對應功能不可用但主系統照常啟動：
+
+- `NAS_*`：檔案管理、知識庫附件等 NAS 功能（開發機沒 NAS 就先不管）
+- `LINE_*` / `TELEGRAM_*`：Bot 整合
+- `GEMINI_API_KEY`、`NANOBANANA_*`、`HUGGINGFACE_API_TOKEN` 等：AI 圖片/語音功能
+- `ERPNEXT_*`：ERPNext 整合
+
+建議開發機把模組範圍縮小，啟動更快、雜訊更少：
+
+```bash
+ENABLED_MODULES=core,knowledge-base,file-manager,ai-agent,skills
+```
+
+可用模組清單與說明見 `.env.example` 的「系統設定」區塊。
+
+**注意**：`.env.example` 中 `FRONTEND_DIR`、`PROJECT_ATTACHMENTS_PATH` 預設寫的是 `/home/ct/SDD/ching-tech-os/...`，請改成你自己的 repo 路徑。
+
+**安全規則**：`.env` 已在 `.gitignore`，任何真實密碼、token 都不准寫進文件或 commit。
+
+## 4. 啟動
+
+### 一鍵（建議）
+
+```bash
+./scripts/start.sh dev
+```
+
+會依序：啟動 Docker 服務（PostgreSQL + code-server）→ `uv sync`（首次）→ `alembic upgrade head` → 以 `--reload` 啟動後端於 8088 port。
+
+### 分步（理解每一步在做什麼）
+
+```bash
+# 1. 啟動資料庫（與 code-server）
+cd docker && docker compose up -d && cd ..
+
+# 2. 安裝後端依賴 + migration
+cd backend
+uv sync
+uv run alembic upgrade head
+
+# 3. 啟動後端
+uv run uvicorn ching_tech_os.main:socket_app --host 0.0.0.0 --port 8088
+```
+
+前端建置與啟動（另開終端）：
+
+```bash
+# 根目錄與 frontend 各有 package.json
+npm install            # 根目錄：esbuild 建置工具
+cd frontend && npm install && cd ..
+npm run build          # 即 node scripts/build-frontend.mjs
+
+# 簡易靜態伺服器
+cd frontend && python3 -m http.server 8080
+```
+
+瀏覽器開 `http://localhost:8080`。API 文件在 `http://localhost:8088/docs`（Swagger）/ `http://localhost:8088/redoc`。
+
+## 5. 預設 admin 帳號
+
+預設管理員由 migration `backend/migrations/versions/007_seed_admin_user.py` 建立：使用者名稱 `ct`、角色 `admin`、**首次登入強制變更密碼**（`must_change_password = TRUE`）。
+
+預設密碼請**向管理者索取**，或自行查看 007 migration 內容。本文件不記載密碼。登入後可在「使用者管理」建立自己的帳號。
+
+## 6. 測試與 CI
+
+### 本機跑測試
+
+```bash
+cd backend && uv run pytest
+
+# 單一檔案 / 關鍵字
+uv run pytest tests/test_bot_api_routes.py -v
+uv run pytest -k permissions -v
+
+# 含 coverage（根目錄）
+npm run test:backend:cov
+
+# push 前完整檢查（前端 build + 後端 coverage）
+npm run ci:check
+```
+
+### CI（`.github/workflows/backend-tests.yml`）
+
+- 觸發：push 到 `main`、PR 到 `main`、手動 dispatch
+- 內容：Python 3.11 + `uv sync` + pytest coverage
+- **CI coverage 門檻：85%**（workflow 的 `COVERAGE_FAIL_UNDER: "85"`，以 `--cov-fail-under` 強制）；CI 會 `--ignore=tests/test_his`（his 是 private submodule，CI 環境拿不到）
+- 注意：本機 `npm run test:backend:cov` 的門檻是 90%，比 CI 嚴，過了本機就不會卡 CI
+
+### PR 流程
+
+`main` 不直接 push。流程：
+
+1. 從**最新的** `main` 開短命 branch
+2. 開發、本機 `npm run ci:check` 通過
+3. 開 PR → CI 綠 → merge
+4. merge 後即刪 branch，下一件事再從新的 main 開新 branch
+
+```bash
+git push origin <branch-name>
+gh run list --limit 5      # 確認 CI 狀態
+```
+
+## 7. 常見坑
+
+| 坑 | 說明 / 解法 |
+|----|------------|
+| repo 放在 `/mnt/c/...`（Windows 路徑） | WSL2 跨檔案系統 I/O 極慢且檔案監看不可靠。repo 請 clone 在 WSL2 自己的檔案系統（如 `~/SDD/ching-tech-os`） |
+| Line endings（CRLF） | `scripts/*.sh` 是 bash 腳本，被 Windows 工具改成 CRLF 會出現 `bad interpreter` 之類錯誤。在 WSL2 內設 `git config --global core.autocrlf input`，編輯器用 LF |
+| Docker 沒啟動 | 後端啟動報資料庫連線錯誤時，先確認 Docker Desktop 在跑、WSL Integration 有開，再 `cd docker && docker compose ps` 確認 `ching-tech-os-db` 是 running |
+| Port 衝突 | 預設佔用 5432（DB）、8443（code-server）、8088（後端）、8080（前端）。DB 與 code-server 的 port 可在 `.env` 用 `DB_PORT` / `CODE_PORT` 改 |
+| code-server 掛載路徑 | `docker/docker-compose.yml` 把 `${HOME}/SDD` 掛進容器、工作目錄設 `/home/coder/SDD/ching-tech-os`。repo 不在 `~/SDD/` 下時 code-server 會看不到專案（不影響主系統，可忽略或自行調整 compose） |
+| `.env` 範本路徑 | `FRONTEND_DIR`、`PROJECT_ATTACHMENTS_PATH` 預設是 `/home/ct/...`，忘記改會找不到前端目錄 |
+| submodule 目錄是空的 | 表示該 submodule 沒初始化。有權限就 `git submodule update --init extends/<name>`；沒權限就確認 `ENABLED_MODULES` 沒列到對應模組即可 |
+| voice 模組裝不起來 | 語音模組需要額外依賴：`uv sync --extra voice`（見 `.env.example` 模組清單註記） |
+| migration 沒跑 | 啟動後 API 報表格不存在 → `cd backend && uv run alembic upgrade head`。schema 變更一律走 Alembic，`docker/init.sql` 已停用 |
+
+## 下一步
+
+- 架構與「改哪些檔」：`docs/module-index.md`
+- extends 外部模組開發：`docs/extends-module.md`
+- 專案規範（migration、版本號、CSS 變數、子路徑部署）：根目錄 `CLAUDE.md`
+- 測試與 CI 細節：`docs/testing-ci.md`


### PR DESCRIPTION
## 目的

Dev Tools 系列第三件：讓同事（與同事機器上的 Claude）看懂 CTOS 架構、能自己上手開發。

## 變更內容

- `.claude/skills/ctos-architecture/SKILL.md`：架構導覽 skill — 「改哪一層」決策樹（改既有 / 內建 App / extends 模組 / CTOS AI Skill）、內建 App 逐檔 checklist（ModuleInfo TypedDict 欄位、前端 IIFE + desktop.js 註冊）、contributes.yaml 四種貢獻規格與 voice/printer/his 範例對照、CTOS AI Skill vs Claude Code skill 區分
- `docs/dev-onboarding.md`：新同事上手指南 — WSL2/Docker 需求、private submodule 的 clone 策略（沒權限跳過不影響主系統）、.env 最小必填、啟動步驟、admin 帳號（指向 007 migration，不含密碼）、測試與 CI（85% 門檻）、常見坑

兩份內容皆出自實際讀取 repo 檔案（modules.py、docs/extends-module.md、desktop.js、workflow 檔等），純新增檔案、不動既有檔案。

附帶發現：CI workflow 門檻是 85%，但 docs/testing-ci.md 與根目錄 package.json 寫 90%（本機較嚴），onboarding 以 workflow 為準並註明差異。

🤖 Generated with [Claude Code](https://claude.com/claude-code)