### PR TITLE
feat(cli): erp 查詢子命令 + erpnext REST proxy 指標更新

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -66,6 +66,14 @@ CTOS_PASSWORD=<密碼> ctos login --url https://ching-tech.ddns.net/ctos --usern
 | `ctos lib get <路徑> [--out 檔名或目錄]` | 下載圖書館檔案 |
 | `ctos files ls [來源/子路徑] [--json]` | 瀏覽 NAS 掛載區（projects / circuits / library；不給路徑列出來源） |
 | `ctos files get <來源/路徑> [--out]` | 下載 NAS 掛載區檔案（如 `circuits/某機台/線路圖.pdf`） |
+| `ctos erp find <關鍵字>` | ERPNext 物料搜尋（比對料號與品名） |
+| `ctos erp item <料號>` | 物料明細（單位、採購價、交期） |
+| `ctos erp stock <料號> [--warehouse]` | 各倉庫存（含保留/在途） |
+| `ctos erp boms <料號>` / `ctos erp bom <BOM名>` | BOM 清單與明細 |
+
+ERP 查詢需要 token scope 含 `inventory-management`（0.1.5 起 `ctos login` 預設已涵蓋；
+舊 token 要用 erp 指令請重新 `ctos login`）。全部唯讀，走 CTOS 的 `/api/erp` proxy，
+ERPNext 憑證只存在伺服器端，不會發到個人機器。
 
 ## 環境變數
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctos-cli"
-version = "0.1.4"
+version = "0.1.5"
 description = "ching-tech-os 知識庫 / 圖書館遠端存取 CLI"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/cli/src/ctos_cli/__init__.py
+++ b/cli/src/ctos_cli/__init__.py
@@ -1,3 +1,3 @@
 """ctos CLI — ching-tech-os 知識庫 / 圖書館遠端存取工具"""
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/cli/src/ctos_cli/main.py
+++ b/cli/src/ctos_cli/main.py
@@ -67,6 +67,12 @@ def _api(path: str, **kwargs):
                 "建立 global 知識需要 global_write 權限（請管理者在後台開），\n"
                 "或改用 --scope personal / --scope project。"
             )
+        if e.status == 403 and "功能權限" in e.detail:
+            _die(
+                f"API 錯誤（HTTP 403）：{e.detail}\n"
+                "你的 token scope 可能不含這個功能。重新換發含該 scope 的 token：\n"
+                "  ctos login --scope knowledge-base --scope inventory-management"
+            )
         _die(f"API 錯誤（HTTP {e.status}）：{e.detail}")
 
 
@@ -138,7 +144,8 @@ def cmd_login(args: argparse.Namespace) -> None:
             token=session_token,
             json_body={
                 "name": name,
-                "scopes": args.scope or ["knowledge-base"],
+                # 預設涵蓋知識庫與 ERP 查詢（皆唯讀），要更收斂可自行指定 --scope
+                "scopes": args.scope or ["knowledge-base", "inventory-management"],
                 "expires_days": args.expires_days,
                 "read_only": not args.read_write,
             },
@@ -518,6 +525,102 @@ def cmd_files_get(args: argparse.Namespace) -> None:
 
 
 # ============================================================
+# erp 子命令（ERPNext 唯讀查詢，走 CTOS /api/erp proxy）
+# ============================================================
+
+
+def cmd_erp_find(args: argparse.Namespace) -> None:
+    resp = _api("/api/erp/items", params={"q": args.query, "limit": args.limit})
+    if args.json:
+        print(json.dumps(resp, ensure_ascii=False, indent=2))
+        return
+    items = resp.get("items", [])
+    if not items:
+        print("查無物料。")
+        return
+    for it in items:
+        disabled = "（停用）" if it.get("disabled") else ""
+        print(f"  {it['name']:<24} {it.get('item_name', '')}{disabled}  [{it.get('item_group', '')}] {it.get('stock_uom', '')}")
+
+
+def cmd_erp_item(args: argparse.Namespace) -> None:
+    resp = _api(f"/api/erp/items/{args.item_code}")
+    if args.json:
+        print(json.dumps(resp, ensure_ascii=False, indent=2))
+        return
+    it = resp.get("item", {})
+    print(f"料號：{it.get('name')}")
+    print(f"品名：{it.get('item_name')}")
+    if it.get("description"):
+        print(f"說明：{it['description']}")
+    print(f"群組：{it.get('item_group')}；單位：{it.get('stock_uom')}")
+    if it.get("last_purchase_rate") is not None:
+        print(f"最近採購價：{it['last_purchase_rate']}")
+    if it.get("lead_time_days"):
+        print(f"交期（天）：{it['lead_time_days']}")
+    if it.get("disabled"):
+        print("狀態：已停用")
+
+
+def cmd_erp_stock(args: argparse.Namespace) -> None:
+    params = {"item": args.item_code}
+    if args.warehouse:
+        params["warehouse"] = args.warehouse
+    resp = _api("/api/erp/stock", params=params)
+    if args.json:
+        print(json.dumps(resp, ensure_ascii=False, indent=2))
+        return
+    bins = resp.get("bins", [])
+    if not bins:
+        print(f"{args.item_code}：無庫存記錄。")
+        return
+    total = 0.0
+    print(f"{args.item_code} 庫存：")
+    for b in bins:
+        qty = b.get("actual_qty") or 0
+        total += qty
+        extra = []
+        if b.get("reserved_qty"):
+            extra.append(f"保留 {b['reserved_qty']}")
+        if b.get("ordered_qty"):
+            extra.append(f"在途 {b['ordered_qty']}")
+        extra_str = f"（{'、'.join(extra)}）" if extra else ""
+        print(f"  {b.get('warehouse', '?'):<30} {qty}{extra_str}")
+    print(f"合計：{total}")
+
+
+def cmd_erp_boms(args: argparse.Namespace) -> None:
+    resp = _api("/api/erp/boms", params={"item": args.item_code})
+    if args.json:
+        print(json.dumps(resp, ensure_ascii=False, indent=2))
+        return
+    boms = resp.get("boms", [])
+    if not boms:
+        print(f"{args.item_code}：沒有 BOM。")
+        return
+    for b in boms:
+        flags = []
+        if b.get("is_default"):
+            flags.append("預設")
+        if b.get("is_active"):
+            flags.append("啟用")
+        flag_str = f"（{'、'.join(flags)}）" if flags else ""
+        print(f"  {b['name']}{flag_str}")
+    print(f"明細：ctos erp bom <BOM 名稱>")
+
+
+def cmd_erp_bom(args: argparse.Namespace) -> None:
+    resp = _api(f"/api/erp/bom/{args.bom_name}")
+    if args.json:
+        print(json.dumps(resp, ensure_ascii=False, indent=2))
+        return
+    bom = resp.get("bom", {})
+    print(f"BOM：{bom.get('name')}（{bom.get('item')} {bom.get('item_name', '')} x {bom.get('quantity')}）")
+    for it in bom.get("items", []):
+        print(f"  {it.get('item_code'):<24} {it.get('item_name', '')}  x {it.get('qty')} {it.get('uom', '')}")
+
+
+# ============================================================
 # argparse
 # ============================================================
 
@@ -635,6 +738,36 @@ def build_parser() -> argparse.ArgumentParser:
     p_fget.add_argument("path", help="檔案路徑（如 circuits/某機台/線路圖.pdf）")
     p_fget.add_argument("--out", help="輸出檔名或目錄")
     p_fget.set_defaults(func=cmd_files_get)
+
+    p_erp = sub.add_parser("erp", help="ERPNext 查詢（物料 / 庫存 / BOM，唯讀）")
+    erp_sub = p_erp.add_subparsers(dest="erp_command", required=True)
+
+    p_efind = erp_sub.add_parser("find", help="關鍵字搜尋物料")
+    p_efind.add_argument("query", help="關鍵字（比對料號與品名）")
+    p_efind.add_argument("--limit", type=int, default=20)
+    p_efind.add_argument("--json", action="store_true")
+    p_efind.set_defaults(func=cmd_erp_find)
+
+    p_eitem = erp_sub.add_parser("item", help="物料明細")
+    p_eitem.add_argument("item_code", help="料號")
+    p_eitem.add_argument("--json", action="store_true")
+    p_eitem.set_defaults(func=cmd_erp_item)
+
+    p_estock = erp_sub.add_parser("stock", help="庫存查詢（各倉 Bin）")
+    p_estock.add_argument("item_code", help="料號")
+    p_estock.add_argument("--warehouse", help="倉庫過濾")
+    p_estock.add_argument("--json", action="store_true")
+    p_estock.set_defaults(func=cmd_erp_stock)
+
+    p_eboms = erp_sub.add_parser("boms", help="物料的 BOM 清單")
+    p_eboms.add_argument("item_code", help="料號")
+    p_eboms.add_argument("--json", action="store_true")
+    p_eboms.set_defaults(func=cmd_erp_boms)
+
+    p_ebom = erp_sub.add_parser("bom", help="BOM 明細（含組成物料）")
+    p_ebom.add_argument("bom_name", help="BOM 名稱（如 BOM-ITEM-001）")
+    p_ebom.add_argument("--json", action="store_true")
+    p_ebom.set_defaults(func=cmd_erp_bom)
 
     return parser
 


### PR DESCRIPTION
CLI 擴充三部曲之三（kb-182 痛點：採購庫存查詢、設計部 BOM）。

## 架構

ERP 憑證不下放：CLI → CTOS `/api/erp/*`（PAT 認證 + inventory-management 權限）→ 伺服器端以共用憑證呼叫 ERPNext REST。proxy 實作在 extends/erpnext（yazelin/ching-tech-erpnext#2，已 merge），以 contributes.yaml 的 routers 機制掛載，主系統零改動——本 PR 只有 CLI + submodule 指標。

## CLI

- `ctos erp find <關鍵字>`（料號+品名 like 搜尋）
- `ctos erp item <料號>`（明細：單位/採購價/交期）
- `ctos erp stock <料號> [--warehouse]`（各倉 Bin，含保留/在途，印合計）
- `ctos erp boms <料號>` / `ctos erp bom <名稱>`（含組成物料）
- login 預設 scopes 加入 inventory-management（唯讀）；403 功能權限 → 換發指引

## 驗證

- argparse 單元邏輯通過；`scaffold.py validate` 對含新 router 宣告的 contributes.yaml 通過（5 模組）
- 功能 E2E 需部署後以含 inventory-management scope 的 token 實測（部署在 merge 後執行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)