### PR TITLE
feat(user): /api/user/me 回傳帳號實際角色，whoami 標明 PAT 降權

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ching-tech-os"
-version = "0.9.1"
+version = "0.9.2"
 description = "Ching Tech OS Backend"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/src/ching_tech_os/__init__.py
+++ b/backend/src/ching_tech_os/__init__.py
@@ -1,3 +1,3 @@
 """Ching Tech OS Backend"""
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"

--- a/backend/src/ching_tech_os/api/user.py
+++ b/backend/src/ching_tech_os/api/user.py
@@ -134,6 +134,8 @@ async def get_current_user(
         is_admin=user_is_admin,
         permissions=UserPermissions(**permissions),
         role=session.role,
+        account_role=user.get("role") or "user",
+        auth_type=session.auth_type,
         has_password=has_password,
     )
 
@@ -171,6 +173,8 @@ async def update_current_user(
         is_admin=user_is_admin,
         permissions=UserPermissions(**permissions),
         role=session.role,
+        account_role=user.get("role") or "user",
+        auth_type=session.auth_type,
     )
 
 

--- a/backend/src/ching_tech_os/main.py
+++ b/backend/src/ching_tech_os/main.py
@@ -311,7 +311,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Ching Tech OS API",
-    version="0.9.1",
+    version="0.9.2",
     lifespan=lifespan,
 )
 

--- a/backend/src/ching_tech_os/models/user.py
+++ b/backend/src/ching_tech_os/models/user.py
@@ -21,7 +21,11 @@ class UserInfo(BaseModel):
     last_login_at: datetime | None
     is_admin: bool = False
     permissions: UserPermissions | None = None
-    role: str = "user"  # admin, user
+    role: str = "user"  # 本次 session 的有效角色（PAT 一律為 user）
+    # 帳號在資料庫中的實際角色（PAT 降權時與 role 不同）
+    account_role: str = "user"
+    # 認證型態：session（web 登入）或 pat（長效 API token）
+    auth_type: str = "session"
     # 密碼狀態
     has_password: bool = False  # 是否已設定密碼（用於顯示變更/設定密碼按鈕）
 

--- a/backend/tests/test_api_user_module.py
+++ b/backend/tests/test_api_user_module.py
@@ -75,6 +75,28 @@ async def test_get_current_user_and_not_found(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.asyncio
+async def test_get_current_user_pat_shows_account_role(monkeypatch: pytest.MonkeyPatch):
+    """PAT 降權時，role 為 session 角色（user），account_role 為帳號實際角色（admin）"""
+    monkeypatch.setattr(
+        user_api, "get_user_by_username", AsyncMock(return_value=_user_row(role="admin"))
+    )
+    monkeypatch.setattr(user_api, "_parse_preferences", lambda _p: {"apps": {}, "knowledge": {}})
+    monkeypatch.setattr(
+        user_api,
+        "get_user_permissions_for_role",
+        lambda _role, _prefs: {"apps": {}, "knowledge": {}},
+    )
+
+    pat_session = _session(role="user")
+    pat_session.auth_type = "pat"
+    user = await user_api.get_current_user(pat_session)
+    assert user.role == "user"
+    assert user.account_role == "admin"
+    assert user.auth_type == "pat"
+    assert user.is_admin is False  # PAT session 不具 admin 身分
+
+
+@pytest.mark.asyncio
 async def test_update_current_user_paths(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(user_api, "_parse_preferences", lambda _p: {"apps": {}, "knowledge": {}})
     monkeypatch.setattr(

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -571,7 +571,7 @@ wheels = [
 
 [[package]]
 name = "ching-tech-os"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctos-cli"
-version = "0.1.1"
+version = "0.1.2"
 description = "ching-tech-os 知識庫 / 圖書館遠端存取 CLI"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/cli/src/ctos_cli/__init__.py
+++ b/cli/src/ctos_cli/__init__.py
@@ -1,3 +1,3 @@
 """ctos CLI — ching-tech-os 知識庫 / 圖書館遠端存取工具"""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/cli/src/ctos_cli/main.py
+++ b/cli/src/ctos_cli/main.py
@@ -173,8 +173,16 @@ def cmd_whoami(_args: argparse.Namespace) -> None:
     print(f"帳號：{me.get('username', cfg.get('username', '?'))}")
     if me.get("display_name"):
         print(f"名稱：{me['display_name']}")
-    if me.get("role"):
-        print(f"角色：{me['role']}")
+
+    role = me.get("role")
+    account_role = me.get("account_role")
+    if role:
+        if me.get("auth_type") == "pat" and account_role and account_role != role:
+            # PAT 一律降權為 user，與帳號實際角色不同時標明，避免誤判帳號權限
+            print(f"角色：{role}（API token 降權；帳號實際角色：{account_role}）")
+        else:
+            print(f"角色：{role}")
+
     print(f"服務：{get_url() or '?'}")
     if cfg.get("token_name"):
         print(f"token：{cfg['token_name']}（id={cfg.get('token_id', '?')}）")


### PR DESCRIPTION
## 問題

實際使用時的困惑：帳號在網頁上是管理員，但 `ctos whoami` 顯示「角色：user」。原因是 `/api/user/me` 回的是 session 的有效角色，而 PAT 設計上一律降權為 user——顯示沒錯，但會讓使用者誤判自己的帳號權限。

## 變更

- `UserInfo` 新增 `account_role`（users 表實際角色）與 `auth_type`（session / pat），`GET /me` 與 `PATCH /me` 都回傳；`role` 欄位語意不變（向下相容）
- CLI `ctos whoami`：PAT 且降權時顯示「角色：user（API token 降權；帳號實際角色：admin）」
- 後端 0.9.2、CLI 0.1.2

## 測試

- 新增 PAT 降權情境測試（role=user、account_role=admin、is_admin=False）
- 全套 1214 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)