### PR TITLE
fix(backup): 收 PR#168 的 Gemini review 三條意見

### DIFF
--- a/scripts/backup-knowledge-to-nas.sh
+++ b/scripts/backup-knowledge-to-nas.sh
@@ -8,27 +8,35 @@ SRC=/home/ct/SDD/ching-tech-os/data/knowledge/
 DST=/mnt/nas/ctos/knowledge/
 LOG=/home/ct/logs/backup-knowledge.log
 
+mkdir -p "$(dirname "$LOG")"
+
 if ! mountpoint -q /mnt/nas/ctos; then
   echo "$(date -Iseconds) [ERROR] /mnt/nas/ctos not mounted" >> "$LOG"
   exit 1
 fi
 
 # 正向：本機正本 → NAS。attachments/ 的正本在 NAS，必須 exclude，
-# 否則 --delete 會把 NAS 上的大附件整批刪光（2026-07-16 事故，26 個附件）
-rsync -av --delete --exclude='.git' --exclude='attachments/' "$SRC" "$DST" >> "$LOG" 2>&1
+# 否則 --delete 會把 NAS 上的大附件整批刪光（2026-07-16 事故，26 個附件）。
+# 容許 exit code 24（vanished source files）：後端寫入中的暫存檔消失不算失敗
+rsync -av --delete --exclude='.git' --exclude='attachments/' "$SRC" "$DST" >> "$LOG" 2>&1 || [ $? -eq 24 ]
 
 # 反向：NAS 大附件 → 本機第二份。不帶 --delete（只進不出），
 # NAS 端誤刪時本機這份不會跟著消失，可反向救援
-if [ -d "${DST}attachments" ]; then
-  rsync -av "${DST}attachments/" "${SRC}attachments/" >> "$LOG" 2>&1
+if [ -d "${DST%/}/attachments" ]; then
+  rsync -av "${DST%/}/attachments/" "${SRC%/}/attachments/" >> "$LOG" 2>&1 || [ $? -eq 24 ]
 fi
 echo "$(date -Iseconds) [OK] rsync done" >> "$LOG"
 
 # 每週日多打一份 tar.gz 到圖書館（保留 90 天；不含大附件，
 # 否則 1GB+ × 13 週會吃掉數十 GB 圖書館空間）
 if [ "$(date +%u)" = "7" ]; then
-  TAR_DIR=/mnt/nas/library/handover-snapshots
-  mkdir -p "$TAR_DIR"
-  tar czf "$TAR_DIR/knowledge-$(date +%Y%m%d).tar.gz" --exclude='knowledge/attachments' -C /home/ct/SDD/ching-tech-os/data knowledge/
-  find "$TAR_DIR" -name "knowledge-*.tar.gz" -mtime +90 -delete
+  if ! mountpoint -q /mnt/nas/library; then
+    # library 沒掛載時絕不能 mkdir -p——會在本機根目錄建同名路徑,tar 塞爆本機碟
+    echo "$(date -Iseconds) [ERROR] /mnt/nas/library not mounted, skip weekly tar" >> "$LOG"
+  else
+    TAR_DIR=/mnt/nas/library/handover-snapshots
+    mkdir -p "$TAR_DIR"
+    tar czf "$TAR_DIR/knowledge-$(date +%Y%m%d).tar.gz" --exclude='knowledge/attachments' -C /home/ct/SDD/ching-tech-os/data knowledge/
+    find "$TAR_DIR" -name "knowledge-*.tar.gz" -mtime +90 -delete
+  fi
 fi


### PR DESCRIPTION
逐條驗證後全收:

1. **High** 週日 tar 前檢查 `/mnt/nas/library` 掛載——library 是獨立 CIFS 掛載點,沒掛載時 `mkdir -p` 會在本機根目錄建同名路徑,tar 直接寫本機碟。
2. **Medium** `mkdir -p` log 目錄,避免 `set -e` 在第一行 log 就殺掉整個備份。
3. **Medium** 兩趟 rsync 容許 exit 24(vanished source files)+ `${VAR%/}/` 安全拼接。

合併後我會同步部署到 .11 的 `~/scripts/` 並實跑驗證。

🤖 Generated with [Claude Code](https://claude.com/claude-code)