### PR TITLE
fix(knowledge): personal 條目補齊條目層級權限（讀取路徑 + MCP 工具）

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ching-tech-os"
-version = "0.9.0"
+version = "0.9.1"
 description = "Ching Tech OS Backend"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/src/ching_tech_os/__init__.py
+++ b/backend/src/ching_tech_os/__init__.py
@@ -1,3 +1,3 @@
 """Ching Tech OS Backend"""
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/backend/src/ching_tech_os/api/knowledge.py
+++ b/backend/src/ching_tech_os/api/knowledge.py
@@ -1,6 +1,7 @@
 """知識庫 API"""
 
 import mimetypes
+import re
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
@@ -42,6 +43,60 @@ from ching_tech_os.api.auth import get_current_session
 from ching_tech_os.models.auth import SessionData
 
 router = APIRouter(prefix="/api/knowledge", tags=["knowledge"])
+
+# 附件/asset 路徑中的知識 ID 樣式
+_ATTACHMENT_KB_ID_RE = re.compile(r"^kb-\d+$")
+_ASSET_KB_ID_RE = re.compile(r"^(kb-\d+)-")
+
+
+async def _ensure_read_access(kb: KnowledgeResponse, session: SessionData) -> None:
+    """檢查讀取權限，無權限時回 404（不洩漏 personal 條目的存在）
+
+    語意與 search_knowledge 的過濾一致：personal 條目僅 owner（與 admin）可讀，
+    global / project 條目所有人可讀。
+    """
+    preferences = await get_user_preferences(session.user_id) if session.user_id else None
+    allowed = await check_knowledge_permission_async(
+        session.role,
+        session.username,
+        preferences,
+        kb.owner,
+        kb.scope,
+        "read",
+        user_id=session.user_id,
+        project_id=kb.project_id,
+    )
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"知識 {kb.id} 不存在",
+        )
+
+
+async def _get_knowledge_with_read_access(kb_id: str, session: SessionData) -> KnowledgeResponse:
+    """取得知識並檢查讀取權限（404 統一處理）"""
+    try:
+        kb = get_knowledge(kb_id)
+    except KnowledgeNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"知識 {kb_id} 不存在",
+        )
+    await _ensure_read_access(kb, session)
+    return kb
+
+
+async def _check_attachment_read_access(kb_id: str, session: SessionData) -> None:
+    """附件下載前檢查所屬知識的讀取權限
+
+    找不到對應知識條目（孤兒檔案）時維持舊行為放行，
+    由檔案系統層自然回 404。
+    """
+    try:
+        kb = get_knowledge(kb_id)
+    except (KnowledgeNotFoundError, KnowledgeError):
+        return
+    await _ensure_read_access(kb, session)
 
 
 @router.get(
@@ -135,8 +190,12 @@ async def get_attachment(
     """代理取得 NAS 上的附件
 
     Args:
-        path: 附件路徑（不含 nas://knowledge/ 前綴）
+        path: 附件路徑（不含 nas://knowledge/ 前綴，格式 attachments 下為 {kb_id}/{filename}）
     """
+    # 附件路徑第一段為知識 ID 時，檢查所屬知識的讀取權限（personal 條目限 owner）
+    first_segment = path.split("/")[0]
+    if _ATTACHMENT_KB_ID_RE.match(first_segment):
+        await _check_attachment_read_access(first_segment, session)
     try:
         content = get_nas_attachment(path)
         filename = path.split("/")[-1]
@@ -168,6 +227,12 @@ async def get_local_asset(
         path: 附件路徑（如 images/kb-001-file.png）
     """
     from pathlib import Path
+
+    # 檔名以知識 ID 開頭時，檢查所屬知識的讀取權限（personal 條目限 owner）
+    filename_part = path.split("/")[-1]
+    kb_id_match = _ASSET_KB_ID_RE.match(filename_part)
+    if kb_id_match:
+        await _check_attachment_read_access(kb_id_match.group(1), session)
 
     # 安全檢查：防止路徑穿越攻擊
     if ".." in path:
@@ -212,16 +277,15 @@ async def get_single_knowledge(
 ) -> KnowledgeResponse:
     """取得單一知識的完整內容與元資料
 
+    personal 條目僅 owner（與 admin）可讀，其他人回 404。
+
     Args:
         kb_id: 知識 ID（如 kb-001）
     """
     try:
-        return get_knowledge(kb_id)
-    except KnowledgeNotFoundError:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"知識 {kb_id} 不存在",
-        )
+        return await _get_knowledge_with_read_access(kb_id, session)
+    except HTTPException:
+        raise
     except KnowledgeError as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -411,6 +475,7 @@ async def get_knowledge_history(
 
     使用 git log --follow 追蹤檔案歷史（含重命名）。
     """
+    await _get_knowledge_with_read_access(kb_id, session)
     try:
         return get_history(kb_id)
     except KnowledgeNotFoundError:
@@ -439,6 +504,7 @@ async def get_knowledge_version(
 
     使用 git show 取得該版本的檔案內容。
     """
+    await _get_knowledge_with_read_access(kb_id, session)
     try:
         return get_version(kb_id, commit)
     except KnowledgeNotFoundError:

--- a/backend/src/ching_tech_os/main.py
+++ b/backend/src/ching_tech_os/main.py
@@ -311,7 +311,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Ching Tech OS API",
-    version="0.9.0",
+    version="0.9.1",
     lifespan=lifespan,
 )
 

--- a/backend/src/ching_tech_os/services/mcp/knowledge_tools.py
+++ b/backend/src/ching_tech_os/services/mcp/knowledge_tools.py
@@ -15,6 +15,60 @@ from .server import (
 from ...database import get_connection
 
 
+async def _check_item_access(item, ctos_user_id: int | None, action: str) -> str | None:
+    """檢查對單一知識條目的存取權限（條目層級，工具層級權限另由 check_mcp_tool_permission 處理）
+
+    語意與 web API / search_knowledge 一致：
+    - 未綁定用戶：僅可讀 scope=global 且 is_public 的條目，不可寫
+    - 綁定用戶：走 check_knowledge_permission_async（personal 限 owner、
+      global/project 可讀、write/delete 需 owner 或 global_write/global_delete）
+
+    Args:
+        item: KnowledgeResponse（含 id/scope/owner/project_id/is_public）
+        ctos_user_id: CTOS 用戶 ID（None 表示未綁定）
+        action: read / write / delete
+
+    Returns:
+        None 表示允許；否則回傳給使用者的錯誤訊息
+        （read 被拒時回「找不到」，不洩漏 personal 條目的存在）
+    """
+    not_found_msg = f"找不到知識 {item.id}"
+
+    if ctos_user_id is None:
+        if action == "read" and item.scope == "global" and getattr(item, "is_public", False):
+            return None
+        if action == "read":
+            return not_found_msg
+        return "❌ 此操作需要綁定 CTOS 帳號"
+
+    async with get_connection() as conn:
+        user_row = await conn.fetchrow(
+            "SELECT username, role, preferences FROM users WHERE id = $1",
+            ctos_user_id,
+        )
+    if user_row is None:
+        return not_found_msg if action == "read" else "❌ 找不到您的帳號"
+
+    from ..permissions import check_knowledge_permission_async
+    from ..user import _parse_preferences
+
+    allowed = await check_knowledge_permission_async(
+        user_row["role"] or "user",
+        user_row["username"],
+        _parse_preferences(user_row["preferences"]),
+        item.owner,
+        item.scope,
+        action,
+        user_id=ctos_user_id,
+        project_id=item.project_id,
+    )
+    if allowed:
+        return None
+    if action == "read":
+        return not_found_msg
+    return f"❌ 您沒有{'刪除' if action == 'delete' else '編輯'}知識 {item.id} 的權限"
+
+
 async def _determine_knowledge_scope(
     line_group_id: str | None,
     line_user_id: str | None,
@@ -187,6 +241,11 @@ async def get_knowledge_item(
     try:
         item = kb_service.get_knowledge(kb_id)
 
+        # 條目層級權限：personal 條目限 owner
+        access_err = await _check_item_access(item, ctos_user_id, "read")
+        if access_err:
+            return access_err
+
         # 格式化輸出
         tags_str = ", ".join(item.tags.topics) if item.tags.topics else "無標籤"
         output = [
@@ -293,6 +352,12 @@ async def update_knowledge_item(
             tags=tags,
         )
 
+        # 條目層級權限：personal 條目限 owner 編輯
+        existing = kb_service.get_knowledge(kb_id)
+        access_err = await _check_item_access(existing, ctos_user_id, "write")
+        if access_err:
+            return access_err
+
         item = kb_service.update_knowledge(kb_id, update_data)
 
         scope_info = f"（{item.scope}）" if item.scope else ""
@@ -337,6 +402,11 @@ async def add_attachments_to_knowledge(
         knowledge = kb_service.get_knowledge(kb_id)
     except Exception:
         return f"找不到知識 {kb_id}"
+
+    # 條目層級權限：personal 條目限 owner 加附件
+    access_err = await _check_item_access(knowledge, ctos_user_id, "write")
+    if access_err:
+        return access_err
 
     # 取得目前附件數量（用來計算新附件的 index）
     current_attachment_count = len(knowledge.attachments)
@@ -402,6 +472,12 @@ async def delete_knowledge_item(
     from .. import knowledge as kb_service
 
     try:
+        # 條目層級權限：personal 條目限 owner 刪除
+        existing = kb_service.get_knowledge(kb_id)
+        access_err = await _check_item_access(existing, ctos_user_id, "delete")
+        if access_err:
+            return access_err
+
         kb_service.delete_knowledge(kb_id)
         return f"✅ 已刪除知識 {kb_id}"
 
@@ -434,6 +510,11 @@ async def get_knowledge_attachments(
 
     try:
         item = kb_service.get_knowledge(kb_id)
+
+        # 條目層級權限：personal 條目限 owner
+        access_err = await _check_item_access(item, ctos_user_id, "read")
+        if access_err:
+            return access_err
 
         if not item.attachments:
             return f"知識 {kb_id} 沒有附件"
@@ -488,6 +569,12 @@ async def update_knowledge_attachment(
     from pathlib import Path
 
     try:
+        # 條目層級權限：personal 條目限 owner 編輯
+        existing = kb_service.get_knowledge(kb_id)
+        access_err = await _check_item_access(existing, ctos_user_id, "write")
+        if access_err:
+            return access_err
+
         attachment = kb_service.update_attachment(
             kb_id=kb_id,
             attachment_idx=attachment_index,
@@ -532,6 +619,11 @@ async def read_knowledge_attachment(
 
     try:
         item = kb_service.get_knowledge(kb_id)
+
+        # 條目層級權限：personal 條目限 owner
+        access_err = await _check_item_access(item, ctos_user_id, "read")
+        if access_err:
+            return access_err
 
         if not item.attachments:
             return f"知識 {kb_id} 沒有附件"

--- a/backend/tests/test_knowledge_api_module.py
+++ b/backend/tests/test_knowledge_api_module.py
@@ -152,6 +152,10 @@ async def test_get_create_update_delete_history_version(monkeypatch: pytest.Monk
     session = _session()
     kb = _knowledge()
 
+    # 讀取權限檢查的細節由 test_knowledge_read_scope.py 專測，這裡放行
+    monkeypatch.setattr(knowledge_api, "get_user_preferences", AsyncMock(return_value={}))
+    monkeypatch.setattr(knowledge_api, "check_knowledge_permission_async", AsyncMock(return_value=True))
+
     monkeypatch.setattr(knowledge_api, "get_knowledge", lambda _id: kb)
     assert (await knowledge_api.get_single_knowledge("kb-1", session=session)).id == "kb-1"
 

--- a/backend/tests/test_knowledge_read_scope.py
+++ b/backend/tests/test_knowledge_read_scope.py
@@ -1,0 +1,156 @@
+"""知識庫條目層級讀取權限測試（API 層）
+
+personal 條目僅 owner（與 admin）可讀，非 owner 一律 404（不洩漏存在）。
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from ching_tech_os.api import knowledge as knowledge_api
+from ching_tech_os.models.auth import SessionData
+from ching_tech_os.models.knowledge import (
+    KnowledgeResponse,
+    KnowledgeSource,
+    KnowledgeTags,
+)
+
+
+def _session(username: str = "u1", role: str = "user") -> SessionData:
+    now = datetime.now()
+    return SessionData(
+        username=username,
+        password="",
+        nas_host="h",
+        user_id=1,
+        created_at=now,
+        expires_at=now + timedelta(hours=1),
+        role=role,
+        app_permissions={"knowledge-base": True},
+    )
+
+
+def _kb(kb_id: str = "kb-9", scope: str = "global", owner: str | None = None) -> KnowledgeResponse:
+    return KnowledgeResponse(
+        id=kb_id,
+        title="t",
+        type="note",
+        category="technical",
+        scope=scope,
+        owner=owner,
+        tags=KnowledgeTags(),
+        source=KnowledgeSource(),
+        related=[],
+        attachments=[],
+        author="a",
+        created_at=date.today(),
+        updated_at=date.today(),
+        content="祕密內容",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_db(monkeypatch: pytest.MonkeyPatch):
+    """讀取權限走真實的 check_knowledge_permission_async，只擋掉 DB 查詢"""
+    monkeypatch.setattr(
+        knowledge_api, "get_user_preferences", AsyncMock(return_value={})
+    )
+
+
+@pytest.mark.asyncio
+async def test_personal_entry_hidden_from_non_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        knowledge_api, "get_knowledge", lambda _id: _kb(scope="personal", owner="jayho")
+    )
+
+    # 非 owner：404（與「不存在」相同訊息，不洩漏存在）
+    with pytest.raises(HTTPException) as e:
+        await knowledge_api.get_single_knowledge("kb-9", session=_session("yazelin"))
+    assert e.value.status_code == 404
+    assert "不存在" in e.value.detail
+
+    # owner：可讀
+    got = await knowledge_api.get_single_knowledge("kb-9", session=_session("jayho"))
+    assert got.content == "祕密內容"
+
+    # admin：可讀（與 check_knowledge_permission_async 既有語意一致）
+    got = await knowledge_api.get_single_knowledge(
+        "kb-9", session=_session("boss", role="admin")
+    )
+    assert got.id == "kb-9"
+
+
+@pytest.mark.asyncio
+async def test_global_and_project_entries_readable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(knowledge_api, "get_knowledge", lambda _id: _kb(scope="global"))
+    assert (await knowledge_api.get_single_knowledge("kb-9", session=_session())).id == "kb-9"
+
+    monkeypatch.setattr(
+        knowledge_api, "get_knowledge", lambda _id: _kb(scope="project", owner=None)
+    )
+    assert (await knowledge_api.get_single_knowledge("kb-9", session=_session())).id == "kb-9"
+
+
+@pytest.mark.asyncio
+async def test_history_and_version_blocked_for_non_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        knowledge_api, "get_knowledge", lambda _id: _kb(scope="personal", owner="jayho")
+    )
+    history_mock = AsyncMock()
+    monkeypatch.setattr(knowledge_api, "get_history", history_mock)
+    monkeypatch.setattr(knowledge_api, "get_version", history_mock)
+
+    with pytest.raises(HTTPException) as e:
+        await knowledge_api.get_knowledge_history("kb-9", session=_session("yazelin"))
+    assert e.value.status_code == 404
+
+    with pytest.raises(HTTPException) as e:
+        await knowledge_api.get_knowledge_version("kb-9", "abc123", session=_session("yazelin"))
+    assert e.value.status_code == 404
+
+    # 完全沒碰到底層 git 函數
+    history_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_attachment_paths_check_owning_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        knowledge_api, "get_knowledge", lambda _id: _kb(kb_id=_id, scope="personal", owner="jayho")
+    )
+
+    # NAS 附件：路徑第一段是 kb id → 非 owner 404
+    with pytest.raises(HTTPException) as e:
+        await knowledge_api.get_attachment("kb-9/secret.pdf", session=_session("yazelin"))
+    assert e.value.status_code == 404
+
+    # 本機 asset：檔名以 kb id 開頭 → 非 owner 404
+    with pytest.raises(HTTPException) as e:
+        await knowledge_api.get_local_asset(
+            "images/kb-9-secret.png", session=_session("yazelin")
+        )
+    assert e.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_attachment_orphan_files_keep_old_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """找不到對應知識條目（孤兒檔案）時不擋，由檔案層自然 404"""
+    from ching_tech_os.services.knowledge import KnowledgeNotFoundError
+
+    monkeypatch.setattr(
+        knowledge_api,
+        "get_knowledge",
+        lambda _id: (_ for _ in ()).throw(KnowledgeNotFoundError("x")),
+    )
+    monkeypatch.setattr(
+        knowledge_api, "get_nas_attachment", lambda _p: b"orphan-bytes"
+    )
+    resp = await knowledge_api.get_attachment("kb-9/orphan.pdf", session=_session("yazelin"))
+    assert resp.body == b"orphan-bytes"

--- a/backend/tests/test_mcp_knowledge_item_access.py
+++ b/backend/tests/test_mcp_knowledge_item_access.py
@@ -1,0 +1,148 @@
+"""MCP 知識工具條目層級權限測試（_check_item_access）"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ching_tech_os.services.mcp import knowledge_tools
+from ching_tech_os.models.knowledge import (
+    KnowledgeResponse,
+    KnowledgeSource,
+    KnowledgeTags,
+)
+
+
+class _ConnCtx:
+    def __init__(self, conn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+def _kb(
+    scope: str = "global",
+    owner: str | None = None,
+    is_public: bool = False,
+) -> KnowledgeResponse:
+    return KnowledgeResponse(
+        id="kb-9",
+        title="t",
+        type="note",
+        category="technical",
+        scope=scope,
+        owner=owner,
+        is_public=is_public,
+        tags=KnowledgeTags(),
+        source=KnowledgeSource(),
+        related=[],
+        attachments=[],
+        author="a",
+        created_at=date.today(),
+        updated_at=date.today(),
+        content="c",
+    )
+
+
+def _user_conn(monkeypatch, username="yazelin", role="user", preferences=None):
+    conn = SimpleNamespace(
+        fetchrow=AsyncMock(
+            return_value={
+                "username": username,
+                "role": role,
+                "preferences": preferences,
+            }
+        )
+    )
+    monkeypatch.setattr(knowledge_tools, "get_connection", lambda: _ConnCtx(conn))
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_unbound_user_access() -> None:
+    # 未綁定：global + is_public 可讀
+    assert await knowledge_tools._check_item_access(
+        _kb(scope="global", is_public=True), None, "read"
+    ) is None
+
+    # 未綁定：global 非公開不可讀
+    err = await knowledge_tools._check_item_access(
+        _kb(scope="global", is_public=False), None, "read"
+    )
+    assert "找不到" in err
+
+    # 未綁定：personal 不可讀（不洩漏存在）
+    err = await knowledge_tools._check_item_access(
+        _kb(scope="personal", owner="jayho"), None, "read"
+    )
+    assert "找不到" in err
+
+    # 未綁定：不可寫
+    err = await knowledge_tools._check_item_access(
+        _kb(scope="global", is_public=True), None, "write"
+    )
+    assert "綁定" in err
+
+
+@pytest.mark.asyncio
+async def test_bound_user_personal_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    _user_conn(monkeypatch, username="yazelin")
+
+    # 非 owner 讀 personal：找不到（不洩漏）
+    err = await knowledge_tools._check_item_access(
+        _kb(scope="personal", owner="jayho"), 7, "read"
+    )
+    assert "找不到" in err
+
+    # 非 owner 寫/刪 personal：權限錯誤
+    err = await knowledge_tools._check_item_access(
+        _kb(scope="personal", owner="jayho"), 7, "write"
+    )
+    assert "權限" in err
+    err = await knowledge_tools._check_item_access(
+        _kb(scope="personal", owner="jayho"), 7, "delete"
+    )
+    assert "權限" in err
+
+    # owner 全可
+    _user_conn(monkeypatch, username="jayho")
+    for action in ("read", "write", "delete"):
+        assert await knowledge_tools._check_item_access(
+            _kb(scope="personal", owner="jayho"), 7, action
+        ) is None
+
+
+@pytest.mark.asyncio
+async def test_bound_user_global_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    _user_conn(monkeypatch, username="yazelin")
+
+    # global：可讀
+    assert await knowledge_tools._check_item_access(_kb(scope="global"), 7, "read") is None
+
+    # global：無 global_write 不可寫
+    err = await knowledge_tools._check_item_access(_kb(scope="global"), 7, "write")
+    assert "權限" in err
+
+    # admin：全可
+    _user_conn(monkeypatch, username="boss", role="admin")
+    assert await knowledge_tools._check_item_access(
+        _kb(scope="personal", owner="jayho"), 7, "delete"
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_bound_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = SimpleNamespace(fetchrow=AsyncMock(return_value=None))
+    monkeypatch.setattr(knowledge_tools, "get_connection", lambda: _ConnCtx(conn))
+
+    err = await knowledge_tools._check_item_access(
+        _kb(scope="personal", owner="jayho"), 99, "read"
+    )
+    assert "找不到" in err

--- a/backend/tests/test_mcp_knowledge_tools.py
+++ b/backend/tests/test_mcp_knowledge_tools.py
@@ -29,6 +29,10 @@ def _allow(monkeypatch: pytest.MonkeyPatch, allowed: bool = True):
         "check_mcp_tool_permission",
         AsyncMock(return_value=(allowed, "DENY")),
     )
+    # 條目層級權限檢查另以 test_mcp_knowledge_item_access.py 專測，這裡直接放行
+    monkeypatch.setattr(
+        knowledge_tools, "_check_item_access", AsyncMock(return_value=None)
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_mcp_knowledge_tools.py
+++ b/backend/tests/test_mcp_knowledge_tools.py
@@ -108,6 +108,12 @@ async def test_update_and_delete_item(monkeypatch: pytest.MonkeyPatch) -> None:
 
     conn = SimpleNamespace(fetchrow=AsyncMock(return_value={"username": "alice"}))
     monkeypatch.setattr(knowledge_tools, "get_connection", lambda: _ConnCtx(conn))
+    # update/delete 前會先 get_knowledge 做條目層級權限檢查（CI 環境沒有 dev 資料，必須 mock）
+    monkeypatch.setattr(
+        kb_service,
+        "get_knowledge",
+        lambda _id: SimpleNamespace(id="kb-001", scope="global", owner=None, project_id=None),
+    )
     monkeypatch.setattr(
         kb_service,
         "update_knowledge",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -571,7 +571,7 @@ wheels = [
 
 [[package]]
 name = "ching-tech-os"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -79,6 +79,12 @@ uv run uvicorn ching_tech_os.main:socket_app --host 0.0.0.0 --port 8088 --reload
 - 不可用 PAT 換發或撤銷 PAT（防止外洩 token 自我複製）
 - 預設效期 180 天（`expires_days`，`null` 為永久）；使用者停用（`is_active=false`）即全部失效
 
+#### 知識條目層級權限
+
+`scope: personal` 的條目僅 owner（與 admin）可讀，非 owner 透過任何讀取路徑
+（單篇 / 版本歷史 / 附件下載 / MCP 工具）一律回 404，與搜尋的過濾語意一致；
+寫入與刪除走 `check_knowledge_permission_async`（owner 或 global_write / global_delete）。
+
 ### 使用者
 
 | 方法 | 端點 | 說明 |


### PR DESCRIPTION
## 問題（實測發現）

kb-182 是 `scope: personal, owner: Jayho`，用 yazelin 帳號：搜尋看不到它（過濾正確），但 `GET /api/knowledge/kb-182` 直接拿到全文。盤查後同類缺口共三處：

1. API 讀取路徑沒檢查：單篇、`/history`、`/version/{commit}`、兩個附件下載端點
2. MCP 讀取工具沒檢查：`get_knowledge_item`、`get_knowledge_attachments`、`read_knowledge_attachment`
3. MCP 寫入工具沒檢查條目層級：`update_knowledge_item`、`delete_knowledge_item`、`add_attachments_to_knowledge`、`update_knowledge_attachment` — 綁定用戶可改刪**別人的** personal 條目

## 修法

全部收斂到既有的 `check_knowledge_permission_async`（PUT/DELETE 端點本來就在用）：

- 讀取被拒一律回 404、訊息與「不存在」相同 — 與搜尋的隱形語意一致，不洩漏條目存在
- 附件端點從路徑解析所屬 kb id（`attachments/{kb-id}/...`、`assets/images/{kb-id}-...`）再檢查；解析不到或孤兒檔案維持舊行為
- MCP 未綁定用戶僅可讀 `global + is_public`（與 search 的 public_only 一致）、不可寫
- admin 可讀全部（沿用既有權限模型）

## 測試

- 新增 `test_knowledge_read_scope.py`（API：非 owner 404 / owner 可讀 / admin 可讀 / history+version 擋下且不碰 git 層 / 附件解析 / 孤兒檔案）
- 新增 `test_mcp_knowledge_item_access.py`（未綁定四情境 / 綁定 personal 三動作 / global 讀寫 / admin / 查無帳號）
- 全套 1213 passed；coverage 85.28%（gate 85%）

🤖 Generated with [Claude Code](https://claude.com/claude-code)