### PR TITLE
fix(cli): 非互動環境登入支援（--username + CTOS_PASSWORD）

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -38,11 +38,21 @@ ctos lib get 技術文件/規格書.pdf
 
 `ctos login` 會以帳號密碼登入一次，換發 PAT（personal access token）後立即登出 session；本機只保存 PAT（`~/.ctos/config.json`，權限 600），不保存密碼。
 
+### 非互動環境登入
+
+`ctos login` 預設互動輸入帳密，**沒有終端機輸入的環境**（CI、Claude Code 的 `!` 指令等）請改用：
+
+```bash
+CTOS_PASSWORD=<密碼> ctos login --url https://ching-tech.ddns.net/ctos --username <帳號>
+```
+
+密碼只從環境變數讀取、不接受命令列參數（避免留在 shell history 與 process list）。
+
 ## 指令一覽
 
 | 指令 | 說明 |
 |------|------|
-| `ctos login [--url URL] [--name 名稱] [--expires-days N] [--scope APP]... [--read-write]` | 登入並換發 API token |
+| `ctos login [--url URL] [--username 帳號] [--name 名稱] [--expires-days N] [--scope APP]... [--read-write]` | 登入並換發 API token |
 | `ctos logout` | 清除本機 token（伺服器端 token 需另行撤銷） |
 | `ctos whoami` | 顯示目前身份與 token 資訊 |
 | `ctos token list` | 列出自己的 API token（需重新輸入帳密） |
@@ -59,6 +69,7 @@ ctos lib get 技術文件/規格書.pdf
 |------|------|
 | `CTOS_URL` | 覆寫服務網址 |
 | `CTOS_TOKEN` | 覆寫 API token（CI / 自動化用） |
+| `CTOS_PASSWORD` | 非互動登入用密碼（只在 `ctos login` / `ctos token` 時讀取） |
 | `CTOS_CONFIG` | 覆寫設定檔路徑（預設 `~/.ctos/config.json`） |
 
 ## 安全說明

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctos-cli"
-version = "0.1.0"
+version = "0.1.1"
 description = "ching-tech-os 知識庫 / 圖書館遠端存取 CLI"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/cli/src/ctos_cli/__init__.py
+++ b/cli/src/ctos_cli/__init__.py
@@ -1,3 +1,3 @@
 """ctos CLI — ching-tech-os 知識庫 / 圖書館遠端存取工具"""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/cli/src/ctos_cli/main.py
+++ b/cli/src/ctos_cli/main.py
@@ -15,6 +15,7 @@
 import argparse
 import getpass
 import json
+import os
 import socket
 import sys
 from pathlib import Path
@@ -57,10 +58,25 @@ def _api(path: str, **kwargs):
         _die(f"API 錯誤（HTTP {e.status}）：{e.detail}")
 
 
-def _session_login(url: str) -> tuple[str, str]:
-    """互動式登入，回傳 (session_token, username)"""
-    username = input("帳號：").strip()
-    password = getpass.getpass("密碼：")
+def _session_login(url: str, username: str | None = None) -> tuple[str, str]:
+    """登入並回傳 (session_token, username)
+
+    帳號優先序：參數（--username）> 互動輸入
+    密碼優先序：環境變數 CTOS_PASSWORD > 互動輸入（getpass）
+    沒有互動式終端機（如 CI、Claude Code 的 ! 指令）時給出明確指引。
+    """
+    try:
+        if not username:
+            username = input("帳號：").strip()
+        password = os.environ.get("CTOS_PASSWORD") or getpass.getpass("密碼：")
+    except EOFError:
+        _die(
+            "無法互動輸入帳密（目前環境沒有終端機輸入）。\n"
+            "請改在一般終端機執行，或改用非互動方式：\n"
+            "  CTOS_PASSWORD=<密碼> ctos login --username <帳號> [--url <網址>]"
+        )
+    if not username:
+        _die("未提供帳號")
     resp = request(
         url,
         "/api/auth/login",
@@ -88,11 +104,17 @@ def _session_logout(url: str, session_token: str) -> None:
 
 def cmd_login(args: argparse.Namespace) -> None:
     cfg = load_config()
-    url = (args.url or get_url(cfg) or input("服務網址（如 https://ching-tech.ddns.net/ctos）：")).strip().rstrip("/")
+    url = args.url or get_url(cfg)
+    if not url:
+        try:
+            url = input("服務網址（如 https://ching-tech.ddns.net/ctos）：")
+        except EOFError:
+            _die("未提供服務網址，請加 --url <網址>")
+    url = url.strip().rstrip("/")
     if not url:
         _die("未提供服務網址")
 
-    session_token, username = _session_login(url)
+    session_token, username = _session_login(url, username=args.username)
 
     default_name = f"{getpass.getuser()}@{socket.gethostname()}"
     name = args.name or default_name
@@ -340,6 +362,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_login = sub.add_parser("login", help="登入並換發長效 API token")
     p_login.add_argument("--url", help="服務網址（如 https://ching-tech.ddns.net/ctos）")
+    p_login.add_argument("--username", help="帳號（非互動環境用，密碼走環境變數 CTOS_PASSWORD）")
     p_login.add_argument("--name", help="token 名稱（預設 使用者@主機名）")
     p_login.add_argument("--expires-days", type=int, default=180, help="token 效期天數（預設 180）")
     p_login.add_argument("--scope", action="append", help="token scope（可重複，預設 knowledge-base）")


### PR DESCRIPTION
在 Claude Code 的 `!` 指令、CI 等沒有 stdin 的環境跑 `ctos login` 會直接 EOFError traceback（實測踩到）。

- `ctos login --username <帳號>` + 環境變數 `CTOS_PASSWORD` 支援非互動登入；密碼不接受命令列參數（避免 shell history / process list 洩漏）
- stdin 不可用時印明確指引取代 traceback（帳密與網址兩個 input 點都處理）
- `ctos token list/revoke` 共用同一登入路徑，自動受惠
- CLI 0.1.1；README 補非互動章節

驗證：`ctos login </dev/null` 與 `ctos login --url x --username y </dev/null` 皆回指引訊息、exit 1，不再 traceback。

🤖 Generated with [Claude Code](https://claude.com/claude-code)