### PR TITLE
docs: ctos-kb skill 與 CLAUDE.md 跟上 files / erp 子命令

### DIFF
--- a/.claude/skills/ctos-kb/SKILL.md
+++ b/.claude/skills/ctos-kb/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: ctos-kb
-description: 透過 ctos CLI 遠端讀取 ching-tech-os（CTOS）知識庫與圖書館。當使用者提到 kb-NNN 編號、要查 CTOS 知識庫 / 圖書館資料、或說「我要開發 kb-XXX 的功能」需要先取得背景資料時使用。
+description: 透過 ctos CLI 遠端存取 ching-tech-os（CTOS）的公司資料：知識庫（kb-NNN）、圖書館、NAS 掛載區（專案圖面 projects / 線路圖 circuits）、ERPNext（物料/庫存/BOM）。當使用者提到 kb-NNN、要查知識庫/圖書館/圖面/線路圖、查料號/庫存/BOM，或說「我要開發 kb-XXX 的功能」需要背景資料時使用。
 ---
 
-# CTOS 知識庫 / 圖書館查詢
+# CTOS 資料存取（知識庫 / 圖書館 / NAS / ERP）
 
 CTOS 知識庫條目以 `kb-NNN` 編號（如 kb-182），存放在部署機上，透過 `ctos` CLI 以 HTTP API 遠端讀取。
 
@@ -39,6 +39,17 @@ ctos lib get 技術文件/規格書.pdf --out tmp/
 # 寫入（需可寫 token：使用者要先 ctos login --read-write）
 ctos kb add --title "標題" --file note.md --scope global --topic 主題
 ctos kb update kb-123 --content "新內容" --topic 新主題
+
+# NAS 掛載區（專案圖面、線路圖）
+ctos files ls                          # 列出來源：projects / circuits / library
+ctos files ls projects/某專案          # 瀏覽專案資料
+ctos files get circuits/某機台/線路圖.pdf --out tmp/
+
+# ERPNext（物料 / 庫存 / BOM，唯讀）
+ctos erp find 馬達                     # 關鍵字搜尋物料（料號+品名）
+ctos erp item <料號>                   # 明細（單位、採購價、交期）
+ctos erp stock <料號>                  # 各倉庫存（含保留/在途）
+ctos erp boms <料號> / ctos erp bom <BOM名>
 ```
 
 ## 開發工作流（使用者說「我要開發 kb-182 的某功能」時）
@@ -56,3 +67,5 @@ ctos kb update kb-123 --content "新內容" --topic 新主題
 - 寫入的 scope 規則：預設 personal（只有作者讀得到）；團隊共用要 `--scope global`（需 global_write 權限）或 `--scope project`（需 --project-id）。開發完把決策/心得寫回知識庫時，先問使用者要哪種 scope。
 - 搜尋結果的 `snippet` 是 ripgrep 匹配片段，要全文請再 `kb get`。
 - 服務網址等設定存於 `~/.ctos/config.json`，可用環境變數 `CTOS_URL` / `CTOS_TOKEN` 覆寫（CI / 自動化情境）。
+- `erp` 指令需要 token scope 含 `inventory-management`（0.1.5 起 login 預設涵蓋）；收到「無物料管理功能權限」403 時請使用者重新 `ctos login`（舊 token scope 不含）。
+- ERP 全部唯讀、走 CTOS proxy，ERPNext 憑證不在個人機器上——不要嘗試直連 ERPNext。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@
 - **查正式機知識庫 / 圖書館**用 `ctos` CLI（不要直接 ssh 去讀檔）：
   - 安裝：`uv tool install ./cli`（或 `uv tool install "git+https://github.com/yazelin/ching-tech-os.git#subdirectory=cli"`）
   - 首次設定：`ctos login --url https://ching-tech.ddns.net/ctos`（互動式，請使用者自己在終端機執行；非互動環境用 `--username` + 環境變數 `CTOS_PASSWORD`）
-  - 常用：`ctos kb get kb-182`、`ctos kb search "關鍵字"`、`ctos lib ls`，完整指令見 `cli/README.md`
+  - 常用：`ctos kb get kb-182`、`ctos kb search "關鍵字"`、`ctos lib ls`、`ctos files ls projects`（NAS 圖面）、`ctos erp stock <料號>`（庫存/BOM）、`ctos kb add`（寫回知識庫，需 `--read-write` token），完整指令見 `cli/README.md`
 - **本 repo 的 Claude Code project skills**（clone 即自動載入）：
   - `ctos-kb`：查知識庫 / 圖書館（使用者提到 kb-NNN 時）
   - `ctos-architecture`：加新功能 / 新 App / 新模組前的架構決策樹與逐檔 checklist


### PR DESCRIPTION
CLI 三部曲（kb 寫入 / files / erp）只更新了 cli/README，skill 觸發條件與 CLAUDE.md 沒跟上。補齊後同事的 Claude 在「查料號庫存」「找某機台線路圖」這類請求時會自動想到 ctos CLI，並知道 erp scope 403 怎麼引導。

🤖 Generated with [Claude Code](https://claude.com/claude-code)