### PR TITLE
fix: extends/his submodule URL 改指 ching-tech-his-tools

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "extends/his"]
 	path = extends/his
-	url = https://github.com/yazelin/ching-tech-his.git
+	url = https://github.com/yazelin/ching-tech-his-tools.git
 [submodule "extends/erpnext"]
 	path = extends/erpnext
 	url = https://github.com/yazelin/ching-tech-erpnext.git


### PR DESCRIPTION
repo `yazelin/ching-tech-his` 已改名 `ching-tech-his-tools`(原名保留給全新 HIS 產品 repo)。GitHub 轉址在原名被新 repo 佔用後會失效,故 .gitmodules 需改指新名。

.11 的 `~/SDD/ching-tech-his` 工作副本 remote 已同步更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)