### PR TITLE
fix(backup): 知識庫備份改雙向,附件不再被 --delete 掃掉

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ docker/code-server.git-credentials
 data/knowledge/entries/
 data/knowledge/assets/
 data/knowledge/index.json
+data/knowledge/attachments/
 
 # Projects data (attachments and runtime files)
 data/projects/

--- a/docs/knowledge-backup.md
+++ b/docs/knowledge-backup.md
@@ -1,0 +1,34 @@
+# 知識庫儲存與備份
+
+> 動備份腳本或知識庫目錄結構前，先讀這份。核心原則：**兩邊各有正本，備份方向相反，誰都不能對對方的正本帶 `--delete`。**
+
+## 儲存分裂（by 設計）
+
+| 內容 | 正本位置 | 寫入者 |
+|------|----------|--------|
+| 條目 md / index.json / 小附件（<1MB，`assets/`） | `.11 本機 ~/SDD/ching-tech-os/data/knowledge/` | 後端 `knowledge.py`（entries 走本機路徑） |
+| 大附件（>=1MB，`attachments/kb-XXX/`） | NAS `/mnt/nas/ctos/knowledge/attachments/` | 後端 `upload_attachment()`（經 `create_knowledge_file_service()`，root = `CTOS_MOUNT_PATH/knowledge`） |
+
+## 每日備份（systemd timer `backup-knowledge.timer`，03:00）
+
+腳本：`/home/ct/scripts/backup-knowledge-to-nas.sh`（repo 存底：`scripts/backup-knowledge-to-nas.sh`，改完要同步部署到 `~/scripts/`）
+
+1. **正向** 本機 → NAS：`rsync --delete --exclude='.git' --exclude='attachments/'`
+   `--exclude='attachments/'` 是保命符，見下方事故。
+2. **反向** NAS → 本機：`rsync`（**不帶** `--delete`，只進不出）把 `attachments/` 拉回本機第二份。
+   NAS 誤刪時本機這份不會跟著消失，可反向救援。
+3. 週日 tar.gz 到 `/mnt/nas/library/handover-snapshots/`（90 天輪替，`--exclude='knowledge/attachments'` 避免圖書館被數十 GB 塞爆）。
+
+結果：完整知識庫在 NAS 和 .11 本機各一份。本機的 `data/knowledge/` 整棵都在 .gitignore，不進 git。
+
+## 2026-07-16 事故（為什麼有這些 exclude）
+
+正向 rsync 原本沒有 exclude `attachments/`，而本機正本沒有這個目錄，於是每晚 `--delete` 把 NAS 上的大附件整批掃掉——自 2026-03 起累計刪了 26 個附件（kb-043 STEP 圖檔、kb-050~062 錄音、kb-103/104 影片、kb-120/182/183/192 PDF、kb-216 影片）。
+
+救援：25 個從 LINE bot 收檔區（`/mnt/nas/ctos/linebot/files/`，檔名帶 LINE 訊息 ID 可比對）copy 回來；kb-040 的 AI 生成圖無源可救，附件紀錄已自條目移除。
+
+教訓：
+- LINE 上傳的附件天然有第二份（收檔區）；**AI 生成的附件只有 `attachments/` 一份**，反向備份就是為它們加的。
+- 修 rsync 規則後一定要 `rsync -n` 乾跑驗證 deleting 清單再上線。
+
+相關：kb-161 §1.5（移交 SOP 的備份段落）、`docs/smb-nas-architecture.md`

--- a/scripts/backup-knowledge-to-nas.sh
+++ b/scripts/backup-knowledge-to-nas.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Daily backup of CTOS knowledge base — two-way, by 正本位置:
+#   條目/index/小附件 正本在本機 data/knowledge/ → 推到 NAS
+#   大附件(>=1MB)   正本在 NAS knowledge/attachments/ → 拉回本機第二份
+# 詳見 kb-161 1.5
+set -euo pipefail
+SRC=/home/ct/SDD/ching-tech-os/data/knowledge/
+DST=/mnt/nas/ctos/knowledge/
+LOG=/home/ct/logs/backup-knowledge.log
+
+if ! mountpoint -q /mnt/nas/ctos; then
+  echo "$(date -Iseconds) [ERROR] /mnt/nas/ctos not mounted" >> "$LOG"
+  exit 1
+fi
+
+# 正向：本機正本 → NAS。attachments/ 的正本在 NAS，必須 exclude，
+# 否則 --delete 會把 NAS 上的大附件整批刪光（2026-07-16 事故，26 個附件）
+rsync -av --delete --exclude='.git' --exclude='attachments/' "$SRC" "$DST" >> "$LOG" 2>&1
+
+# 反向：NAS 大附件 → 本機第二份。不帶 --delete（只進不出），
+# NAS 端誤刪時本機這份不會跟著消失，可反向救援
+if [ -d "${DST}attachments" ]; then
+  rsync -av "${DST}attachments/" "${SRC}attachments/" >> "$LOG" 2>&1
+fi
+echo "$(date -Iseconds) [OK] rsync done" >> "$LOG"
+
+# 每週日多打一份 tar.gz 到圖書館（保留 90 天；不含大附件，
+# 否則 1GB+ × 13 週會吃掉數十 GB 圖書館空間）
+if [ "$(date +%u)" = "7" ]; then
+  TAR_DIR=/mnt/nas/library/handover-snapshots
+  mkdir -p "$TAR_DIR"
+  tar czf "$TAR_DIR/knowledge-$(date +%Y%m%d).tar.gz" --exclude='knowledge/attachments' -C /home/ct/SDD/ching-tech-os/data knowledge/
+  find "$TAR_DIR" -name "knowledge-*.tar.gz" -mtime +90 -delete
+fi


### PR DESCRIPTION
## 背景
2026-07-16 發現 kb-216 附件下載 404。追查:每日 03:00 備份 rsync --delete 把 NAS 上的大附件目錄整批刪掉(本機正本沒有 attachments/),自 2026-03 起累計 26 個附件受害。25 個已從 LINE bot 收檔區救回,kb-040 AI 生成圖無源可救(附件紀錄已移除)。

## 修正(已部署到 ~/scripts/ 並實跑驗證)
- 正向 rsync 加 --exclude=attachments/(NAS 是大附件正本,不能被掃)
- 新增反向 rsync:NAS attachments/ → 本機第二份(不帶 --delete,只進不出)
- 週日 tar 排除大附件,避免圖書館 90 天輪替吃掉數十 GB
- .gitignore 補 data/knowledge/attachments/
- 新增 docs/knowledge-backup.md 記錄儲存分裂設計+事故+教訓

## 驗證
- 實跑:NAS 26 個/585M = 本機 26 個/585M
- 正向乾跑:0 deleting
- 反向乾跑:0 待傳(冪等)
- ctos kb attachments kb-216 --download 實測成功(218,229,497 bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)