### PR TITLE
fix(log): 遮蔽 httpx log 裡的 Telegram bot token 並丟掉輪詢雜訊

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,15 @@ PROJECT_ATTACHMENTS_PATH=/home/ct/SDD/ching-tech-os/data/projects/attachments
 GEMINI_API_KEY=your_gemini_api_key
 
 # ===================
+# AI Provider 路由（Codex provider 尚未接入；目前所有模式都安全回到 Claude）
+# ===================
+# claude（預設）| codex | auto；非法值會記錄錯誤並使用 claude
+AI_PROVIDER_MODE=claude
+# 首批 canary allowlist，exact match、逗號分隔；尚未有正式 caller 使用
+AI_PROVIDER_CANARY_CONTEXTS=internal_admin,internal_test
+AI_PROVIDER_CANARY_AGENTS=test-agent
+
+# ===================
 # Codex Image Service（自架，吃 ChatGPT 訂閱配額；設了就優先於 nanobanana）
 # ===================
 # Bearer key 從 codex-image-service admin 後台「Create API Key」取得（cimg_<random>）

--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,17 @@ AI_PROVIDER_MODE=claude
 # 首批 canary allowlist，exact match、逗號分隔；尚未有正式 caller 使用
 AI_PROVIDER_CANARY_CONTEXTS=internal_admin,internal_test
 AI_PROVIDER_CANARY_AGENTS=test-agent
+# auto mode：>=90% 切 Codex，低於 85% 才切回 Claude
+CLAUDE_USAGE_SWITCH_THRESHOLD=0.90
+CLAUDE_USAGE_RECOVERY_THRESHOLD=0.85
+# Router 只讀記憶體快照；背景每 60 秒刷新，最多沿用 300 秒舊資料
+CLAUDE_USAGE_REFRESH_TTL_SECONDS=60
+CLAUDE_USAGE_MAX_STALE_SECONDS=300
+CLAUDE_USAGE_REFRESH_INTERVAL_SECONDS=60
+CLAUDE_USAGE_HTTP_TIMEOUT_SECONDS=5
+CLAUDE_USAGE_STARTUP_TIMEOUT_SECONDS=2
+# 預設使用執行服務帳號的 ~/.claude/.credentials.json
+# CLAUDE_USAGE_CREDENTIALS_PATH=/home/ct/.claude/.credentials.json
 
 # ===================
 # Codex Image Service（自架，吃 ChatGPT 訂閱配額；設了就優先於 nanobanana）

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 # 測試 coverage 暫存
 .coverage
 .coverage.*
+coverage.xml
 htmlcov/
 .Python
 *.egg-info/

--- a/backend/src/ching_tech_os/config.py
+++ b/backend/src/ching_tech_os/config.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+from collections.abc import Collection
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -44,6 +45,43 @@ def _get_env_bool(key: str, default: bool = False) -> bool:
     if value in ("false", "0", "no", "off"):
         return False
     return default
+
+
+def _get_env_choice(
+    key: str,
+    default: str,
+    allowed: Collection[str],
+) -> str:
+    """取得小寫選項設定；非法值明確告警並回到安全預設。"""
+    allowed_values = frozenset(str(item).strip().lower() for item in allowed)
+    normalized_default = default.strip().lower()
+    if normalized_default not in allowed_values:
+        raise ValueError(f"{key} 的預設值不在合法選項中")
+
+    value = _get_env(key, normalized_default).strip().lower()
+    if value in allowed_values:
+        return value
+
+    logger.error(
+        "環境變數 %s 的值 %r 無效，合法值為 %s；使用安全預設值 %s",
+        key,
+        value,
+        ", ".join(sorted(allowed_values)),
+        normalized_default,
+    )
+    return normalized_default
+
+
+def _get_env_lower_set(key: str, default: str = "") -> frozenset[str]:
+    """取得逗號分隔、不含空字串的小寫集合。"""
+    return frozenset(
+        item.strip().lower()
+        for item in _get_env(key, default).split(",")
+        if item.strip()
+    )
+
+
+AI_PROVIDER_MODES = frozenset({"claude", "codex", "auto"})
 
 
 class Settings:
@@ -86,6 +124,23 @@ class Settings:
     # ===================
     session_ttl_hours: int = _get_env_int("SESSION_TTL_HOURS", 8)
     session_cleanup_interval_minutes: int = 10
+
+    # ===================
+    # AI Provider 路由（Codex provider 尚未接入，所有 mode 目前皆安全回到 Claude）
+    # ===================
+    ai_provider_mode: str = _get_env_choice(
+        "AI_PROVIDER_MODE",
+        "claude",
+        AI_PROVIDER_MODES,
+    )
+    ai_provider_canary_contexts: frozenset[str] = _get_env_lower_set(
+        "AI_PROVIDER_CANARY_CONTEXTS",
+        "internal_admin,internal_test",
+    )
+    ai_provider_canary_agents: frozenset[str] = _get_env_lower_set(
+        "AI_PROVIDER_CANARY_AGENTS",
+        "test-agent",
+    )
 
     # ===================
     # 路徑設定

--- a/backend/src/ching_tech_os/config.py
+++ b/backend/src/ching_tech_os/config.py
@@ -180,7 +180,7 @@ class Settings:
     session_cleanup_interval_minutes: int = 10
 
     # ===================
-    # AI Provider 路由（Codex provider 尚未接入，所有 mode 目前皆安全回到 Claude）
+    # AI Provider 路由（預設固定 Claude；Codex 只供 forced/canary 路徑選用）
     # ===================
     ai_provider_mode: str = _get_env_choice(
         "AI_PROVIDER_MODE",
@@ -227,6 +227,30 @@ class Settings:
     claude_usage_credentials_path: str = _get_env(
         "CLAUDE_USAGE_CREDENTIALS_PATH",
         str(Path.home() / ".claude/.credentials.json"),
+    )
+    codex_acp_bin_path: str = _get_env(
+        "CODEX_ACP_BIN_PATH",
+        str(_project_root / "node_modules/.bin/codex-acp"),
+    )
+    codex_bin_path: str = _get_env(
+        "CODEX_BIN_PATH",
+        str(_project_root / "node_modules/.bin/codex"),
+    )
+    codex_model: str = _get_env("CODEX_MODEL", "")
+    codex_max_concurrency: int = _get_env_int_bounded(
+        "CODEX_MAX_CONCURRENCY", 2, minimum=1, maximum=16
+    )
+    codex_queue_timeout_seconds: float = _get_env_float_bounded(
+        "CODEX_QUEUE_TIMEOUT_SECONDS", 5.0, minimum=0.1, maximum=60.0
+    )
+    codex_circuit_failure_threshold: int = _get_env_int_bounded(
+        "CODEX_CIRCUIT_FAILURE_THRESHOLD", 3, minimum=1, maximum=20
+    )
+    codex_circuit_cooldown_seconds: float = _get_env_float_bounded(
+        "CODEX_CIRCUIT_COOLDOWN_SECONDS", 60.0, minimum=1.0, maximum=3600.0
+    )
+    codex_stderr_max_bytes: int = _get_env_int_bounded(
+        "CODEX_STDERR_MAX_BYTES", 8192, minimum=1024, maximum=65536
     )
 
     # ===================

--- a/backend/src/ching_tech_os/config.py
+++ b/backend/src/ching_tech_os/config.py
@@ -37,6 +37,60 @@ def _get_env_int(key: str, default: int) -> int:
         return default
 
 
+def _get_env_float_bounded(
+    key: str,
+    default: float,
+    *,
+    minimum: float,
+    maximum: float,
+) -> float:
+    """取得有上下限的浮點設定；非法值回到安全預設。"""
+    value = os.getenv(key)
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except ValueError:
+        parsed = float("nan")
+    if minimum <= parsed <= maximum:
+        return parsed
+    logger.error(
+        "環境變數 %s 必須介於 %s 與 %s；使用安全預設值 %s",
+        key,
+        minimum,
+        maximum,
+        default,
+    )
+    return default
+
+
+def _get_env_int_bounded(
+    key: str,
+    default: int,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int:
+    """取得有上下限的整數設定；非法值回到安全預設。"""
+    value = os.getenv(key)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        parsed = minimum - 1
+    if minimum <= parsed <= maximum:
+        return parsed
+    logger.error(
+        "環境變數 %s 必須介於 %d 與 %d；使用安全預設值 %d",
+        key,
+        minimum,
+        maximum,
+        default,
+    )
+    return default
+
+
 def _get_env_bool(key: str, default: bool = False) -> bool:
     """取得布林環境變數"""
     value = os.getenv(key, "").lower()
@@ -140,6 +194,39 @@ class Settings:
     ai_provider_canary_agents: frozenset[str] = _get_env_lower_set(
         "AI_PROVIDER_CANARY_AGENTS",
         "test-agent",
+    )
+    claude_usage_switch_threshold: float = _get_env_float_bounded(
+        "CLAUDE_USAGE_SWITCH_THRESHOLD", 0.90, minimum=0.01, maximum=1.0
+    )
+    claude_usage_recovery_threshold: float = _get_env_float_bounded(
+        "CLAUDE_USAGE_RECOVERY_THRESHOLD", 0.85, minimum=0.0, maximum=0.99
+    )
+    if claude_usage_recovery_threshold >= claude_usage_switch_threshold:
+        logger.error("Claude usage recovery threshold 必須小於 switch threshold；使用 0.85/0.90")
+        claude_usage_recovery_threshold = 0.85
+        claude_usage_switch_threshold = 0.90
+    claude_usage_refresh_ttl_seconds: int = _get_env_int_bounded(
+        "CLAUDE_USAGE_REFRESH_TTL_SECONDS", 60, minimum=5, maximum=3600
+    )
+    claude_usage_max_stale_seconds: int = _get_env_int_bounded(
+        "CLAUDE_USAGE_MAX_STALE_SECONDS", 300, minimum=10, maximum=86400
+    )
+    if claude_usage_max_stale_seconds <= claude_usage_refresh_ttl_seconds:
+        logger.error("Claude usage max-stale 必須大於 refresh TTL；使用 300/60 秒")
+        claude_usage_refresh_ttl_seconds = 60
+        claude_usage_max_stale_seconds = 300
+    claude_usage_refresh_interval_seconds: int = _get_env_int_bounded(
+        "CLAUDE_USAGE_REFRESH_INTERVAL_SECONDS", 60, minimum=5, maximum=3600
+    )
+    claude_usage_http_timeout_seconds: float = _get_env_float_bounded(
+        "CLAUDE_USAGE_HTTP_TIMEOUT_SECONDS", 5.0, minimum=0.1, maximum=30.0
+    )
+    claude_usage_startup_timeout_seconds: float = _get_env_float_bounded(
+        "CLAUDE_USAGE_STARTUP_TIMEOUT_SECONDS", 2.0, minimum=0.1, maximum=10.0
+    )
+    claude_usage_credentials_path: str = _get_env(
+        "CLAUDE_USAGE_CREDENTIALS_PATH",
+        str(Path.home() / ".claude/.credentials.json"),
     )
 
     # ===================

--- a/backend/src/ching_tech_os/main.py
+++ b/backend/src/ching_tech_os/main.py
@@ -17,12 +17,16 @@ from .services.session import session_manager
 from .services.terminal import terminal_service
 from .services.scheduler import start_scheduler, stop_scheduler
 from .modules import get_module_registry, is_module_enabled
+from .utils.log_filters import install_log_filters
 
 try:  # 向下相容：保留可 monkeypatch 的符號
     from .services.linebot_agents import ensure_default_linebot_agents  # noqa: F401
 except Exception:  # pragma: no cover - 僅在依賴缺失時啟用
     async def ensure_default_linebot_agents():
         return None
+
+# 擋掉 Telegram 長輪詢雜訊並遮蔽 log 裡的 bot token(詳見 utils/log_filters.py)
+install_log_filters()
 
 # 建立 Socket.IO 伺服器
 sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*')

--- a/backend/src/ching_tech_os/main.py
+++ b/backend/src/ching_tech_os/main.py
@@ -229,6 +229,18 @@ async def lifespan(app: FastAPI):
         app.state.skillhub_client = SkillHubClient()
     await init_db_pool()
 
+    # Claude usage monitor 只在 auto mode 啟動；預設 forced Claude 不讀 credentials。
+    usage_monitor_started = False
+    if settings.ai_provider_mode == "auto":
+        try:
+            from .services.claude_usage import claude_usage_monitor
+
+            await claude_usage_monitor.start()
+            usage_monitor_started = True
+        except Exception:
+            # 啟動失敗不得阻止既有服務；詳細內容可能含敏感資料，不寫入 log。
+            _logging.getLogger(__name__).warning("Claude usage monitor 啟動失敗")
+
     # 註冊 Bot 斜線指令
     from .services.bot.command_handlers import register_builtin_commands
     register_builtin_commands()
@@ -278,6 +290,13 @@ async def lifespan(app: FastAPI):
             await telegram_polling_task
         except asyncio.CancelledError:
             pass
+    if usage_monitor_started:
+        try:
+            from .services.claude_usage import claude_usage_monitor
+
+            await claude_usage_monitor.stop()
+        except Exception:
+            _logging.getLogger(__name__).warning("Claude usage monitor 關閉失敗")
     stop_scheduler()
     await terminal_service.stop_cleanup_task()
     terminal_service.close_all()

--- a/backend/src/ching_tech_os/services/ai_provider.py
+++ b/backend/src/ching_tech_os/services/ai_provider.py
@@ -1,0 +1,71 @@
+"""AI provider 共用契約。
+
+此模組只定義 provider-neutral 型別與 Protocol，不負責選擇或啟動 provider。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+
+ToolNotifyCallback = Callable[[str, dict], Awaitable[None]]
+DEFAULT_TIMEOUT = 180
+
+
+@dataclass
+class ToolCall:
+    """Provider-neutral 工具呼叫紀錄。"""
+
+    id: str
+    name: str
+    input: dict
+    output: str | None = None
+
+
+@dataclass
+class AIResponse:
+    """所有 AI provider 共用的回應格式。"""
+
+    success: bool
+    message: str
+    error: str | None = None
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    tool_timings: list[dict] = field(default_factory=list)
+    provider: str = "unknown"
+    actual_model: str | None = None
+    route_reason: str | None = None
+    provider_started: bool = False
+    usage_snapshot: dict[str, Any] | None = None
+
+
+@runtime_checkable
+class AIProvider(Protocol):
+    """Claude 與未來 Codex adapter 必須實作的 provider 契約。"""
+
+    provider_name: str
+
+    async def is_ready(self) -> bool:
+        """在尚未建立 session 前檢查 provider 是否可接受請求。"""
+        ...
+
+    async def call(
+        self,
+        prompt: str,
+        model: str = "sonnet",
+        history: list[dict] | None = None,
+        system_prompt: str | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+        tools: list[str] | None = None,
+        tool_call_limits: dict[str, int] | None = None,
+        on_tool_start: ToolNotifyCallback | None = None,
+        on_tool_end: ToolNotifyCallback | None = None,
+        required_mcp_servers: set[str] | None = None,
+        ctos_user_id: int | None = None,
+        extra_mcp_env: dict[str, str] | None = None,
+    ) -> AIResponse:
+        """執行單次 provider request。"""
+        ...

--- a/backend/src/ching_tech_os/services/ai_router.py
+++ b/backend/src/ching_tech_os/services/ai_router.py
@@ -1,7 +1,4 @@
-"""Provider-neutral AI 呼叫旁路。
-
-目前固定委派 Claude；usage routing、canary 與 Codex provider 尚未接入。
-"""
+"""Provider-neutral AI 呼叫旁路。"""
 
 from __future__ import annotations
 
@@ -15,6 +12,7 @@ from ..config import AI_PROVIDER_MODES, settings
 from .ai_provider import AIProvider, AIResponse, DEFAULT_TIMEOUT, ToolNotifyCallback
 from .claude_agent import call_claude
 from .claude_usage import UsageSnapshot, claude_usage_monitor
+from .codex_agent import call_codex, codex_provider
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +120,21 @@ class _ClaudeProvider:
         return await call_claude(**provider_kwargs)
 
 
-_provider_router = ProviderRouter({"claude": _ClaudeProvider()})
+class _CodexProvider:
+    """保留可 monkeypatch 的 call_codex 邊界並委派 readiness。"""
+
+    provider_name = "codex"
+
+    async def is_ready(self) -> bool:
+        return await codex_provider.is_ready()
+
+    async def call(self, **provider_kwargs: Any) -> AIResponse:
+        return await call_codex(**provider_kwargs)
+
+
+_provider_router = ProviderRouter(
+    {"claude": _ClaudeProvider(), "codex": _CodexProvider()}
+)
 
 
 @dataclass(frozen=True)
@@ -262,7 +274,7 @@ async def call_ai(
     extra_mcp_env: dict[str, str] | None = None,
     routing_context: RoutingContext | None = None,
 ) -> AIResponse:
-    """以 provider-neutral 介面呼叫 AI，目前永遠固定使用 Claude。
+    """以 provider-neutral 介面呼叫 AI。
 
     ``routing_context`` 只保留給未來 router 判斷，不會傳入 prompt 或 provider。
     """

--- a/backend/src/ching_tech_os/services/ai_router.py
+++ b/backend/src/ching_tech_os/services/ai_router.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -13,6 +14,7 @@ from typing import Any
 from ..config import AI_PROVIDER_MODES, settings
 from .ai_provider import AIProvider, AIResponse, DEFAULT_TIMEOUT, ToolNotifyCallback
 from .claude_agent import call_claude
+from .claude_usage import UsageSnapshot, claude_usage_monitor
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +141,42 @@ class RoutingContext:
         object.__setattr__(self, "agent_name", normalized_agent or None)
 
 
+class UsageRoutingPolicy:
+    """以 90%/85% hysteresis 維持單一穩定 provider 狀態。"""
+
+    def __init__(self, *, switch_threshold: float, recovery_threshold: float) -> None:
+        if not 0 <= recovery_threshold < switch_threshold <= 1:
+            raise ValueError("usage thresholds 必須符合 0 <= recovery < switch <= 1")
+        self.switch_threshold = switch_threshold
+        self.recovery_threshold = recovery_threshold
+        self._stable_provider = "claude"
+        self._lock = threading.Lock()
+
+    def select(self, snapshot: UsageSnapshot) -> tuple[str, str]:
+        with self._lock:
+            if snapshot.state == "unknown":
+                self._stable_provider = "claude"
+                return "claude", "usage_unknown"
+            if snapshot.state == "error" or snapshot.utilization is None:
+                self._stable_provider = "claude"
+                return "claude", "usage_error"
+            if snapshot.state == "stale":
+                return self._stable_provider, "usage_stale"
+
+            if snapshot.utilization >= self.switch_threshold:
+                self._stable_provider = "codex"
+                return "codex", "usage_threshold"
+            if snapshot.utilization < self.recovery_threshold:
+                reason = (
+                    "usage_recovered"
+                    if self._stable_provider == "codex"
+                    else "usage_below_threshold"
+                )
+                self._stable_provider = "claude"
+                return "claude", reason
+            return self._stable_provider, "usage_hysteresis"
+
+
 def is_canary_allowed(
     routing_context: RoutingContext | None,
     *,
@@ -163,30 +201,50 @@ def is_canary_allowed(
     )
 
 
-def _claude_route_reason(routing_context: RoutingContext | None) -> str:
-    """在 Codex/usage 尚未接入前，產生安全且可觀測的 Claude 路由原因。"""
-    mode = str(settings.ai_provider_mode).strip().lower()
+def select_provider_decision(
+    *,
+    mode: str,
+    routing_context: RoutingContext | None,
+    usage_snapshot: UsageSnapshot | None,
+    policy: UsageRoutingPolicy,
+    allowed_contexts: frozenset[str],
+    allowed_agents: frozenset[str],
+) -> ProviderDecision:
+    """在 provider 執行前，以設定、canary 與快照建立單次決策。"""
+    mode = str(mode).strip().lower()
     if mode not in AI_PROVIDER_MODES:
-        return "invalid_mode"
+        return ProviderDecision("claude", "invalid_mode")
     if mode == "claude":
-        return "forced_claude"
+        return ProviderDecision("claude", "forced_claude")
     if mode == "codex":
-        return "codex_unready"
+        return ProviderDecision(
+            "codex",
+            "forced_codex",
+            fallback_provider="claude",
+            fallback_reason="codex_unready",
+        )
     if not is_canary_allowed(
         routing_context,
-        allowed_contexts=settings.ai_provider_canary_contexts,
-        allowed_agents=settings.ai_provider_canary_agents,
+        allowed_contexts=allowed_contexts,
+        allowed_agents=allowed_agents,
     ):
-        return "canary_not_allowed"
-    return "usage_unknown"
+        return ProviderDecision("claude", "canary_not_allowed")
+
+    selected, reason = policy.select(usage_snapshot or UsageSnapshot())
+    if selected == "codex":
+        return ProviderDecision(
+            "codex",
+            reason,
+            fallback_provider="claude",
+            fallback_reason="codex_unready",
+        )
+    return ProviderDecision("claude", reason)
 
 
-def _safe_claude_decision(routing_context: RoutingContext | None) -> ProviderDecision:
-    """Codex/usage 尚未接入時，所有 mode 都建立固定 Claude 決策。"""
-    return ProviderDecision(
-        provider_name="claude",
-        route_reason=_claude_route_reason(routing_context),
-    )
+_usage_policy = UsageRoutingPolicy(
+    switch_threshold=settings.claude_usage_switch_threshold,
+    recovery_threshold=settings.claude_usage_recovery_threshold,
+)
 
 
 async def call_ai(
@@ -208,8 +266,17 @@ async def call_ai(
 
     ``routing_context`` 只保留給未來 router 判斷，不會傳入 prompt 或 provider。
     """
-    decision = _safe_claude_decision(routing_context)
-    return await _provider_router.execute(
+    mode = str(settings.ai_provider_mode).strip().lower()
+    usage_snapshot = claude_usage_monitor.snapshot() if mode == "auto" else None
+    decision = select_provider_decision(
+        mode=mode,
+        routing_context=routing_context,
+        usage_snapshot=usage_snapshot,
+        policy=_usage_policy,
+        allowed_contexts=settings.ai_provider_canary_contexts,
+        allowed_agents=settings.ai_provider_canary_agents,
+    )
+    response = await _provider_router.execute(
         decision,
         prompt=prompt,
         model=model,
@@ -224,3 +291,6 @@ async def call_ai(
         ctos_user_id=ctos_user_id,
         extra_mcp_env=extra_mcp_env,
     )
+    if usage_snapshot is not None:
+        response.usage_snapshot = usage_snapshot.as_metadata()
+    return response

--- a/backend/src/ching_tech_os/services/ai_router.py
+++ b/backend/src/ching_tech_os/services/ai_router.py
@@ -1,0 +1,226 @@
+"""Provider-neutral AI 呼叫旁路。
+
+目前固定委派 Claude；usage routing、canary 與 Codex provider 尚未接入。
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ..config import AI_PROVIDER_MODES, settings
+from .ai_provider import AIProvider, AIResponse, DEFAULT_TIMEOUT, ToolNotifyCallback
+from .claude_agent import call_claude
+
+logger = logging.getLogger(__name__)
+
+
+class ProviderUnavailableError(RuntimeError):
+    """選定的 provider 與允許的 pre-start fallback 都不可用。"""
+
+
+@dataclass(frozen=True)
+class ProviderDecision:
+    """單次請求在任何 provider 執行前固定的路由決策。"""
+
+    provider_name: str
+    route_reason: str
+    fallback_provider: str | None = None
+    fallback_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        provider_name = self.provider_name.strip().lower()
+        route_reason = self.route_reason.strip().lower()
+        fallback_provider = (
+            self.fallback_provider.strip().lower()
+            if self.fallback_provider
+            else None
+        )
+        fallback_reason = (
+            self.fallback_reason.strip().lower()
+            if self.fallback_reason
+            else None
+        )
+        if not provider_name or not route_reason:
+            raise ValueError("provider_name 與 route_reason 不得為空")
+        if fallback_provider == provider_name:
+            raise ValueError("fallback provider 不得與主要 provider 相同")
+        object.__setattr__(self, "provider_name", provider_name)
+        object.__setattr__(self, "route_reason", route_reason)
+        object.__setattr__(self, "fallback_provider", fallback_provider)
+        object.__setattr__(self, "fallback_reason", fallback_reason)
+
+
+class ProviderRouter:
+    """先完成 readiness，再以 sticky provider 執行單次請求。"""
+
+    def __init__(self, providers: Mapping[str, AIProvider]) -> None:
+        normalized: dict[str, AIProvider] = {}
+        for name, provider in providers.items():
+            normalized_name = str(name).strip().lower()
+            if not normalized_name:
+                raise ValueError("provider registry 名稱不得為空")
+            provider_name = str(provider.provider_name).strip().lower()
+            if provider_name != normalized_name:
+                raise ValueError("provider registry key 與 provider_name 不一致")
+            normalized[normalized_name] = provider
+        self._providers = normalized
+
+    async def _get_ready_provider(self, provider_name: str) -> AIProvider | None:
+        provider = self._providers.get(provider_name)
+        if provider is None:
+            return None
+        try:
+            ready = await provider.is_ready()
+        except Exception:
+            # readiness error 可能含敏感診斷，這裡只記 provider 名稱。
+            logger.warning("AI provider %s readiness check 失敗", provider_name)
+            return None
+        return provider if ready else None
+
+    async def execute(
+        self,
+        decision: ProviderDecision,
+        **provider_kwargs: Any,
+    ) -> AIResponse:
+        """依既定決策執行；只允許在 provider call 前 fallback。"""
+        provider = await self._get_ready_provider(decision.provider_name)
+        selected_name = decision.provider_name
+        route_reason = decision.route_reason
+
+        if provider is None and decision.fallback_provider:
+            selected_name = decision.fallback_provider
+            provider = await self._get_ready_provider(selected_name)
+            route_reason = decision.fallback_reason or decision.route_reason
+
+        if provider is None:
+            raise ProviderUnavailableError(
+                f"AI provider unavailable: {selected_name}"
+            )
+
+        # 進入 provider.call 後視為已跨越 router 的執行邊界；任何結果或例外
+        # 都直接回傳/拋出，不再查詢或呼叫 fallback provider。
+        response = await provider.call(**provider_kwargs)
+        response.provider = selected_name
+        response.route_reason = route_reason
+        return response
+
+
+class _ClaudeProvider:
+    """將現有 call_claude 包成 provider-neutral adapter。"""
+
+    provider_name = "claude"
+
+    async def is_ready(self) -> bool:
+        return True
+
+    async def call(self, **provider_kwargs: Any) -> AIResponse:
+        return await call_claude(**provider_kwargs)
+
+
+_provider_router = ProviderRouter({"claude": _ClaudeProvider()})
+
+
+@dataclass(frozen=True)
+class RoutingContext:
+    """只供 router 判斷的可信上下文，不得傳入模型或 provider。"""
+
+    context_type: str
+    agent_name: str | None = None
+
+    def __post_init__(self) -> None:
+        normalized_context = self.context_type.strip().lower()
+        if not normalized_context:
+            raise ValueError("routing context_type 不得為空")
+        normalized_agent = self.agent_name.strip().lower() if self.agent_name else None
+        object.__setattr__(self, "context_type", normalized_context)
+        object.__setattr__(self, "agent_name", normalized_agent or None)
+
+
+def is_canary_allowed(
+    routing_context: RoutingContext | None,
+    *,
+    allowed_contexts: frozenset[str],
+    allowed_agents: frozenset[str],
+) -> bool:
+    """以 context 或 Agent exact match 判斷是否進入 canary scope。"""
+    if routing_context is None:
+        return False
+
+    normalized_contexts = {
+        str(value).strip().lower() for value in allowed_contexts if str(value).strip()
+    }
+    normalized_agents = {
+        str(value).strip().lower() for value in allowed_agents if str(value).strip()
+    }
+    if routing_context.context_type in normalized_contexts:
+        return True
+    return bool(
+        routing_context.agent_name
+        and routing_context.agent_name in normalized_agents
+    )
+
+
+def _claude_route_reason(routing_context: RoutingContext | None) -> str:
+    """在 Codex/usage 尚未接入前，產生安全且可觀測的 Claude 路由原因。"""
+    mode = str(settings.ai_provider_mode).strip().lower()
+    if mode not in AI_PROVIDER_MODES:
+        return "invalid_mode"
+    if mode == "claude":
+        return "forced_claude"
+    if mode == "codex":
+        return "codex_unready"
+    if not is_canary_allowed(
+        routing_context,
+        allowed_contexts=settings.ai_provider_canary_contexts,
+        allowed_agents=settings.ai_provider_canary_agents,
+    ):
+        return "canary_not_allowed"
+    return "usage_unknown"
+
+
+def _safe_claude_decision(routing_context: RoutingContext | None) -> ProviderDecision:
+    """Codex/usage 尚未接入時，所有 mode 都建立固定 Claude 決策。"""
+    return ProviderDecision(
+        provider_name="claude",
+        route_reason=_claude_route_reason(routing_context),
+    )
+
+
+async def call_ai(
+    prompt: str,
+    model: str = "sonnet",
+    history: list[dict] | None = None,
+    system_prompt: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    tools: list[str] | None = None,
+    tool_call_limits: dict[str, int] | None = None,
+    on_tool_start: ToolNotifyCallback | None = None,
+    on_tool_end: ToolNotifyCallback | None = None,
+    required_mcp_servers: set[str] | None = None,
+    ctos_user_id: int | None = None,
+    extra_mcp_env: dict[str, str] | None = None,
+    routing_context: RoutingContext | None = None,
+) -> AIResponse:
+    """以 provider-neutral 介面呼叫 AI，目前永遠固定使用 Claude。
+
+    ``routing_context`` 只保留給未來 router 判斷，不會傳入 prompt 或 provider。
+    """
+    decision = _safe_claude_decision(routing_context)
+    return await _provider_router.execute(
+        decision,
+        prompt=prompt,
+        model=model,
+        history=history,
+        system_prompt=system_prompt,
+        timeout=timeout,
+        tools=tools,
+        tool_call_limits=tool_call_limits,
+        on_tool_start=on_tool_start,
+        on_tool_end=on_tool_end,
+        required_mcp_servers=required_mcp_servers,
+        ctos_user_id=ctos_user_id,
+        extra_mcp_env=extra_mcp_env,
+    )

--- a/backend/src/ching_tech_os/services/claude_agent.py
+++ b/backend/src/ching_tech_os/services/claude_agent.py
@@ -12,23 +12,16 @@ import re
 import shutil
 import tempfile
 import time
-from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import yaml
 from claude_code_acp import ClaudeClient
 
 from ..config import settings
+from .ai_provider import AIResponse, DEFAULT_TIMEOUT, ToolCall, ToolNotifyCallback
 
 logger = logging.getLogger(__name__)
-
-# Tool 進度通知 callback 型態（保持向後相容）
-ToolNotifyCallback = Callable[[str, dict], Awaitable[None]]
-
-# 超時設定（秒）
-DEFAULT_TIMEOUT = 180
 
 # 工作目錄基底（模組級只做 base，每次 call 會建立獨立子目錄）
 _WORKING_DIR_BASE = os.environ.get("CHING_TECH_WORKING_DIR", "")
@@ -179,28 +172,11 @@ MODEL_MAP = {
 
 
 # ============================================================
-# 資料類別（保持不變）
+# 資料類別相容 alias
 # ============================================================
 
-@dataclass
-class ToolCall:
-    """工具調用記錄"""
-    id: str
-    name: str
-    input: dict
-    output: Optional[str] = None
-
-
-@dataclass
-class ClaudeResponse:
-    """Claude CLI 回應"""
-    success: bool
-    message: str
-    error: Optional[str] = None
-    tool_calls: list[ToolCall] = field(default_factory=list)
-    input_tokens: Optional[int] = None
-    output_tokens: Optional[int] = None
-    tool_timings: list[dict] = field(default_factory=list)
+# 既有 caller 可繼續從 claude_agent 匯入 ClaudeResponse / ToolCall。
+ClaudeResponse = AIResponse
 
 
 # ============================================================
@@ -440,6 +416,7 @@ async def call_claude(
         mcp_servers=mcp_servers,
         system_prompt=system_prompt,
     )
+    provider_started = False
 
     @client.on_tool_start
     async def handle_tool_start(tool_id: str, title: str, raw_input: dict):
@@ -569,7 +546,9 @@ async def call_claude(
     # 避免 start_session() 掛住時沒有超時機制（例如 MCP 工具巢狀呼叫場景）
     async def _run_session() -> str:
         """啟動 session、設定模型/權限、送出 prompt"""
+        nonlocal provider_started
         await client.start_session()
+        provider_started = True
 
         if cli_model and cli_model != "sonnet":
             try:
@@ -603,6 +582,10 @@ async def call_claude(
             input_tokens=_usage_data.get("input_tokens"),
             output_tokens=_usage_data.get("output_tokens"),
             tool_timings=tool_timings,
+            provider="claude",
+            actual_model=cli_model,
+            route_reason="direct_claude",
+            provider_started=provider_started,
         )
 
     except asyncio.TimeoutError:
@@ -634,6 +617,10 @@ async def call_claude(
             input_tokens=_usage_data.get("input_tokens"),
             output_tokens=_usage_data.get("output_tokens"),
             tool_timings=tool_timings,
+            provider="claude",
+            actual_model=cli_model,
+            route_reason="direct_claude",
+            provider_started=provider_started,
         )
 
     except (ConnectionError, OSError, RuntimeError, asyncio.CancelledError) as e:
@@ -645,6 +632,10 @@ async def call_claude(
             error=f"呼叫 Claude 時發生錯誤: {str(e)}",
             tool_calls=tool_calls,
             tool_timings=tool_timings,
+            provider="claude",
+            actual_model=cli_model,
+            route_reason="direct_claude",
+            provider_started=provider_started,
         )
     finally:
         # 清理底層 ClaudeClient 的 session 和行程
@@ -667,6 +658,10 @@ async def call_claude_for_summary(
             success=False,
             message="",
             error="找不到 summarizer prompt",
+            provider="claude",
+            actual_model="haiku",
+            route_reason="direct_claude",
+            provider_started=False,
         )
 
     conversation_parts = []

--- a/backend/src/ching_tech_os/services/claude_usage.py
+++ b/backend/src/ching_tech_os/services/claude_usage.py
@@ -1,0 +1,317 @@
+"""Claude OAuth 用量快照與背景刷新服務。
+
+Router 只讀取記憶體快照；credentials 與 HTTP 都不在使用者請求路徑執行。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+import httpx
+
+from ..config import settings
+
+logger = logging.getLogger(__name__)
+
+USAGE_API_URL = "https://api.anthropic.com/api/oauth/usage"
+_ANTHROPIC_BETA = "claude-code-20250219"
+_USER_AGENT = "claude-code/0.2.29"
+
+UsageState = Literal["unknown", "fresh", "stale", "error"]
+
+
+class UsagePayloadError(ValueError):
+    """Usage API payload 格式錯誤。"""
+
+
+class UsageRefreshError(RuntimeError):
+    """不包含 credentials 或 response body 的安全錯誤分類。"""
+
+
+@dataclass(frozen=True)
+class UsageValues:
+    """已正規化為 0–1 的 usage 數值。"""
+
+    five_hour: float
+    seven_day: float
+    utilization: float
+
+
+@dataclass(frozen=True)
+class UsageSnapshot:
+    """Router 可安全讀取的 Claude 用量快照。"""
+
+    state: UsageState = "unknown"
+    utilization: float | None = None
+    five_hour: float | None = None
+    seven_day: float | None = None
+    fetched_at: datetime | None = None
+    last_attempt_at: datetime | None = None
+    last_error: str | None = None
+    consecutive_failures: int = 0
+
+    def as_metadata(self) -> dict[str, Any]:
+        """轉成不含 credentials 的 response metadata。"""
+        return {
+            "state": self.state,
+            "utilization": self.utilization,
+            "five_hour": self.five_hour,
+            "seven_day": self.seven_day,
+            "fetched_at": self.fetched_at.isoformat() if self.fetched_at else None,
+            "last_attempt_at": (
+                self.last_attempt_at.isoformat() if self.last_attempt_at else None
+            ),
+            "last_error": self.last_error,
+            "consecutive_failures": self.consecutive_failures,
+        }
+
+
+def _normalize_utilization(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise UsagePayloadError("utilization 必須是數字")
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric < 0 or numeric > 100:
+        raise UsagePayloadError("utilization 超出 0–100 範圍")
+    return numeric / 100 if numeric > 1 else numeric
+
+
+def parse_usage_payload(payload: Any) -> UsageValues:
+    """解析 5h/7d payload，並相容 0–1 與 0–100 格式。"""
+    if not isinstance(payload, dict):
+        raise UsagePayloadError("usage payload 必須是物件")
+    try:
+        five_hour_raw = payload["five_hour"]["utilization"]
+        seven_day_raw = payload["seven_day"]["utilization"]
+    except (KeyError, TypeError) as exc:
+        raise UsagePayloadError("usage payload 缺少必要欄位") from exc
+
+    five_hour = _normalize_utilization(five_hour_raw)
+    seven_day = _normalize_utilization(seven_day_raw)
+    return UsageValues(
+        five_hour=five_hour,
+        seven_day=seven_day,
+        utilization=max(five_hour, seven_day),
+    )
+
+
+class ClaudeUsageMonitor:
+    """以 single-flight 刷新並保存 Claude OAuth 用量。"""
+
+    def __init__(
+        self,
+        *,
+        credentials_path: str | Path | None = None,
+        refresh_ttl_seconds: float | None = None,
+        max_stale_seconds: float | None = None,
+        refresh_interval_seconds: float | None = None,
+        http_timeout_seconds: float | None = None,
+        startup_timeout_seconds: float | None = None,
+        fetcher: Callable[[], Awaitable[dict]] | None = None,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.credentials_path = Path(
+            credentials_path or settings.claude_usage_credentials_path
+        ).expanduser()
+        self.refresh_ttl_seconds = float(
+            refresh_ttl_seconds
+            if refresh_ttl_seconds is not None
+            else settings.claude_usage_refresh_ttl_seconds
+        )
+        self.max_stale_seconds = float(
+            max_stale_seconds
+            if max_stale_seconds is not None
+            else settings.claude_usage_max_stale_seconds
+        )
+        self.refresh_interval_seconds = float(
+            refresh_interval_seconds
+            if refresh_interval_seconds is not None
+            else settings.claude_usage_refresh_interval_seconds
+        )
+        self.http_timeout_seconds = float(
+            http_timeout_seconds
+            if http_timeout_seconds is not None
+            else settings.claude_usage_http_timeout_seconds
+        )
+        self.startup_timeout_seconds = float(
+            startup_timeout_seconds
+            if startup_timeout_seconds is not None
+            else settings.claude_usage_startup_timeout_seconds
+        )
+        self._clock = clock or (lambda: datetime.now(UTC))
+        self._fetcher = fetcher or self._fetch_payload
+        self._snapshot = UsageSnapshot()
+        self._refresh_lock = asyncio.Lock()
+        self._background_task: asyncio.Task | None = None
+
+    @property
+    def is_running(self) -> bool:
+        return bool(self._background_task and not self._background_task.done())
+
+    def _age_seconds(self, now: datetime) -> float | None:
+        if self._snapshot.fetched_at is None:
+            return None
+        return max(0.0, (now - self._snapshot.fetched_at).total_seconds())
+
+    def snapshot(self) -> UsageSnapshot:
+        """依目前時間計算 fresh/stale/error，不觸發 I/O。"""
+        now = self._clock()
+        age = self._age_seconds(now)
+        if age is None:
+            state: UsageState = (
+                "error" if self._snapshot.last_attempt_at is not None else "unknown"
+            )
+        elif age <= self.refresh_ttl_seconds:
+            state = "fresh"
+        elif age <= self.max_stale_seconds:
+            state = "stale"
+        else:
+            state = "error"
+        return replace(self._snapshot, state=state)
+
+    def _cache_is_fresh(self) -> bool:
+        return self.snapshot().state == "fresh"
+
+    def _record_failure(self, category: str, attempted_at: datetime) -> UsageSnapshot:
+        self._snapshot = replace(
+            self._snapshot,
+            last_attempt_at=attempted_at,
+            last_error=category,
+            consecutive_failures=self._snapshot.consecutive_failures + 1,
+        )
+        safe_snapshot = self.snapshot()
+        logger.warning(
+            "Claude usage refresh 失敗: category=%s failures=%d",
+            category,
+            safe_snapshot.consecutive_failures,
+        )
+        return safe_snapshot
+
+    async def refresh(self, *, force: bool = False) -> UsageSnapshot:
+        """刷新快照；同時間只允許一個外部請求。"""
+        if not force and self._cache_is_fresh():
+            return self.snapshot()
+
+        async with self._refresh_lock:
+            if not force and self._cache_is_fresh():
+                return self.snapshot()
+            attempted_at = self._clock()
+            try:
+                payload = await self._fetcher()
+                values = parse_usage_payload(payload)
+            except asyncio.CancelledError:
+                raise
+            except UsageRefreshError as exc:
+                return self._record_failure(str(exc), attempted_at)
+            except UsagePayloadError:
+                return self._record_failure("invalid_response", attempted_at)
+            except Exception:
+                return self._record_failure("unexpected_error", attempted_at)
+
+            self._snapshot = UsageSnapshot(
+                state="fresh",
+                utilization=values.utilization,
+                five_hour=values.five_hour,
+                seven_day=values.seven_day,
+                fetched_at=attempted_at,
+                last_attempt_at=attempted_at,
+            )
+            logger.info(
+                "Claude usage refresh 成功: 5h=%.1f%% 7d=%.1f%% max=%.1f%%",
+                values.five_hour * 100,
+                values.seven_day * 100,
+                values.utilization * 100,
+            )
+            return self.snapshot()
+
+    def _load_access_token(self) -> str:
+        try:
+            raw = self.credentials_path.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise UsageRefreshError("credentials_missing") from exc
+        except OSError as exc:
+            raise UsageRefreshError("credentials_unreadable") from exc
+        try:
+            credentials = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            raise UsageRefreshError("credentials_invalid") from exc
+        if not isinstance(credentials, dict):
+            raise UsageRefreshError("credentials_invalid")
+        oauth = credentials.get("claudeAiOauth")
+        if not isinstance(oauth, dict):
+            oauth = {}
+        token = oauth.get("accessToken")
+        if not isinstance(token, str) or not token.strip():
+            raise UsageRefreshError("credentials_token_missing")
+        return token.strip()
+
+    async def _fetch_payload(self) -> dict:
+        token = self._load_access_token()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "anthropic-beta": _ANTHROPIC_BETA,
+            "User-Agent": _USER_AGENT,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=self.http_timeout_seconds) as client:
+                response = await client.get(USAGE_API_URL, headers=headers)
+        except httpx.RequestError as exc:
+            raise UsageRefreshError("network_error") from exc
+
+        if response.status_code != 200:
+            category = (
+                "http_5xx" if response.status_code >= 500 else f"http_{response.status_code}"
+            )
+            raise UsageRefreshError(category)
+        try:
+            payload = response.json()
+        except (TypeError, ValueError) as exc:
+            raise UsageRefreshError("invalid_response") from exc
+        if not isinstance(payload, dict):
+            raise UsageRefreshError("invalid_response")
+        return payload
+
+    async def _refresh_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self.refresh_interval_seconds)
+                await self.refresh(force=True)
+        except asyncio.CancelledError:
+            raise
+
+    async def start(self) -> None:
+        """短 timeout 初次刷新；任何失敗都不阻止服務啟動。"""
+        if self.is_running:
+            return
+        try:
+            await asyncio.wait_for(
+                self.refresh(force=True),
+                timeout=self.startup_timeout_seconds,
+            )
+        except TimeoutError:
+            self._record_failure("startup_timeout", self._clock())
+        self._background_task = asyncio.create_task(
+            self._refresh_loop(),
+            name="claude-usage-monitor",
+        )
+
+    async def stop(self) -> None:
+        task = self._background_task
+        self._background_task = None
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+claude_usage_monitor = ClaudeUsageMonitor()

--- a/backend/src/ching_tech_os/services/codex_acp.py
+++ b/backend/src/ching_tech_os/services/codex_acp.py
@@ -1,0 +1,328 @@
+"""Codex ACP compatibility layer。
+
+修正 Generic client 的重複文字、HTTP MCP、terminal tool event 與 permission
+identity 遺失問題；provider 業務邏輯留在 ``codex_agent.py``。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from acp.client.connection import ClientSideConnection
+from acp.schema import (
+    AgentMessageChunk,
+    AllowedOutcome,
+    EnvVariable,
+    HttpHeader,
+    HttpMcpServer,
+    Implementation,
+    McpServerStdio,
+    PermissionOption,
+    RequestPermissionResponse,
+    TextContentBlock,
+    ToolCallProgress,
+    ToolCallStart,
+    ToolCallUpdate,
+)
+from claude_code_acp.acp_client import AcpClient as GenericAcpClient
+
+logger = logging.getLogger(__name__)
+
+MAX_ACP_FRAME_SIZE = 64 * 1024 * 1024
+TERMINAL_TOOL_STATUSES = frozenset({"completed", "failed"})
+
+
+def _as_plain_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if hasattr(value, "model_dump"):
+        return value.model_dump(by_alias=True, exclude_none=True)
+    raise ValueError("MCP server 設定必須是 dict 或 ACP schema object")
+
+
+def to_acp_mcp_server(value: Any) -> McpServerStdio | HttpMcpServer:
+    """轉換並完整保留 stdio 或 Streamable HTTP MCP 設定。"""
+    config = _as_plain_mapping(value)
+    server_type = str(config.get("type", "stdio")).strip().lower()
+    name = str(config.get("name", "")).strip()
+    if not name:
+        raise ValueError("MCP server name 不得為空")
+
+    if server_type == "http":
+        raw_headers = config.get("headers") or {}
+        if isinstance(raw_headers, list):
+            header_pairs = [
+                (item.get("name"), item.get("value"))
+                for item in raw_headers
+                if isinstance(item, dict)
+            ]
+        elif isinstance(raw_headers, dict):
+            header_pairs = list(raw_headers.items())
+        else:
+            raise ValueError("HTTP MCP headers 格式無效")
+        return HttpMcpServer(
+            type="http",
+            name=name,
+            url=str(config.get("url", "")),
+            headers=[
+                HttpHeader(name=str(key), value=str(item_value))
+                for key, item_value in header_pairs
+                if key is not None and item_value is not None
+            ],
+        )
+
+    if server_type != "stdio":
+        raise ValueError(f"不支援的 MCP transport: {server_type}")
+    raw_env = config.get("env") or {}
+    if isinstance(raw_env, list):
+        env_pairs = [
+            (item.get("name"), item.get("value"))
+            for item in raw_env
+            if isinstance(item, dict)
+        ]
+    elif isinstance(raw_env, dict):
+        env_pairs = list(raw_env.items())
+    else:
+        raise ValueError("stdio MCP env 格式無效")
+    return McpServerStdio(
+        name=name,
+        command=str(config.get("command", "")),
+        args=[str(item) for item in config.get("args", [])],
+        env=[
+            EnvVariable(name=str(key), value=str(item_value))
+            for key, item_value in env_pairs
+            if key is not None and item_value is not None
+        ],
+    )
+
+
+def _reject_option_id(options: list[PermissionOption]) -> str:
+    for option in options:
+        if str(option.kind).startswith("reject"):
+            return option.option_id
+    return "reject"
+
+
+class CodexAcpClient(GenericAcpClient):
+    """針對 Codex 事件契約補強的 ACP client。"""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.input_tokens: int | None = None
+        self.output_tokens: int | None = None
+        self.model_name: str | None = None
+        self._active_tool_identity: dict[str, tuple[str, dict[str, Any]]] = {}
+        self._terminal_tool_ids: set[str] = set()
+
+    def _create_client_handler(self):
+        handler = super()._create_client_handler()
+        generic_session_update = handler.session_update
+
+        async def session_update(session_id: str, update: Any) -> None:
+            if isinstance(update, AgentMessageChunk):
+                content = getattr(update, "content", None)
+                text = getattr(content, "text", None) if content is not None else None
+                if text:
+                    # ACP message chunk 是 ordered delta；重複文字也必須保留。
+                    self._text_buffer += text
+                    if self.events.on_text:
+                        await self.events.on_text(text)
+                return
+
+            if isinstance(update, ToolCallStart):
+                raw_input = update.raw_input if isinstance(update.raw_input, dict) else {}
+                self._active_tool_identity[update.tool_call_id] = (
+                    update.title or "",
+                    dict(raw_input),
+                )
+                if self.events.on_tool_start:
+                    await self.events.on_tool_start(
+                        update.tool_call_id,
+                        update.title or "",
+                        dict(raw_input),
+                    )
+                if update.status in TERMINAL_TOOL_STATUSES:
+                    await self._emit_terminal_tool_update(update)
+                return
+
+            if isinstance(update, ToolCallProgress):
+                if update.title or isinstance(update.raw_input, dict):
+                    old_title, old_input = self._active_tool_identity.get(
+                        update.tool_call_id, ("", {})
+                    )
+                    self._active_tool_identity[update.tool_call_id] = (
+                        update.title or old_title,
+                        dict(update.raw_input) if isinstance(update.raw_input, dict) else old_input,
+                    )
+                if update.status in TERMINAL_TOOL_STATUSES:
+                    await self._emit_terminal_tool_update(update)
+                return
+
+            await generic_session_update(session_id, update)
+
+        async def request_permission(
+            options: list[PermissionOption],
+            session_id: str,
+            tool_call: ToolCallUpdate,
+            **_kwargs: Any,
+        ) -> RequestPermissionResponse:
+            del session_id
+            title = tool_call.title or ""
+            raw_input = (
+                dict(tool_call.raw_input)
+                if isinstance(tool_call.raw_input, dict)
+                else {}
+            )
+            active = self._active_tool_identity.get(tool_call.tool_call_id)
+            if active:
+                active_title, active_input = active
+                title = title or active_title
+                raw_input = {**active_input, **raw_input}
+            raw_input["_acp_tool_call_id"] = tool_call.tool_call_id
+
+            selected_id = _reject_option_id(options)
+            if self.events.on_permission:
+                option_list = [
+                    {
+                        "id": option.option_id,
+                        "name": option.name,
+                        "kind": option.kind,
+                        "_meta": option.field_meta,
+                    }
+                    for option in options
+                ]
+                selected_id = await self.events.on_permission(
+                    title or "Unknown",
+                    raw_input,
+                    option_list,
+                )
+            return RequestPermissionResponse(
+                outcome=AllowedOutcome(outcome="selected", option_id=selected_id)
+            )
+
+        handler.session_update = session_update
+        handler.request_permission = request_permission
+        return handler
+
+    async def _emit_terminal_tool_update(self, update: Any) -> None:
+        tool_id = update.tool_call_id
+        if tool_id in self._terminal_tool_ids:
+            return
+        self._terminal_tool_ids.add(tool_id)
+        raw_output = update.raw_output
+        if update.content is not None:
+            raw_output = (
+                update.content
+                if raw_output is None
+                else {"raw_output": raw_output, "content": update.content}
+            )
+        if self.events.on_tool_end:
+            await self.events.on_tool_end(
+                tool_id,
+                update.status or "",
+                raw_output,
+            )
+        self._active_tool_identity.pop(tool_id, None)
+
+    async def new_session(self) -> str:
+        if not self._connection:
+            raise RuntimeError("Not connected")
+        mcp_servers = [to_acp_mcp_server(server) for server in self.mcp_servers]
+        response = await self._connection.new_session(
+            cwd=self.cwd,
+            mcp_servers=mcp_servers,
+        )
+        self._session_id = response.session_id
+        if self._pending_model:
+            pending_model = self._pending_model
+            self._pending_model = None
+            await self._connection.set_session_model(
+                model_id=pending_model,
+                session_id=self._session_id,
+            )
+        return self._session_id
+
+    async def prompt(self, text: str) -> str:
+        if not self._connection:
+            raise RuntimeError("Not connected")
+        if not self._session_id:
+            await self.new_session()
+        self._text_buffer = ""
+        self._terminal_tool_ids.clear()
+        self.input_tokens = None
+        self.output_tokens = None
+        self.model_name = None
+        try:
+            response = await self._connection.prompt(
+                prompt=[TextContentBlock(type="text", text=text)],
+                session_id=self._session_id,
+            )
+            usage = getattr(response, "usage", None)
+            if usage is not None:
+                self.input_tokens = getattr(usage, "input_tokens", None)
+                self.output_tokens = getattr(usage, "output_tokens", None)
+            metadata = getattr(response, "field_meta", None) or {}
+            if isinstance(metadata, dict):
+                quota = metadata.get("quota") or {}
+                model_usage = quota.get("model_usage") or []
+                if isinstance(model_usage, list) and model_usage:
+                    first = model_usage[0]
+                    if isinstance(first, dict) and first.get("model"):
+                        self.model_name = str(first["model"])
+            if self.events.on_complete:
+                await self.events.on_complete()
+            return self._text_buffer
+        except Exception as exc:
+            if self.events.on_error:
+                await self.events.on_error(exc)
+            raise
+
+    async def connect(self) -> None:
+        if self._process is not None:
+            return
+        self._process = await asyncio.create_subprocess_exec(
+            self.command,
+            *self.args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+            cwd=self.cwd,
+            env=self.env,
+            limit=MAX_ACP_FRAME_SIZE,
+        )
+        if self._process.stdin is None or self._process.stdout is None:
+            raise RuntimeError("無法建立 Codex ACP subprocess pipes")
+        self._connection = ClientSideConnection(
+            to_client=self._create_client_handler(),
+            input_stream=self._process.stdin,
+            output_stream=self._process.stdout,
+        )
+        response = await self._connection.initialize(
+            protocol_version=1,
+            client_info=Implementation(
+                name="ching-tech-os-codex-client",
+                version="1.0.0",
+            ),
+        )
+        logger.info("Codex ACP 已連線: %s", response.agent_info)
+        self._initialized = True
+
+    async def disconnect(self) -> None:
+        process = self._process
+        try:
+            await super().disconnect()
+        finally:
+            if process is not None:
+                for stream in (
+                    getattr(process, "stdin", None),
+                    getattr(process, "stdout", None),
+                    getattr(process, "stderr", None),
+                ):
+                    transport = getattr(stream, "_transport", None)
+                    if transport is not None:
+                        transport.close()
+                transport = getattr(process, "_transport", None)
+                if transport is not None:
+                    transport.close()

--- a/backend/src/ching_tech_os/services/codex_acp.py
+++ b/backend/src/ching_tech_os/services/codex_acp.py
@@ -7,7 +7,9 @@ identity 遺失問題；provider 業務邏輯留在 ``codex_agent.py``。
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
+import re
 from typing import Any
 
 from acp.client.connection import ClientSideConnection
@@ -32,6 +34,16 @@ logger = logging.getLogger(__name__)
 
 MAX_ACP_FRAME_SIZE = 64 * 1024 * 1024
 TERMINAL_TOOL_STATUSES = frozenset({"completed", "failed"})
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)(bearer\s+)[^\s,;]+"),
+    re.compile(r"(?i)((?:api[_-]?key|access[_-]?token|authorization)\s*[=:]\s*)[^\s,;]+"),
+)
+
+
+def _redact_diagnostics(value: str) -> str:
+    for pattern in _SECRET_PATTERNS:
+        value = pattern.sub(r"\1[REDACTED]", value)
+    return value
 
 
 def _as_plain_mapping(value: Any) -> dict[str, Any]:
@@ -115,6 +127,24 @@ class CodexAcpClient(GenericAcpClient):
         self.model_name: str | None = None
         self._active_tool_identity: dict[str, tuple[str, dict[str, Any]]] = {}
         self._terminal_tool_ids: set[str] = set()
+        self._stderr_tail = bytearray()
+        self._stderr_task: asyncio.Task[None] | None = None
+        self.stderr_max_bytes = 8192
+
+    @property
+    def stderr_tail(self) -> str:
+        """只暴露有界、可替換解碼的診斷尾端。"""
+        decoded = bytes(self._stderr_tail).decode("utf-8", errors="replace")
+        return _redact_diagnostics(decoded)
+
+    async def _drain_stderr(self) -> None:
+        if self._process is None or self._process.stderr is None:
+            return
+        while chunk := await self._process.stderr.read(4096):
+            self._stderr_tail.extend(chunk)
+            overflow = len(self._stderr_tail) - self.stderr_max_bytes
+            if overflow > 0:
+                del self._stderr_tail[:overflow]
 
     def _create_client_handler(self):
         handler = super()._create_client_handler()
@@ -287,13 +317,17 @@ class CodexAcpClient(GenericAcpClient):
             *self.args,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
             cwd=self.cwd,
             env=self.env,
             limit=MAX_ACP_FRAME_SIZE,
         )
         if self._process.stdin is None or self._process.stdout is None:
             raise RuntimeError("無法建立 Codex ACP subprocess pipes")
+        self._stderr_tail.clear()
+        self._stderr_task = asyncio.create_task(
+            self._drain_stderr(), name="codex-acp-stderr"
+        )
         self._connection = ClientSideConnection(
             to_client=self._create_client_handler(),
             input_stream=self._process.stdin,
@@ -314,6 +348,13 @@ class CodexAcpClient(GenericAcpClient):
         try:
             await super().disconnect()
         finally:
+            stderr_task = self._stderr_task
+            self._stderr_task = None
+            if stderr_task is not None:
+                if not stderr_task.done():
+                    stderr_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await stderr_task
             if process is not None:
                 for stream in (
                     getattr(process, "stdin", None),

--- a/backend/src/ching_tech_os/services/codex_agent.py
+++ b/backend/src/ching_tech_os/services/codex_agent.py
@@ -1,0 +1,510 @@
+"""Codex ACP provider。
+
+此模組只在 Router 已選定 Codex 後啟動 subprocess。所有工具權限均以
+``mcp__server__tool`` canonical identity 精確比對，任何不完整事件都拒絕。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from acp.schema import EnvVariable
+
+from ..config import settings
+from .ai_provider import AIResponse, DEFAULT_TIMEOUT, ToolCall, ToolNotifyCallback
+from .claude_agent import (
+    _build_mcp_servers,
+    _clean_overgenerated_response,
+    _cleanup_session_workdir,
+    _create_session_workdir,
+    compose_prompt_with_history,
+)
+from .codex_acp import CodexAcpClient
+
+logger = logging.getLogger(__name__)
+
+_SECURITY_PROMPT = """
+安全限制（由 ching-tech-os framework 強制執行）：
+- 工作區為唯讀；禁止 terminal、shell、檔案寫入及原生圖片工具。
+- 只能呼叫本次明確提供且允許的 MCP 工具。
+- 圖片只能透過允許的 ching-tech-os/nanobanana MCP 工具產生。
+""".strip()
+
+
+class CodexCircuitBreaker:
+    """只針對 provider 基礎設施失敗開路的輕量 circuit breaker。"""
+
+    def __init__(
+        self,
+        failure_threshold: int,
+        cooldown_seconds: float,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.failure_threshold = max(1, failure_threshold)
+        self.cooldown_seconds = max(0.1, cooldown_seconds)
+        self._clock = clock
+        self._failures = 0
+        self._opened_at: float | None = None
+
+    def allows_request(self) -> bool:
+        if self._opened_at is None:
+            return True
+        if self._clock() - self._opened_at >= self.cooldown_seconds:
+            self._opened_at = None
+            self._failures = 0
+            return True
+        return False
+
+    def record_success(self) -> None:
+        self._failures = 0
+        self._opened_at = None
+
+    def record_failure(self) -> None:
+        self._failures += 1
+        if self._failures >= self.failure_threshold:
+            self._opened_at = self._clock()
+
+
+def _resolve_executable(value: str) -> str | None:
+    """接受明確路徑或 PATH command，且只回傳可執行檔。"""
+    candidate = Path(value).expanduser()
+    if candidate.is_absolute() or candidate.parent != Path("."):
+        return str(candidate) if candidate.is_file() and os.access(candidate, os.X_OK) else None
+    resolved = shutil.which(value)
+    return resolved if resolved and os.access(resolved, os.X_OK) else None
+
+
+def _allowed_identities(tools: list[str] | None) -> set[tuple[str, str]]:
+    """只接受完整 ``mcp__server__tool`` 名稱；短名稱一律不推測。"""
+    identities: set[tuple[str, str]] = set()
+    for value in tools or []:
+        normalized = str(value).strip().lower()
+        if not normalized.startswith("mcp__"):
+            continue
+        remainder = normalized[5:]
+        server, separator, tool = remainder.partition("__")
+        if separator and server and tool:
+            identities.add((server, tool))
+    return identities
+
+
+def _canonical_identity(title: str, raw_input: dict[str, Any]) -> tuple[str, str] | None:
+    """ACP title 與 raw server/tool 必須同時存在且完全一致。"""
+    server = str(raw_input.get("server", "")).strip().lower()
+    tool = str(raw_input.get("tool", "")).strip().lower()
+    normalized_title = str(title).strip().lower()
+    if not server or not tool or normalized_title != f"mcp.{server}.{tool}":
+        return None
+    return server, tool
+
+
+def _canonical_tool_name(identity: tuple[str, str]) -> str:
+    return f"mcp__{identity[0]}__{identity[1]}"
+
+
+def _permission_option(options: list[dict], *, allow: bool) -> str:
+    target = "allow" if allow else "reject"
+    for option in options:
+        if target in str(option.get("kind", "")).lower():
+            return str(option.get("id", target))
+    return target
+
+
+def _safe_error_category(exc: BaseException) -> str:
+    text = str(exc).lower()
+    if isinstance(exc, FileNotFoundError):
+        return "binary_missing"
+    if "auth" in text or "login" in text or "unauthorized" in text:
+        return "auth_error"
+    if "mcp" in text and ("start" in text or "connect" in text):
+        return "mcp_startup_error"
+    if "overload" in text or "rate limit" in text or "429" in text:
+        return "overload"
+    if "protocol" in text or "jsonrpc" in text or "initialize" in text:
+        return "protocol_error"
+    return "execution_error"
+
+
+class CodexProvider:
+    """符合 ``AIProvider`` 的隔離式 Codex ACP adapter。"""
+
+    provider_name = "codex"
+
+    def __init__(
+        self,
+        *,
+        client_factory: Callable[..., CodexAcpClient] = CodexAcpClient,
+        adapter_path: str | None = None,
+        codex_path: str | None = None,
+        model: str | None = None,
+        max_concurrency: int | None = None,
+        queue_timeout: float | None = None,
+        circuit_breaker: CodexCircuitBreaker | None = None,
+    ) -> None:
+        self._client_factory = client_factory
+        self.adapter_path = adapter_path or settings.codex_acp_bin_path
+        self.codex_path = codex_path or settings.codex_bin_path
+        self.model = settings.codex_model if model is None else model
+        concurrency = max_concurrency or settings.codex_max_concurrency
+        self._semaphore = asyncio.Semaphore(max(1, concurrency))
+        self.queue_timeout = queue_timeout or settings.codex_queue_timeout_seconds
+        self.circuit_breaker = circuit_breaker or CodexCircuitBreaker(
+            settings.codex_circuit_failure_threshold,
+            settings.codex_circuit_cooldown_seconds,
+        )
+
+    async def is_ready(self) -> bool:
+        return bool(
+            self.circuit_breaker.allows_request()
+            and _resolve_executable(self.adapter_path)
+            and _resolve_executable(self.codex_path)
+        )
+
+    def _client_env(self, codex_binary: str) -> dict[str, str]:
+        env = dict(os.environ)
+        env.update(
+            {
+                "CODEX_PATH": codex_binary,
+                "INITIAL_AGENT_MODE": "read-only",
+                "NO_BROWSER": "1",
+                "CODEX_CONFIG": json.dumps(
+                    {
+                        "features": {"multi_agent": False},
+                        "sandbox_mode": "read-only",
+                        "approval_policy": "on-request",
+                    }
+                ),
+            }
+        )
+        return env
+
+    async def call(
+        self,
+        prompt: str,
+        model: str = "sonnet",
+        history: list[dict] | None = None,
+        system_prompt: str | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+        tools: list[str] | None = None,
+        tool_call_limits: dict[str, int] | None = None,
+        on_tool_start: ToolNotifyCallback | None = None,
+        on_tool_end: ToolNotifyCallback | None = None,
+        required_mcp_servers: set[str] | None = None,
+        ctos_user_id: int | None = None,
+        extra_mcp_env: dict[str, str] | None = None,
+    ) -> AIResponse:
+        del model  # Claude 的 workload role 不可直接當成 Codex model slug。
+        try:
+            await asyncio.wait_for(
+                self._semaphore.acquire(), timeout=self.queue_timeout
+            )
+        except TimeoutError:
+            return AIResponse(
+                success=False,
+                message="",
+                error="Codex 暫時忙碌（queue_timeout）",
+                provider="codex",
+                provider_started=False,
+            )
+
+        try:
+            return await self._call_acp(
+                prompt=prompt,
+                history=history,
+                system_prompt=system_prompt,
+                timeout=timeout,
+                tools=tools,
+                tool_call_limits=tool_call_limits,
+                on_tool_start=on_tool_start,
+                on_tool_end=on_tool_end,
+                required_mcp_servers=required_mcp_servers,
+                ctos_user_id=ctos_user_id,
+                extra_mcp_env=extra_mcp_env,
+            )
+        finally:
+            self._semaphore.release()
+
+    async def _call_acp(
+        self,
+        *,
+        prompt: str,
+        history: list[dict] | None,
+        system_prompt: str | None,
+        timeout: int,
+        tools: list[str] | None,
+        tool_call_limits: dict[str, int] | None,
+        on_tool_start: ToolNotifyCallback | None,
+        on_tool_end: ToolNotifyCallback | None,
+        required_mcp_servers: set[str] | None,
+        ctos_user_id: int | None,
+        extra_mcp_env: dict[str, str] | None,
+    ) -> AIResponse:
+        adapter_binary = _resolve_executable(self.adapter_path)
+        codex_binary = _resolve_executable(self.codex_path)
+        if not adapter_binary or not codex_binary:
+            self.circuit_breaker.record_failure()
+            return AIResponse(
+                success=False,
+                message="",
+                error="Codex 無法啟動（binary_missing）",
+                provider="codex",
+                provider_started=False,
+            )
+
+        session_dir = _create_session_workdir()
+        try:
+            allowed = _allowed_identities(tools)
+            allowed_servers = {server for server, _tool in allowed}
+            effective_servers = (
+                set(required_mcp_servers) & allowed_servers
+                if required_mcp_servers is not None
+                else allowed_servers
+            )
+            mcp_servers = (
+                _build_mcp_servers(session_dir, effective_servers) if tools else []
+            )
+            if mcp_servers and (ctos_user_id is not None or extra_mcp_env):
+                for server in mcp_servers:
+                    if server.name != "ching-tech-os" or not hasattr(server, "env"):
+                        continue
+                    if ctos_user_id is not None:
+                        server.env.append(
+                            EnvVariable(name="CTOS_USER_ID", value=str(ctos_user_id))
+                        )
+                    for key, value in (extra_mcp_env or {}).items():
+                        server.env.append(
+                            EnvVariable(name=str(key), value=str(value))
+                        )
+                    break
+
+            client = self._client_factory(
+                command=adapter_binary,
+                cwd=session_dir,
+                env=self._client_env(codex_binary),
+                mcp_servers=mcp_servers,
+            )
+            if hasattr(client, "stderr_max_bytes"):
+                client.stderr_max_bytes = settings.codex_stderr_max_bytes
+        except Exception:
+            self.circuit_breaker.record_failure()
+            _cleanup_session_workdir(session_dir)
+            logger.warning("Codex provider 初始化失敗，category=execution_error")
+            return AIResponse(
+                success=False,
+                message="",
+                error="Codex 請求失敗（execution_error）",
+                provider="codex",
+                provider_started=False,
+            )
+
+        limits = self._build_tool_limits(allowed, tool_call_limits)
+        counts: dict[str, int] = {}
+        pending: dict[str, tuple[str, dict[str, Any]]] = {}
+        active: dict[str, tuple[str, float, dict[str, Any]]] = {}
+        approved: set[str] = set()
+        tool_calls: list[ToolCall] = []
+        tool_timings: list[dict] = []
+        permission_lock = asyncio.Lock()
+        security_violation: str | None = None
+        provider_started = False
+
+        async def safe_notify(callback: ToolNotifyCallback | None, name: str, data: dict) -> None:
+            if callback is None:
+                return
+            try:
+                await callback(name, data)
+            except Exception:
+                logger.warning("Codex 工具通知 callback 失敗", exc_info=False)
+
+        @client.on_tool_start
+        async def handle_tool_start(tool_id: str, title: str, raw_input: dict) -> None:
+            nonlocal security_violation
+            identity = _canonical_identity(title, raw_input)
+            if identity is None:
+                security_violation = "non_canonical_tool"
+                return
+            pending[tool_id] = (_canonical_tool_name(identity), dict(raw_input))
+
+        @client.on_permission
+        async def handle_permission(title: str, raw_input: dict, options: list[dict]) -> str:
+            nonlocal security_violation
+            identity = _canonical_identity(title, raw_input)
+            tool_id = str(raw_input.get("_acp_tool_call_id", ""))
+            async with permission_lock:
+                if identity is None or identity not in allowed or not tool_id:
+                    security_violation = "permission_denied"
+                    return _permission_option(options, allow=False)
+                tool_name = _canonical_tool_name(identity)
+                pending_entry = pending.get(tool_id)
+                if pending_entry is None or pending_entry[0] != tool_name:
+                    security_violation = "identity_mismatch"
+                    return _permission_option(options, allow=False)
+                limit = limits.get(tool_name)
+                current = counts.get(tool_name, 0)
+                if limit is not None and current >= limit:
+                    return _permission_option(options, allow=False)
+                counts[tool_name] = current + 1
+                approved.add(tool_id)
+                active[tool_id] = (tool_name, time.monotonic(), pending_entry[1])
+            await safe_notify(on_tool_start, tool_name, pending_entry[1])
+            return _permission_option(options, allow=True)
+
+        @client.on_tool_end
+        async def handle_tool_end(tool_id: str, status: str, raw_output: Any) -> None:
+            nonlocal security_violation
+            pending.pop(tool_id, None)
+            item = active.pop(tool_id, None)
+            if tool_id not in approved or item is None:
+                if str(status).lower() == "completed":
+                    security_violation = "unapproved_tool_completed"
+                return
+            approved.discard(tool_id)
+            tool_name, started_at, tool_input = item
+            duration_ms = int((time.monotonic() - started_at) * 1000)
+            output = "" if raw_output is None else str(raw_output)
+            tool_calls.append(ToolCall(tool_id, tool_name, tool_input, output))
+            timing = {"name": tool_name, "duration_ms": duration_ms}
+            tool_timings.append(timing)
+            await safe_notify(
+                on_tool_end,
+                tool_name,
+                {"duration_ms": duration_ms, "output": output, "status": status},
+            )
+
+        @client.on_terminal_create
+        async def deny_terminal(_command: str, _cwd: str) -> bool:
+            nonlocal security_violation
+            security_violation = "terminal_denied"
+            return False
+
+        @client.on_file_write
+        async def deny_file_write(_path: str, _content: str) -> bool:
+            nonlocal security_violation
+            security_violation = "file_write_denied"
+            return False
+
+        full_prompt = compose_prompt_with_history(history, prompt) if history else prompt
+        prompt_parts = [_SECURITY_PROMPT]
+        if system_prompt:
+            prompt_parts.extend(["系統指示：", system_prompt])
+        prompt_parts.extend(["使用者請求：", full_prompt])
+
+        try:
+            async def run() -> str:
+                nonlocal provider_started
+                await client.connect()
+                provider_started = True
+                if self.model:
+                    await client.set_model(self.model)
+                await client.new_session()
+                return await client.prompt("\n\n".join(prompt_parts))
+
+            text = await asyncio.wait_for(run(), timeout=max(0.1, timeout))
+            if security_violation:
+                return self._failure_response(
+                    client, "security_violation", provider_started, tool_calls, tool_timings
+                )
+            self.circuit_breaker.record_success()
+            return AIResponse(
+                success=True,
+                message=_clean_overgenerated_response(text),
+                tool_calls=tool_calls,
+                input_tokens=getattr(client, "input_tokens", None),
+                output_tokens=getattr(client, "output_tokens", None),
+                tool_timings=tool_timings,
+                provider="codex",
+                actual_model=getattr(client, "model_name", None) or self.model or None,
+                provider_started=provider_started,
+            )
+        except TimeoutError:
+            self.circuit_breaker.record_failure()
+            try:
+                await client.cancel()
+            except Exception:
+                logger.debug("Codex cancel 失敗", exc_info=False)
+            return self._failure_response(
+                client, "timeout", provider_started, tool_calls, tool_timings
+            )
+        except (ConnectionError, OSError, RuntimeError, ValueError) as exc:
+            category = _safe_error_category(exc)
+            self.circuit_breaker.record_failure()
+            logger.warning("Codex provider 失敗，category=%s", category)
+            return self._failure_response(
+                client, category, provider_started, tool_calls, tool_timings
+            )
+        finally:
+            try:
+                try:
+                    await asyncio.wait_for(client.disconnect(), timeout=8)
+                except Exception:
+                    logger.warning("Codex client cleanup 未正常完成", exc_info=False)
+            finally:
+                _cleanup_session_workdir(session_dir)
+
+    @staticmethod
+    def _failure_response(
+        client: Any,
+        category: str,
+        provider_started: bool,
+        tool_calls: list[ToolCall],
+        tool_timings: list[dict],
+    ) -> AIResponse:
+        return AIResponse(
+            success=False,
+            message=_clean_overgenerated_response(getattr(client, "_text_buffer", "")),
+            error=f"Codex 請求失敗（{category}）",
+            tool_calls=tool_calls,
+            input_tokens=getattr(client, "input_tokens", None),
+            output_tokens=getattr(client, "output_tokens", None),
+            tool_timings=tool_timings,
+            provider="codex",
+            actual_model=getattr(client, "model_name", None),
+            provider_started=provider_started,
+        )
+
+    @staticmethod
+    def _build_tool_limits(
+        allowed: set[tuple[str, str]],
+        overrides: dict[str, int] | None,
+    ) -> dict[str, int]:
+        names = {_canonical_tool_name(identity) for identity in allowed}
+        limits: dict[str, int] = {}
+        image_defaults = {
+            "mcp__nanobanana__generate_image": settings.nanobanana_max_calls_per_request,
+            "mcp__nanobanana__edit_image": settings.nanobanana_max_calls_per_request,
+            "mcp__nanobanana__restore_image": settings.nanobanana_max_calls_per_request,
+            "mcp__ching-tech-os__codex_image_tool": settings.codex_image_max_calls_per_request,
+        }
+        for name, limit in image_defaults.items():
+            if name in names and int(limit) > 0:
+                limits[name] = int(limit)
+        for raw_name, raw_limit in (overrides or {}).items():
+            name = str(raw_name).strip().lower()
+            if name not in names:
+                continue
+            try:
+                limit = int(raw_limit)
+            except (TypeError, ValueError):
+                continue
+            if limit <= 0:
+                limits.pop(name, None)
+            else:
+                limits[name] = limit
+        return limits
+
+
+codex_provider = CodexProvider()
+
+
+async def call_codex(**provider_kwargs: Any) -> AIResponse:
+    """供測試與明確 provider caller 使用的 singleton 包裝。"""
+    return await codex_provider.call(**provider_kwargs)

--- a/backend/src/ching_tech_os/utils/log_filters.py
+++ b/backend/src/ching_tech_os/utils/log_filters.py
@@ -1,0 +1,62 @@
+"""httpx 日誌過濾:擋掉 Telegram 輪詢雜訊,並遮蔽 URL 裡的 bot token。
+
+**為什麼需要這支**
+
+python-telegram-bot 透過 httpx 長輪詢 `getUpdates`,每 ~30 秒一筆。
+2026-08-17 實測近 24 小時:本服務 log 共 2992 行,其中 2851 行(95.3%)
+是這個輪詢,而且每一行都把 bot token 明文寫進 /var/log/syslog 與
+systemd journal——那兩處 `ct` 讀得到,一旦有人把 log 貼進 issue 或支援單,
+token 就跟著出去了。
+
+**為什麼是掛 filter,不是把 httpx 調成 WARNING**
+
+httpx 在本專案有 12 個模組在用(clawhub、skillhub、presentation、
+claude_usage、codex_image、media_tools ...)。調等級會連帶失去那些模組的
+「打去哪、回什麼碼」紀錄,那是除錯時真正要看的東西。掛 filter 可以只精準
+拿掉輪詢雜訊,其餘完整保留。
+
+**範圍限制**
+
+filter 掛在 `httpx` logger 上,只涵蓋 httpx 發出的紀錄。若日後有別的
+函式庫也把 token 印出來,需要另外處理(logging 的 filter 不會沿著
+propagate 往上套用到子 logger 的紀錄)。
+"""
+
+import logging
+import re
+
+# Telegram bot token 形如 bot123456789:AAxxxxxxxx-yyyy
+_TOKEN_RE = re.compile(r"bot\d+:[A-Za-z0-9_-]+")
+_REDACTED = "bot***"
+
+# 長輪詢端點:內容重複且無診斷價值,整筆丟棄
+_POLLING_MARKER = "getUpdates"
+
+
+class TelegramTokenFilter(logging.Filter):
+    """丟掉輪詢雜訊,並把其餘紀錄裡的 bot token 遮蔽掉。"""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+
+        if _POLLING_MARKER in message:
+            return False
+
+        if _TOKEN_RE.search(message):
+            # 直接改寫成已格式化的字串,並清掉 args——否則之後再
+            # getMessage() 會拿含 % 佔位符的新 msg 去套舊 args 而爆掉
+            record.msg = _TOKEN_RE.sub(_REDACTED, message)
+            record.args = ()
+
+        return True
+
+
+def install_log_filters() -> None:
+    """把過濾器掛到 httpx logger 上。重複呼叫是安全的。"""
+    logger = logging.getLogger("httpx")
+
+    # uvicorn --reload 會重複 import,掛兩次會讓每筆紀錄被過濾兩輪
+    if any(isinstance(f, TelegramTokenFilter) for f in logger.filters):
+        return
+
+    logger.addFilter(TelegramTokenFilter())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -44,6 +44,68 @@ class MockToolCall:
     output: str | None
 
 
+@dataclass(frozen=True)
+class ProviderContractSpec:
+    """Claude 與未來 Codex provider 共用的測試契約。"""
+
+    claude_request_fields: frozenset[str]
+    ai_request_fields: frozenset[str]
+    response_fields: frozenset[str]
+    routing_metadata_fields: frozenset[str]
+    tool_start_fields: frozenset[str]
+    tool_end_fields: frozenset[str]
+    partial_result_fields: frozenset[str]
+
+
+@pytest.fixture
+def provider_contract_spec() -> ProviderContractSpec:
+    """提供 provider contract 的唯一測試定義，供 Claude/Codex 套用同一組斷言。"""
+    claude_request_fields = frozenset({
+        "prompt",
+        "model",
+        "history",
+        "system_prompt",
+        "timeout",
+        "tools",
+        "tool_call_limits",
+        "on_tool_start",
+        "on_tool_end",
+        "required_mcp_servers",
+        "ctos_user_id",
+        "extra_mcp_env",
+    })
+    response_fields = frozenset({
+        "success",
+        "message",
+        "error",
+        "tool_calls",
+        "input_tokens",
+        "output_tokens",
+        "tool_timings",
+    })
+    return ProviderContractSpec(
+        claude_request_fields=claude_request_fields,
+        ai_request_fields=claude_request_fields | {"routing_context"},
+        response_fields=response_fields,
+        routing_metadata_fields=frozenset({
+            "provider",
+            "actual_model",
+            "route_reason",
+            "provider_started",
+            "usage_snapshot",
+        }),
+        tool_start_fields=frozenset({"tool_call_id", "name", "input"}),
+        tool_end_fields=frozenset({
+            "tool_call_id",
+            "name",
+            "status",
+            "output",
+            "duration_ms",
+        }),
+        partial_result_fields=response_fields,
+    )
+
+
 @pytest.fixture
 def mock_tool_call():
     """建立 MockToolCall 的工廠函式"""

--- a/backend/tests/fixtures/codex_acp_compatibility_1_1_9.json
+++ b/backend/tests/fixtures/codex_acp_compatibility_1_1_9.json
@@ -1,0 +1,35 @@
+{
+  "recorded_at": "2026-08-04",
+  "platform": "linux-x64",
+  "versions": {
+    "codex_acp": "1.1.9",
+    "codex_cli": "0.146.0",
+    "claude_code_acp": "0.5.1",
+    "agent_client_protocol": "0.8.0",
+    "acp_protocol_version": 1
+  },
+  "validated": {
+    "pure_text": true,
+    "repeated_message_chunks": true,
+    "stdio_mcp_tool": true,
+    "http_mcp_handshake": true,
+    "timeout_cancel": true,
+    "subprocess_cleanup": true,
+    "token_and_model_metadata_fixture": true,
+    "canonical_permission_identity": true
+  },
+  "canonical_mcp_event": {
+    "title": "mcp.ctos-readonly-smoke.read_only_marker",
+    "raw_input": {
+      "server": "ctos-readonly-smoke",
+      "tool": "read_only_marker"
+    },
+    "permission_decision": "allow_once"
+  },
+  "security": {
+    "mode": "read-only",
+    "multi_agent": false,
+    "external_production_mcp": false,
+    "fixture_has_side_effects": false
+  }
+}

--- a/backend/tests/fixtures/codex_readonly_mcp_server.py
+++ b/backend/tests/fixtures/codex_readonly_mcp_server.py
@@ -1,0 +1,26 @@
+"""Codex ACP smoke 專用的單一唯讀 MCP 工具。"""
+
+from __future__ import annotations
+
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+
+mcp = FastMCP(
+    "ctos-readonly-smoke",
+    host="127.0.0.1",
+    port=int(os.getenv("CTOS_SMOKE_MCP_PORT", "8765")),
+    stateless_http=True,
+)
+
+
+@mcp.tool()
+def read_only_marker(value: str) -> str:
+    """原樣回傳 marker，不讀寫任何系統或外部資料。"""
+    return value
+
+
+if __name__ == "__main__":
+    transport = os.getenv("CTOS_SMOKE_MCP_TRANSPORT", "stdio")
+    mcp.run(transport=transport)

--- a/backend/tests/test_ai_provider_router.py
+++ b/backend/tests/test_ai_provider_router.py
@@ -270,7 +270,6 @@ async def test_call_ai_does_not_retry_after_claude_exception(
     ("mode", "routing_context", "expected_reason"),
     [
         ("claude", None, "forced_claude"),
-        ("codex", None, "codex_unready"),
         ("invalid-provider", None, "invalid_mode"),
         (
             "auto",
@@ -284,7 +283,7 @@ async def test_call_ai_does_not_retry_after_claude_exception(
         ),
     ],
 )
-async def test_call_ai_modes_remain_safely_on_claude_without_codex_provider(
+async def test_call_ai_modes_that_do_not_select_codex_remain_on_claude(
     monkeypatch: pytest.MonkeyPatch,
     mode: str,
     routing_context,
@@ -313,6 +312,53 @@ async def test_call_ai_modes_remain_safely_on_claude_without_codex_provider(
     assert result.provider == "claude"
     assert result.route_reason == expected_reason
     call_claude.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_call_ai_forced_codex_uses_registered_provider_and_forwards_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = ai_provider.AIResponse(success=True, message="Codex 回覆")
+    call_codex = AsyncMock(return_value=response)
+    monkeypatch.setattr(ai_router, "call_codex", call_codex)
+    monkeypatch.setattr(
+        ai_router.codex_provider, "is_ready", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(ai_router.settings, "ai_provider_mode", "codex")
+    on_start = AsyncMock()
+    on_end = AsyncMock()
+
+    result = await ai_router.call_ai(
+        prompt="Codex 測試",
+        model="sonnet",
+        history=[{"role": "user", "content": "先前內容"}],
+        system_prompt="系統提示",
+        timeout=30,
+        tools=["mcp__ching-tech-os__search_knowledge"],
+        tool_call_limits={"mcp__ching-tech-os__search_knowledge": 1},
+        on_tool_start=on_start,
+        on_tool_end=on_end,
+        required_mcp_servers={"ching-tech-os"},
+        ctos_user_id=7,
+        extra_mcp_env={"CTOS_GROUP_ID": "g-1"},
+    )
+
+    assert result.provider == "codex"
+    assert result.route_reason == "forced_codex"
+    call_codex.assert_awaited_once_with(
+        prompt="Codex 測試",
+        model="sonnet",
+        history=[{"role": "user", "content": "先前內容"}],
+        system_prompt="系統提示",
+        timeout=30,
+        tools=["mcp__ching-tech-os__search_knowledge"],
+        tool_call_limits={"mcp__ching-tech-os__search_knowledge": 1},
+        on_tool_start=on_start,
+        on_tool_end=on_end,
+        required_mcp_servers={"ching-tech-os"},
+        ctos_user_id=7,
+        extra_mcp_env={"CTOS_GROUP_ID": "g-1"},
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_ai_provider_router.py
+++ b/backend/tests/test_ai_provider_router.py
@@ -1,0 +1,413 @@
+"""Provider-neutral AI 契約與固定 Claude 旁路測試。"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ching_tech_os import config
+from ching_tech_os.services import ai_provider, ai_router, claude_agent
+
+
+class _FakeProvider:
+    def __init__(
+        self,
+        provider_name: str,
+        *,
+        ready: bool = True,
+        readiness_error: Exception | None = None,
+        response: ai_provider.AIResponse | None = None,
+        call_error: Exception | None = None,
+    ) -> None:
+        self.provider_name = provider_name
+        self.ready = ready
+        self.readiness_error = readiness_error
+        self.response = response or ai_provider.AIResponse(
+            success=True,
+            message=f"{provider_name} 回覆",
+            provider=provider_name,
+            provider_started=True,
+        )
+        self.call_error = call_error
+        self.readiness_count = 0
+        self.call_count = 0
+        self.received_kwargs: dict = {}
+
+    async def is_ready(self) -> bool:
+        self.readiness_count += 1
+        if self.readiness_error:
+            raise self.readiness_error
+        return self.ready
+
+    async def call(self, **kwargs):
+        self.call_count += 1
+        self.received_kwargs = kwargs
+        if self.call_error:
+            raise self.call_error
+        return self.response
+
+
+def test_provider_types_keep_claude_alias_compatible(provider_contract_spec) -> None:
+    assert claude_agent.ClaudeResponse is ai_provider.AIResponse
+    assert claude_agent.ToolCall is ai_provider.ToolCall
+
+    response = claude_agent.ClaudeResponse(success=True, message="相容回覆")
+    assert response.provider == "unknown"
+    assert response.actual_model is None
+    assert response.route_reason is None
+    assert response.provider_started is False
+    assert response.usage_snapshot is None
+    assert provider_contract_spec.response_fields <= set(vars(response))
+    assert provider_contract_spec.routing_metadata_fields <= set(vars(response))
+
+
+def test_call_ai_signature_extends_claude_contract(provider_contract_spec) -> None:
+    request_fields = set(inspect.signature(ai_router.call_ai).parameters)
+    assert request_fields == provider_contract_spec.ai_request_fields
+
+
+def test_ai_provider_protocol_is_runtime_checkable() -> None:
+    class _FakeProvider:
+        provider_name = "fake"
+
+        async def is_ready(self) -> bool:
+            return True
+
+        async def call(self, **_kwargs):
+            return ai_provider.AIResponse(success=True, message="ok")
+
+    assert isinstance(_FakeProvider(), ai_provider.AIProvider)
+
+
+def test_provider_decision_normalizes_and_rejects_ambiguous_fallback() -> None:
+    decision = ai_router.ProviderDecision(
+        provider_name=" Codex ",
+        route_reason=" Forced_Codex ",
+        fallback_provider=" Claude ",
+        fallback_reason=" Codex_Unready ",
+    )
+    assert decision.provider_name == "codex"
+    assert decision.route_reason == "forced_codex"
+    assert decision.fallback_provider == "claude"
+    assert decision.fallback_reason == "codex_unready"
+
+    with pytest.raises(ValueError, match="不得為空"):
+        ai_router.ProviderDecision(provider_name=" ", route_reason="forced_codex")
+    with pytest.raises(ValueError, match="不得與主要 provider 相同"):
+        ai_router.ProviderDecision(
+            provider_name="claude",
+            route_reason="forced_claude",
+            fallback_provider="CLAUDE",
+        )
+
+
+def test_provider_registry_rejects_empty_or_mismatched_names() -> None:
+    claude = _FakeProvider("claude")
+    with pytest.raises(ValueError, match="名稱不得為空"):
+        ai_router.ProviderRouter({" ": claude})
+    with pytest.raises(ValueError, match="不一致"):
+        ai_router.ProviderRouter({"codex": claude})
+
+
+def test_provider_mode_env_validation_falls_back_to_claude(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    allowed = frozenset({"claude", "codex", "auto"})
+
+    monkeypatch.delenv("TEST_AI_PROVIDER_MODE", raising=False)
+    assert config._get_env_choice("TEST_AI_PROVIDER_MODE", "claude", allowed) == "claude"
+
+    monkeypatch.setenv("TEST_AI_PROVIDER_MODE", " AUTO ")
+    assert config._get_env_choice("TEST_AI_PROVIDER_MODE", "claude", allowed) == "auto"
+
+    caplog.set_level("ERROR", logger=config.__name__)
+    monkeypatch.setenv("TEST_AI_PROVIDER_MODE", "invalid-provider")
+    assert config._get_env_choice("TEST_AI_PROVIDER_MODE", "claude", allowed) == "claude"
+    assert "TEST_AI_PROVIDER_MODE" in caplog.text
+    assert "使用安全預設值 claude" in caplog.text
+
+    monkeypatch.setenv(
+        "TEST_AI_PROVIDER_CANARY",
+        " Internal_Admin, internal_test,INTERNAL_ADMIN,, ",
+    )
+    assert config._get_env_lower_set("TEST_AI_PROVIDER_CANARY") == {
+        "internal_admin",
+        "internal_test",
+    }
+
+
+def test_routing_context_normalizes_and_validates_values() -> None:
+    context = ai_router.RoutingContext(
+        context_type=" Internal_Admin ",
+        agent_name=" Test-Agent ",
+    )
+    assert context.context_type == "internal_admin"
+    assert context.agent_name == "test-agent"
+
+    with pytest.raises(ValueError, match="context_type"):
+        ai_router.RoutingContext(context_type="   ")
+
+
+@pytest.mark.parametrize(
+    ("context", "expected"),
+    [
+        (ai_router.RoutingContext(context_type="internal_admin"), True),
+        (ai_router.RoutingContext(context_type="web", agent_name="test-agent"), True),
+        (ai_router.RoutingContext(context_type="web", agent_name="normal-agent"), False),
+        (ai_router.RoutingContext(context_type="web", agent_name="test-agent-copy"), False),
+        (None, False),
+    ],
+)
+def test_canary_allowlist_matches_context_or_agent(context, expected: bool) -> None:
+    assert ai_router.is_canary_allowed(
+        context,
+        allowed_contexts=frozenset({"internal_admin", "internal_test"}),
+        allowed_agents=frozenset({"test-agent"}),
+    ) is expected
+
+
+@pytest.mark.asyncio
+async def test_call_ai_forced_claude_forwards_all_provider_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = ai_provider.AIResponse(
+        success=True,
+        message="Claude 回覆",
+        provider="claude",
+        route_reason="direct_claude",
+        provider_started=True,
+    )
+    call_claude = AsyncMock(return_value=response)
+    monkeypatch.setattr(ai_router, "call_claude", call_claude)
+    monkeypatch.setattr(ai_router.settings, "ai_provider_mode", "claude")
+
+    on_start = AsyncMock()
+    on_end = AsyncMock()
+    result = await ai_router.call_ai(
+        prompt="最新問題",
+        model="claude-opus",
+        history=[{"role": "user", "content": "先前問題"}],
+        system_prompt="系統提示",
+        timeout=45,
+        tools=["search_knowledge"],
+        tool_call_limits={"search_knowledge": 1},
+        on_tool_start=on_start,
+        on_tool_end=on_end,
+        required_mcp_servers={"ching-tech-os"},
+        ctos_user_id=123,
+        extra_mcp_env={"CTOS_GROUP_ID": "group-1"},
+        routing_context=ai_router.RoutingContext(
+            context_type="internal_test",
+            agent_name="test-agent",
+        ),
+    )
+
+    assert result is response
+    assert result.provider == "claude"
+    assert result.route_reason == "forced_claude"
+    call_claude.assert_awaited_once_with(
+        prompt="最新問題",
+        model="claude-opus",
+        history=[{"role": "user", "content": "先前問題"}],
+        system_prompt="系統提示",
+        timeout=45,
+        tools=["search_knowledge"],
+        tool_call_limits={"search_knowledge": 1},
+        on_tool_start=on_start,
+        on_tool_end=on_end,
+        required_mcp_servers={"ching-tech-os"},
+        ctos_user_id=123,
+        extra_mcp_env={"CTOS_GROUP_ID": "group-1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_ai_does_not_retry_after_claude_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    call_claude = AsyncMock(side_effect=RuntimeError("provider failed"))
+    monkeypatch.setattr(ai_router, "call_claude", call_claude)
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        await ai_router.call_ai(prompt="不要重送")
+
+    assert call_claude.await_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "routing_context", "expected_reason"),
+    [
+        ("claude", None, "forced_claude"),
+        ("codex", None, "codex_unready"),
+        ("invalid-provider", None, "invalid_mode"),
+        (
+            "auto",
+            ai_router.RoutingContext(context_type="web", agent_name="normal-agent"),
+            "canary_not_allowed",
+        ),
+        (
+            "auto",
+            ai_router.RoutingContext(context_type="internal_test"),
+            "usage_unknown",
+        ),
+    ],
+)
+async def test_call_ai_modes_remain_safely_on_claude_without_codex_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+    routing_context,
+    expected_reason: str,
+) -> None:
+    response = ai_provider.AIResponse(success=True, message="安全回覆")
+    call_claude = AsyncMock(return_value=response)
+    monkeypatch.setattr(ai_router, "call_claude", call_claude)
+    monkeypatch.setattr(ai_router.settings, "ai_provider_mode", mode)
+    monkeypatch.setattr(
+        ai_router.settings,
+        "ai_provider_canary_contexts",
+        frozenset({"internal_admin", "internal_test"}),
+    )
+    monkeypatch.setattr(
+        ai_router.settings,
+        "ai_provider_canary_agents",
+        frozenset({"test-agent"}),
+    )
+
+    result = await ai_router.call_ai(
+        prompt="安全模式測試",
+        routing_context=routing_context,
+    )
+
+    assert result.provider == "claude"
+    assert result.route_reason == expected_reason
+    call_claude.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "readiness_error",
+    [None, RuntimeError("preflight failed")],
+)
+async def test_provider_router_falls_back_only_when_primary_is_unready(
+    readiness_error: Exception | None,
+) -> None:
+    codex = _FakeProvider(
+        "codex",
+        ready=False,
+        readiness_error=readiness_error,
+    )
+    claude = _FakeProvider("claude")
+    router = ai_router.ProviderRouter({"codex": codex, "claude": claude})
+    decision = ai_router.ProviderDecision(
+        provider_name="codex",
+        route_reason="forced_codex",
+        fallback_provider="claude",
+        fallback_reason="codex_unready",
+    )
+
+    result = await router.execute(decision, prompt="唯讀測試")
+
+    assert result.provider == "claude"
+    assert result.route_reason == "codex_unready"
+    assert codex.readiness_count == 1
+    assert codex.call_count == 0
+    assert claude.readiness_count == 1
+    assert claude.call_count == 1
+    assert claude.received_kwargs == {"prompt": "唯讀測試"}
+
+
+@pytest.mark.asyncio
+async def test_provider_router_treats_missing_primary_as_pre_start_unready() -> None:
+    claude = _FakeProvider("claude")
+    router = ai_router.ProviderRouter({"claude": claude})
+    decision = ai_router.ProviderDecision(
+        provider_name="codex",
+        route_reason="forced_codex",
+        fallback_provider="claude",
+        fallback_reason="codex_unready",
+    )
+
+    result = await router.execute(decision, prompt="adapter 尚未安裝")
+
+    assert result.provider == "claude"
+    assert result.route_reason == "codex_unready"
+    assert claude.readiness_count == 1
+    assert claude.call_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_started", [False, True])
+async def test_provider_router_keeps_selection_sticky_after_call_begins(
+    provider_started: bool,
+) -> None:
+    codex_response = ai_provider.AIResponse(
+        success=False,
+        message="部分內容",
+        error="provider failed",
+        provider="codex",
+        provider_started=provider_started,
+    )
+    codex = _FakeProvider("codex", response=codex_response)
+    claude = _FakeProvider("claude")
+    router = ai_router.ProviderRouter({"codex": codex, "claude": claude})
+    decision = ai_router.ProviderDecision(
+        provider_name="codex",
+        route_reason="forced_codex",
+        fallback_provider="claude",
+        fallback_reason="codex_unready",
+    )
+
+    result = await router.execute(decision, prompt="不可重送")
+
+    assert result is codex_response
+    assert result.provider == "codex"
+    assert result.route_reason == "forced_codex"
+    assert codex.call_count == 1
+    assert claude.readiness_count == 0
+    assert claude.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_provider_router_does_not_retry_call_exception() -> None:
+    codex = _FakeProvider(
+        "codex",
+        call_error=RuntimeError("execution failed"),
+    )
+    claude = _FakeProvider("claude")
+    router = ai_router.ProviderRouter({"codex": codex, "claude": claude})
+    decision = ai_router.ProviderDecision(
+        provider_name="codex",
+        route_reason="forced_codex",
+        fallback_provider="claude",
+        fallback_reason="codex_unready",
+    )
+
+    with pytest.raises(RuntimeError, match="execution failed"):
+        await router.execute(decision, prompt="不可重送")
+
+    assert codex.call_count == 1
+    assert claude.readiness_count == 0
+    assert claude.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_provider_router_fails_when_fallback_is_also_unready() -> None:
+    codex = _FakeProvider("codex", ready=False)
+    claude = _FakeProvider("claude", ready=False)
+    router = ai_router.ProviderRouter({"codex": codex, "claude": claude})
+    decision = ai_router.ProviderDecision(
+        provider_name="codex",
+        route_reason="forced_codex",
+        fallback_provider="claude",
+        fallback_reason="codex_unready",
+    )
+
+    with pytest.raises(ai_router.ProviderUnavailableError, match="claude"):
+        await router.execute(decision, prompt="無可用 provider")
+
+    assert codex.call_count == 0
+    assert claude.call_count == 0

--- a/backend/tests/test_ai_provider_router.py
+++ b/backend/tests/test_ai_provider_router.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import inspect
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
 
 from ching_tech_os import config
-from ching_tech_os.services import ai_provider, ai_router, claude_agent
+from ching_tech_os.services import ai_provider, ai_router, claude_agent, claude_usage
 
 
 class _FakeProvider:
@@ -137,6 +138,33 @@ def test_provider_mode_env_validation_falls_back_to_claude(
         "internal_admin",
         "internal_test",
     }
+
+
+def test_numeric_env_helpers_validate_without_changing_existing_int_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TEST_EXISTING_INT", "42")
+    assert config._get_env_int("TEST_EXISTING_INT", 7) == 42
+    monkeypatch.setenv("TEST_EXISTING_INT", "invalid")
+    assert config._get_env_int("TEST_EXISTING_INT", 7) == 7
+
+    monkeypatch.setenv("TEST_BOUNDED_FLOAT", "0.9")
+    assert config._get_env_float_bounded(
+        "TEST_BOUNDED_FLOAT", 0.5, minimum=0.0, maximum=1.0
+    ) == 0.9
+    monkeypatch.setenv("TEST_BOUNDED_FLOAT", "1.1")
+    assert config._get_env_float_bounded(
+        "TEST_BOUNDED_FLOAT", 0.5, minimum=0.0, maximum=1.0
+    ) == 0.5
+
+    monkeypatch.setenv("TEST_BOUNDED_INT", "60")
+    assert config._get_env_int_bounded(
+        "TEST_BOUNDED_INT", 30, minimum=5, maximum=300
+    ) == 60
+    monkeypatch.setenv("TEST_BOUNDED_INT", "oops")
+    assert config._get_env_int_bounded(
+        "TEST_BOUNDED_INT", 30, minimum=5, maximum=300
+    ) == 30
 
 
 def test_routing_context_normalizes_and_validates_values() -> None:
@@ -411,3 +439,67 @@ async def test_provider_router_fails_when_fallback_is_also_unready() -> None:
 
     assert codex.call_count == 0
     assert claude.call_count == 0
+
+
+def _usage_snapshot(state: str, utilization: float | None) -> claude_usage.UsageSnapshot:
+    now = datetime(2026, 8, 4, tzinfo=UTC)
+    return claude_usage.UsageSnapshot(
+        state=state,
+        utilization=utilization,
+        five_hour=utilization,
+        seven_day=utilization,
+        fetched_at=now if utilization is not None else None,
+        last_attempt_at=now if state != "unknown" else None,
+    )
+
+
+def test_usage_policy_applies_90_85_hysteresis() -> None:
+    policy = ai_router.UsageRoutingPolicy(switch_threshold=0.90, recovery_threshold=0.85)
+
+    assert policy.select(_usage_snapshot("fresh", 0.849)) == ("claude", "usage_below_threshold")
+    assert policy.select(_usage_snapshot("fresh", 0.899)) == ("claude", "usage_hysteresis")
+    assert policy.select(_usage_snapshot("fresh", 0.90)) == ("codex", "usage_threshold")
+    assert policy.select(_usage_snapshot("fresh", 0.85)) == ("codex", "usage_hysteresis")
+    assert policy.select(_usage_snapshot("fresh", 0.849)) == ("claude", "usage_recovered")
+
+    with pytest.raises(ValueError, match="thresholds"):
+        ai_router.UsageRoutingPolicy(switch_threshold=0.85, recovery_threshold=0.90)
+
+
+def test_usage_policy_handles_unknown_stale_and_error_safely() -> None:
+    policy = ai_router.UsageRoutingPolicy(switch_threshold=0.90, recovery_threshold=0.85)
+
+    assert policy.select(_usage_snapshot("unknown", None)) == ("claude", "usage_unknown")
+    assert policy.select(_usage_snapshot("fresh", 0.95))[0] == "codex"
+    assert policy.select(_usage_snapshot("stale", 0.95)) == ("codex", "usage_stale")
+    assert policy.select(_usage_snapshot("error", 0.95)) == ("claude", "usage_error")
+    assert policy.select(_usage_snapshot("stale", 0.95)) == ("claude", "usage_stale")
+
+
+def test_auto_route_decision_requires_canary_and_attaches_safe_fallback() -> None:
+    policy = ai_router.UsageRoutingPolicy(switch_threshold=0.90, recovery_threshold=0.85)
+    canary = ai_router.RoutingContext(context_type="internal_test")
+
+    denied = ai_router.select_provider_decision(
+        mode="auto",
+        routing_context=ai_router.RoutingContext(context_type="web"),
+        usage_snapshot=_usage_snapshot("fresh", 0.95),
+        policy=policy,
+        allowed_contexts=frozenset({"internal_test"}),
+        allowed_agents=frozenset(),
+    )
+    assert denied.provider_name == "claude"
+    assert denied.route_reason == "canary_not_allowed"
+
+    selected = ai_router.select_provider_decision(
+        mode="auto",
+        routing_context=canary,
+        usage_snapshot=_usage_snapshot("fresh", 0.95),
+        policy=policy,
+        allowed_contexts=frozenset({"internal_test"}),
+        allowed_agents=frozenset(),
+    )
+    assert selected.provider_name == "codex"
+    assert selected.route_reason == "usage_threshold"
+    assert selected.fallback_provider == "claude"
+    assert selected.fallback_reason == "codex_unready"

--- a/backend/tests/test_claude_agent.py
+++ b/backend/tests/test_claude_agent.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import json
 import sys
 import types
@@ -11,7 +13,54 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from ching_tech_os import modules
 from ching_tech_os.services import ai_manager, claude_agent
+
+
+def test_provider_contract_fixture_matches_current_claude_boundary(
+    provider_contract_spec,
+) -> None:
+    request_fields = set(inspect.signature(claude_agent.call_claude).parameters)
+    assert request_fields == provider_contract_spec.claude_request_fields
+    assert provider_contract_spec.ai_request_fields == request_fields | {"routing_context"}
+
+    response = claude_agent.ClaudeResponse(
+        success=False,
+        message="部分內容",
+        error="請求超時",
+        tool_calls=[
+            claude_agent.ToolCall(
+                id="tool-1",
+                name="search_knowledge",
+                input={"query": "馬達"},
+                output="{}",
+            )
+        ],
+        input_tokens=11,
+        output_tokens=7,
+        tool_timings=[{"name": "search_knowledge", "duration_ms": 12}],
+    )
+    assert provider_contract_spec.response_fields <= set(vars(response))
+    assert provider_contract_spec.partial_result_fields <= set(vars(response))
+    assert provider_contract_spec.routing_metadata_fields == {
+        "provider",
+        "actual_model",
+        "route_reason",
+        "provider_started",
+        "usage_snapshot",
+    }
+    assert provider_contract_spec.tool_start_fields == {
+        "tool_call_id",
+        "name",
+        "input",
+    }
+    assert provider_contract_spec.tool_end_fields == {
+        "tool_call_id",
+        "name",
+        "status",
+        "output",
+        "duration_ms",
+    }
 
 
 def test_workdir_and_prompt_helpers(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -145,6 +194,93 @@ def test_load_mcp_servers_and_build(monkeypatch: pytest.MonkeyPatch, tmp_path: P
     assert {s.name for s in filtered} == {"ching-tech-os", "external"}
 
 
+def test_extends_mcp_merge_respects_enabled_modules_and_hides_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    project_root = tmp_path / "project"
+    extends_dir = project_root / "extends"
+    enabled_dir = extends_dir / "enabled"
+    disabled_dir = extends_dir / "disabled"
+    enabled_dir.mkdir(parents=True)
+    disabled_dir.mkdir(parents=True)
+
+    secret = "mcp-secret-must-not-be-logged"
+    monkeypatch.setenv("TEST_MCP_SECRET", secret)
+    monkeypatch.setattr(claude_agent.settings, "project_root", str(project_root))
+    monkeypatch.setattr(claude_agent.settings, "extends_dir", str(extends_dir))
+    monkeypatch.setitem(claude_agent._MCP_ENV_VARS, "PROJECT_ROOT", str(project_root))
+    monkeypatch.setattr(claude_agent, "_extends_mcp_servers", None)
+    monkeypatch.setattr(
+        modules,
+        "is_module_enabled",
+        lambda module_id: module_id == "enabled-module",
+    )
+
+    (project_root / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "ching-tech-os": {
+                        "type": "stdio",
+                        "command": "base-command",
+                        "args": [],
+                    },
+                    "shared": {
+                        "type": "stdio",
+                        "command": "base-wins",
+                        "args": [],
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (enabled_dir / "contributes.yaml").write_text(
+        """
+module_id: enabled-module
+mcp_servers:
+  shared:
+    command: must-not-override
+  enabled-http:
+    type: http
+    url: https://example.test/mcp
+    headers:
+      Authorization: Bearer ${TEST_MCP_SECRET}
+  enabled-stdio:
+    command: python
+    args:
+      - ${PROJECT_ROOT}/server.py
+    env:
+      SECRET: ${TEST_MCP_SECRET}
+""".strip(),
+        encoding="utf-8",
+    )
+    (disabled_dir / "contributes.yaml").write_text(
+        """
+module_id: disabled-module
+mcp_servers:
+  disabled-server:
+    command: should-not-load
+""".strip(),
+        encoding="utf-8",
+    )
+
+    caplog.set_level("INFO", logger=claude_agent.__name__)
+    extends_servers = claude_agent._load_extends_mcp_servers()
+    merged = claude_agent._build_merged_mcp_json()["mcpServers"]
+
+    assert set(extends_servers) == {"shared", "enabled-http", "enabled-stdio"}
+    assert "disabled-server" not in merged
+    assert merged["shared"]["command"] == "base-wins"
+    assert merged["enabled-http"]["headers"]["Authorization"] == f"Bearer {secret}"
+    assert merged["enabled-stdio"]["args"] == [f"{project_root}/server.py"]
+    assert merged["enabled-stdio"]["env"]["SECRET"] == secret
+    assert merged["enabled-stdio"]["type"] == "stdio"
+    assert secret not in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_get_prompt_content_and_summary(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ai_manager, "get_prompt_by_name", AsyncMock(return_value=None))
@@ -161,6 +297,10 @@ async def test_get_prompt_content_and_summary(monkeypatch: pytest.MonkeyPatch) -
     no_prompt = await claude_agent.call_claude_for_summary([{"role": "user", "content": "a"}])
     assert no_prompt.success is False
     assert "找不到 summarizer prompt" in (no_prompt.error or "")
+    assert no_prompt.provider == "claude"
+    assert no_prompt.actual_model == "haiku"
+    assert no_prompt.route_reason == "direct_claude"
+    assert no_prompt.provider_started is False
 
     monkeypatch.setattr(claude_agent, "get_prompt_content", AsyncMock(return_value="summary prompt"))
     call_mock = AsyncMock(
@@ -181,10 +321,13 @@ class _BaseFakeClient:
         self._on_tool_start = None
         self._on_tool_end = None
         self._on_permission = None
+        self._on_tool_input_transform = None
         self._on_result = None
         self._text_buffer = "partial response"
         self.model = None
         self.mode = None
+        self.started = False
+        self.closed = False
 
     def on_tool_start(self, fn):
         self._on_tool_start = fn
@@ -198,11 +341,16 @@ class _BaseFakeClient:
         self._on_permission = fn
         return fn
 
+    def on_tool_input_transform(self, fn):
+        self._on_tool_input_transform = fn
+        return fn
+
     def on_result(self, fn):
         self._on_result = fn
         return fn
 
     async def start_session(self):
+        self.started = True
         return None
 
     async def set_model(self, model: str):
@@ -212,6 +360,7 @@ class _BaseFakeClient:
         self.mode = mode
 
     async def close(self):
+        self.closed = True
         return None
 
 
@@ -252,11 +401,122 @@ class _NanobananaLoopClient(_BaseFakeClient):
         return "圖片完成"
 
 
+class _CodexImageLoopClient(_BaseFakeClient):
+    async def query(self, _prompt: str):
+        tool_name = "mcp__ching-tech-os__codex_image_tool"
+        for idx in range(2):
+            if self._on_permission:
+                allowed = await self._on_permission(
+                    tool_name,
+                    {"prompt": f"p{idx}"},
+                )
+            else:
+                allowed = True
+            if not allowed:
+                continue
+            tool_id = f"codex-image-{idx}"
+            if self._on_tool_start:
+                await self._on_tool_start(tool_id, tool_name, {"prompt": f"p{idx}"})
+            if self._on_tool_end:
+                await self._on_tool_end(tool_id, "ok", {"path": f"/tmp/{idx}.png"})
+        return "圖片完成"
+
+
+class _IdentityAndLimitClient(_BaseFakeClient):
+    latest: "_IdentityAndLimitClient | None" = None
+
+    def __init__(self, cwd=None, mcp_servers=None, system_prompt=None) -> None:
+        super().__init__(cwd=cwd, mcp_servers=mcp_servers, system_prompt=system_prompt)
+        self.received_prompt = ""
+        self.permission_decisions: list[tuple[str, bool]] = []
+        self.transformed_input: dict | None = None
+        type(self).latest = self
+
+    async def query(self, prompt: str):
+        self.received_prompt = prompt
+        assert self._on_permission is not None
+
+        denied = await self._on_permission(
+            "mcp__ching-tech-os__add_note",
+            {"content": "不應執行"},
+        )
+        self.permission_decisions.append(("add_note", denied))
+
+        raw_input = {"query": "馬達", "ctos_user_id": 999}
+        if self._on_tool_input_transform:
+            self.transformed_input = await self._on_tool_input_transform(
+                "mcp__ching-tech-os__search_knowledge",
+                raw_input,
+            )
+
+        first = await self._on_permission(
+            "mcp__ching-tech-os__search_knowledge",
+            raw_input,
+        )
+        self.permission_decisions.append(("search_knowledge_1", first))
+        if first:
+            assert self._on_tool_start is not None
+            assert self._on_tool_end is not None
+            await self._on_tool_start(
+                "search-1",
+                "mcp__ching-tech-os__search_knowledge",
+                self.transformed_input or raw_input,
+            )
+            await self._on_tool_end("search-1", "ok", {"items": []})
+
+        second = await self._on_permission(
+            "mcp__ching-tech-os__search_knowledge",
+            raw_input,
+        )
+        self.permission_decisions.append(("search_knowledge_2", second))
+
+        if self._on_result:
+            await self._on_result({"input_tokens": 7, "output_tokens": 9})
+        return "受保護回覆"
+
+
 class _TimeoutClient(_BaseFakeClient):
     async def query(self, _prompt: str):
         if self._on_tool_start:
             await self._on_tool_start("tool-2", "prepare", {"id": 1})
         raise TimeoutError
+
+
+class _PartialTimeoutClient(_BaseFakeClient):
+    latest: "_PartialTimeoutClient | None" = None
+
+    def __init__(self, cwd=None, mcp_servers=None, system_prompt=None) -> None:
+        super().__init__(cwd=cwd, mcp_servers=mcp_servers, system_prompt=system_prompt)
+        type(self).latest = self
+
+    async def query(self, _prompt: str):
+        if self._on_result:
+            await self._on_result({"input_tokens": 31, "output_tokens": 17})
+        if self._on_tool_start:
+            await self._on_tool_start("done-1", "search_knowledge", {"query": "馬達"})
+        if self._on_tool_end:
+            await self._on_tool_end("done-1", "ok", {"items": ["結果"]})
+        if self._on_tool_start:
+            await self._on_tool_start(
+                "pending-1",
+                "download_web_file",
+                {"url": "https://example.test/large.pdf", "query": "規格"},
+            )
+        self._text_buffer = "已完成的部分內容\nuser: 不應出現"
+        await asyncio.sleep(60)
+        return "不應完成"
+
+
+class _CancelledClient(_BaseFakeClient):
+    latest: "_CancelledClient | None" = None
+
+    def __init__(self, cwd=None, mcp_servers=None, system_prompt=None) -> None:
+        super().__init__(cwd=cwd, mcp_servers=mcp_servers, system_prompt=system_prompt)
+        type(self).latest = self
+
+    async def query(self, _prompt: str):
+        self._text_buffer = "取消前的部分內容"
+        raise asyncio.CancelledError("cancelled by caller")
 
 
 class _ErrorClient(_BaseFakeClient):
@@ -306,6 +566,10 @@ async def test_call_claude_success_timeout_and_error(monkeypatch: pytest.MonkeyP
     assert ok.message == "成功回覆"
     assert ok.input_tokens == 11
     assert ok.output_tokens == 22
+    assert ok.provider == "claude"
+    assert ok.actual_model == "opus"
+    assert ok.route_reason == "direct_claude"
+    assert ok.provider_started is True
     assert len(ok.tool_calls) == 1
     assert started == ["search_knowledge"]
     assert ended == ["search_knowledge"]
@@ -320,11 +584,83 @@ async def test_call_claude_success_timeout_and_error(monkeypatch: pytest.MonkeyP
     assert timeout_resp.success is False
     assert "請求超時" in (timeout_resp.error or "")
     assert "prepare" in (timeout_resp.error or "")
+    assert timeout_resp.provider == "claude"
+    assert timeout_resp.provider_started is True
 
     monkeypatch.setattr(claude_agent, "ClaudeClient", _ErrorClient)
     err_resp = await claude_agent.call_claude(prompt="hello")
     assert err_resp.success is False
     assert "呼叫 Claude 時發生錯誤" in (err_resp.error or "")
+    assert err_resp.provider == "claude"
+    assert err_resp.provider_started is True
+
+
+@pytest.mark.asyncio
+async def test_call_claude_timeout_preserves_partial_state_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    session_dir = tmp_path / "timeout-session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    cleanup_calls: list[str] = []
+
+    monkeypatch.setattr(claude_agent, "_create_session_workdir", lambda: str(session_dir))
+    monkeypatch.setattr(
+        claude_agent,
+        "_cleanup_session_workdir",
+        lambda path: cleanup_calls.append(path),
+    )
+    monkeypatch.setattr(claude_agent, "_build_mcp_servers", lambda _session_dir, _required: [])
+    monkeypatch.setattr(claude_agent, "ClaudeClient", _PartialTimeoutClient)
+
+    result = await claude_agent.call_claude(
+        prompt="分析大型文件",
+        tools=["search_knowledge", "download_web_file"],
+        timeout=0.01,
+    )
+
+    client = _PartialTimeoutClient.latest
+    assert client is not None
+    assert result.success is False
+    assert result.message == "已完成的部分內容"
+    assert "請求超時" in (result.error or "")
+    assert "download_web_file" in (result.error or "")
+    assert "url=https://example.test/large.pdf" in (result.error or "")
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].name == "search_knowledge"
+    assert len(result.tool_timings) == 1
+    assert result.input_tokens == 31
+    assert result.output_tokens == 17
+    assert client.closed is True
+    assert cleanup_calls == [str(session_dir)]
+
+
+@pytest.mark.asyncio
+async def test_call_claude_cancel_returns_partial_state_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    session_dir = tmp_path / "cancel-session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    cleanup_calls: list[str] = []
+
+    monkeypatch.setattr(claude_agent, "_create_session_workdir", lambda: str(session_dir))
+    monkeypatch.setattr(
+        claude_agent,
+        "_cleanup_session_workdir",
+        lambda path: cleanup_calls.append(path),
+    )
+    monkeypatch.setattr(claude_agent, "ClaudeClient", _CancelledClient)
+
+    result = await claude_agent.call_claude(prompt="取消測試")
+
+    client = _CancelledClient.latest
+    assert client is not None
+    assert result.success is False
+    assert result.message == "取消前的部分內容"
+    assert "cancelled by caller" in (result.error or "")
+    assert client.closed is True
+    assert cleanup_calls == [str(session_dir)]
 
 
 @pytest.mark.asyncio
@@ -347,3 +683,103 @@ async def test_call_claude_limits_nanobanana_calls(monkeypatch: pytest.MonkeyPat
     # 第二次呼叫會被 permission guard 擋下，避免單回合重複扣費
     assert len(result.tool_calls) == 1
     assert result.tool_calls[0].name == "mcp__nanobanana__generate_image"
+
+
+@pytest.mark.asyncio
+async def test_call_claude_limits_codex_image_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    session_dir = tmp_path / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(claude_agent, "_create_session_workdir", lambda: str(session_dir))
+    monkeypatch.setattr(claude_agent, "_cleanup_session_workdir", lambda _path: None)
+    monkeypatch.setattr(claude_agent, "_build_mcp_servers", lambda _session_dir, _required: [])
+    monkeypatch.setattr(claude_agent.settings, "codex_image_max_calls_per_request", 1)
+    monkeypatch.setattr(claude_agent, "ClaudeClient", _CodexImageLoopClient)
+
+    result = await claude_agent.call_claude(
+        prompt="畫圖",
+        tools=["mcp__ching-tech-os__codex_image_tool"],
+    )
+
+    assert result.success is True
+    # 第二次呼叫會被全域上限擋下，避免單回合持續微調而增加成本
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].name == "mcp__ching-tech-os__codex_image_tool"
+
+
+@pytest.mark.asyncio
+async def test_call_claude_preserves_identity_whitelist_limits_and_callback_isolation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    session_dir = tmp_path / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    server = SimpleNamespace(name="ching-tech-os", env=[])
+    required_calls: list[set[str] | None] = []
+
+    monkeypatch.setattr(claude_agent, "_create_session_workdir", lambda: str(session_dir))
+    monkeypatch.setattr(claude_agent, "_cleanup_session_workdir", lambda _path: None)
+
+    def _build_servers(_session_dir: str, required: set[str] | None):
+        required_calls.append(required)
+        return [server]
+
+    monkeypatch.setattr(claude_agent, "_build_mcp_servers", _build_servers)
+    monkeypatch.setattr(claude_agent, "ClaudeClient", _IdentityAndLimitClient)
+
+    async def _failing_start(_name: str, _raw: dict) -> None:
+        raise RuntimeError("start callback boom")
+
+    async def _failing_end(_name: str, _raw: dict) -> None:
+        raise RuntimeError("end callback boom")
+
+    caplog.set_level("WARNING", logger=claude_agent.__name__)
+    result = await claude_agent.call_claude(
+        prompt="最新問題",
+        model="claude-opus",
+        history=[{"role": "user", "content": "先前問題"}],
+        system_prompt="系統提示",
+        tools=["mcp__ching-tech-os__search_knowledge"],
+        tool_call_limits={"mcp__ching-tech-os__search_knowledge": 1},
+        on_tool_start=_failing_start,
+        on_tool_end=_failing_end,
+        required_mcp_servers={"external"},
+        ctos_user_id=123,
+        extra_mcp_env={"CTOS_GROUP_ID": "group-1"},
+    )
+
+    client = _IdentityAndLimitClient.latest
+    assert client is not None
+    assert result.success is True
+    assert result.message == "受保護回覆"
+    assert result.input_tokens == 7
+    assert result.output_tokens == 9
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].input["ctos_user_id"] == 123
+    assert client.transformed_input == {
+        "query": "馬達",
+        "ctos_user_id": 123,
+    }
+    assert client.permission_decisions == [
+        ("add_note", False),
+        ("search_knowledge_1", True),
+        ("search_knowledge_2", False),
+    ]
+    assert client.started is True
+    assert client.closed is True
+    assert client.model == "opus"
+    assert client.mode == "bypassPermissions"
+    assert client.system_prompt == "系統提示"
+    assert "user: 先前問題" in client.received_prompt
+    assert client.received_prompt.endswith("最新問題")
+    assert required_calls == [{"external"}]
+    assert {(item.name, item.value) for item in server.env} == {
+        ("CTOS_USER_ID", "123"),
+        ("CTOS_GROUP_ID", "group-1"),
+    }
+    assert "on_tool_start callback 失敗" in caplog.text
+    assert "on_tool_end callback 失敗" in caplog.text

--- a/backend/tests/test_claude_usage.py
+++ b/backend/tests/test_claude_usage.py
@@ -1,0 +1,437 @@
+"""Claude OAuth usage monitor 的資料、安全與生命週期測試。"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import httpx
+import pytest
+
+from ching_tech_os.services import claude_usage
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = datetime(2026, 8, 4, tzinfo=UTC)
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += timedelta(seconds=seconds)
+
+
+@pytest.mark.parametrize(
+    ("payload", "five_hour", "seven_day", "utilization"),
+    [
+        (
+            {"five_hour": {"utilization": 0.42}, "seven_day": {"utilization": 0.91}},
+            0.42,
+            0.91,
+            0.91,
+        ),
+        (
+            {"five_hour": {"utilization": 42}, "seven_day": {"utilization": 91}},
+            0.42,
+            0.91,
+            0.91,
+        ),
+        (
+            {"five_hour": {"utilization": 0}, "seven_day": {"utilization": 100}},
+            0.0,
+            1.0,
+            1.0,
+        ),
+        (
+            {"five_hour": {"utilization": 1}, "seven_day": {"utilization": 0.5}},
+            1.0,
+            0.5,
+            1.0,
+        ),
+    ],
+)
+def test_parse_usage_payload_accepts_ratio_and_percentage(
+    payload: dict,
+    five_hour: float,
+    seven_day: float,
+    utilization: float,
+) -> None:
+    result = claude_usage.parse_usage_payload(payload)
+
+    assert result.five_hour == five_hour
+    assert result.seven_day == seven_day
+    assert result.utilization == utilization
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        {},
+        {"five_hour": {}, "seven_day": {"utilization": 0.5}},
+        {"five_hour": {"utilization": "oops"}, "seven_day": {"utilization": 0.5}},
+        {"five_hour": {"utilization": True}, "seven_day": {"utilization": 0.5}},
+        {"five_hour": {"utilization": -0.1}, "seven_day": {"utilization": 0.5}},
+        {"five_hour": {"utilization": 101}, "seven_day": {"utilization": 0.5}},
+        {"five_hour": {"utilization": float("nan")}, "seven_day": {"utilization": 0.5}},
+        {"five_hour": {"utilization": 0.5}, "seven_day": {"utilization": float("inf")}},
+    ],
+)
+def test_parse_usage_payload_rejects_malformed_or_out_of_range(payload) -> None:
+    with pytest.raises(claude_usage.UsagePayloadError):
+        claude_usage.parse_usage_payload(payload)
+
+
+@pytest.mark.asyncio
+async def test_monitor_snapshot_transitions_unknown_fresh_stale_error() -> None:
+    clock = _Clock()
+
+    async def fetcher() -> dict:
+        return {
+            "five_hour": {"utilization": 0.25},
+            "seven_day": {"utilization": 0.75},
+        }
+
+    monitor = claude_usage.ClaudeUsageMonitor(
+        fetcher=fetcher,
+        clock=clock,
+        refresh_ttl_seconds=60,
+        max_stale_seconds=300,
+    )
+
+    assert monitor.snapshot().state == "unknown"
+    fresh = await monitor.refresh()
+    assert fresh.state == "fresh"
+    assert fresh.fetched_at == clock.now
+    assert fresh.last_attempt_at == clock.now
+    assert fresh.last_error is None
+    assert fresh.consecutive_failures == 0
+
+    clock.advance(61)
+    assert monitor.snapshot().state == "stale"
+
+    clock.advance(240)
+    expired = monitor.snapshot()
+    assert expired.state == "error"
+    assert expired.utilization == 0.75
+
+
+@pytest.mark.asyncio
+async def test_monitor_preserves_last_good_snapshot_and_recovers() -> None:
+    clock = _Clock()
+    results: list[dict | Exception] = [
+        {"five_hour": {"utilization": 0.4}, "seven_day": {"utilization": 0.7}},
+        claude_usage.UsageRefreshError("network_error"),
+        {"five_hour": {"utilization": 0.2}, "seven_day": {"utilization": 0.3}},
+    ]
+
+    async def fetcher() -> dict:
+        result = results.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monitor = claude_usage.ClaudeUsageMonitor(
+        fetcher=fetcher,
+        clock=clock,
+        refresh_ttl_seconds=60,
+        max_stale_seconds=300,
+    )
+
+    first = await monitor.refresh(force=True)
+    clock.advance(61)
+    failed = await monitor.refresh(force=True)
+    assert failed.state == "stale"
+    assert failed.utilization == first.utilization == 0.7
+    assert failed.last_error == "network_error"
+    assert failed.consecutive_failures == 1
+
+    clock.advance(1)
+    recovered = await monitor.refresh(force=True)
+    assert recovered.state == "fresh"
+    assert recovered.utilization == 0.3
+    assert recovered.last_error is None
+    assert recovered.consecutive_failures == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("result", "category"),
+    [
+        ({"five_hour": {}, "seven_day": {}}, "invalid_response"),
+        (RuntimeError("secret-unexpected-detail"), "unexpected_error"),
+    ],
+)
+async def test_monitor_categorizes_invalid_and_unexpected_fetcher_results(
+    result,
+    category: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def fetcher() -> dict:
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monitor = claude_usage.ClaudeUsageMonitor(fetcher=fetcher)
+    caplog.set_level("WARNING", logger=claude_usage.__name__)
+
+    snapshot = await monitor.refresh(force=True)
+
+    assert snapshot.last_error == category
+    assert "secret-unexpected-detail" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_monitor_refresh_is_single_flight_and_uses_ttl_cache() -> None:
+    clock = _Clock()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    async def fetcher() -> dict:
+        nonlocal call_count
+        call_count += 1
+        started.set()
+        await release.wait()
+        return {"five_hour": {"utilization": 0.1}, "seven_day": {"utilization": 0.2}}
+
+    monitor = claude_usage.ClaudeUsageMonitor(
+        fetcher=fetcher,
+        clock=clock,
+        refresh_ttl_seconds=60,
+        max_stale_seconds=300,
+    )
+    tasks = [asyncio.create_task(monitor.refresh()) for _ in range(3)]
+    await started.wait()
+    release.set()
+    snapshots = await asyncio.gather(*tasks)
+
+    assert call_count == 1
+    assert {snapshot.utilization for snapshot in snapshots} == {0.2}
+    assert (await monitor.refresh()).utilization == 0.2
+    assert call_count == 1
+
+
+class _Response:
+    def __init__(self, status_code: int, payload=None, text: str = "") -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class _Client:
+    def __init__(self, response=None, error: Exception | None = None, **_kwargs) -> None:
+        self.response = response
+        self.error = error
+        self.headers = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def get(self, _url: str, *, headers: dict):
+        self.headers = headers
+        if self.error:
+            raise self.error
+        return self.response
+
+
+@pytest.mark.asyncio
+async def test_http_success_refreshes_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    credential = tmp_path / "credentials.json"
+    credential.write_text(
+        '{"claudeAiOauth": {"accessToken": "success-secret-token"}}',
+        encoding="utf-8",
+    )
+    client = _Client(
+        _Response(
+            200,
+            payload={
+                "five_hour": {"utilization": 25},
+                "seven_day": {"utilization": 0.8},
+            },
+        )
+    )
+    monkeypatch.setattr(claude_usage.httpx, "AsyncClient", lambda **kwargs: client)
+
+    snapshot = await claude_usage.ClaudeUsageMonitor(
+        credentials_path=credential
+    ).refresh(force=True)
+
+    assert snapshot.state == "fresh"
+    assert snapshot.five_hour == 0.25
+    assert snapshot.seven_day == 0.8
+    assert snapshot.utilization == 0.8
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_code", "category"),
+    [(401, "http_401"), (429, "http_429"), (500, "http_5xx")],
+)
+async def test_http_failures_are_categorized_without_response_body_in_log(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+    status_code: int,
+    category: str,
+) -> None:
+    credential = tmp_path / "credentials.json"
+    credential.write_text(
+        '{"claudeAiOauth": {"accessToken": "super-secret-token"}}',
+        encoding="utf-8",
+    )
+    client = _Client(_Response(status_code, text="secret-response-body"))
+    monkeypatch.setattr(claude_usage.httpx, "AsyncClient", lambda **kwargs: client)
+    monitor = claude_usage.ClaudeUsageMonitor(credentials_path=credential)
+    caplog.set_level("WARNING", logger=claude_usage.__name__)
+
+    snapshot = await monitor.refresh(force=True)
+
+    assert snapshot.state == "error"
+    assert snapshot.last_error == category
+    assert "secret-response-body" not in caplog.text
+    assert "super-secret-token" not in caplog.text
+    assert client.headers["Authorization"] == "Bearer super-secret-token"
+
+
+@pytest.mark.asyncio
+async def test_missing_credentials_and_network_error_are_safely_reported(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    missing = claude_usage.ClaudeUsageMonitor(
+        credentials_path=tmp_path / "missing.json"
+    )
+    caplog.set_level("WARNING", logger=claude_usage.__name__)
+    snapshot = await missing.refresh(force=True)
+    assert snapshot.last_error == "credentials_missing"
+
+    credential = tmp_path / "credentials.json"
+    credential.write_text(
+        '{"claudeAiOauth": {"accessToken": "another-secret-token"}}',
+        encoding="utf-8",
+    )
+    request = httpx.Request("GET", claude_usage.USAGE_API_URL)
+    client = _Client(error=httpx.ReadTimeout("secret-network-detail", request=request))
+    monkeypatch.setattr(claude_usage.httpx, "AsyncClient", lambda **kwargs: client)
+    network = claude_usage.ClaudeUsageMonitor(credentials_path=credential)
+
+    snapshot = await network.refresh(force=True)
+
+    assert snapshot.last_error == "network_error"
+    assert "secret-network-detail" not in caplog.text
+    assert "another-secret-token" not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("credential_content", "category"),
+    [
+        ("not-json", "credentials_invalid"),
+        ("[]", "credentials_invalid"),
+        ("{}", "credentials_token_missing"),
+        ('{"claudeAiOauth": {"accessToken": ""}}', "credentials_token_missing"),
+    ],
+)
+async def test_invalid_credentials_are_categorized(
+    tmp_path,
+    credential_content: str,
+    category: str,
+) -> None:
+    credential = tmp_path / "credentials.json"
+    credential.write_text(credential_content, encoding="utf-8")
+    monitor = claude_usage.ClaudeUsageMonitor(credentials_path=credential)
+
+    snapshot = await monitor.refresh(force=True)
+
+    assert snapshot.last_error == category
+
+
+@pytest.mark.asyncio
+async def test_unreadable_credentials_are_categorized(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    def _raise_permission_error(_self: Path, **_kwargs):
+        raise PermissionError("secret-path-detail")
+
+    monkeypatch.setattr(Path, "read_text", _raise_permission_error)
+    monitor = claude_usage.ClaudeUsageMonitor(
+        credentials_path=tmp_path / "credentials.json"
+    )
+
+    snapshot = await monitor.refresh(force=True)
+
+    assert snapshot.last_error == "credentials_unreadable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [ValueError("secret-json-detail"), [], None],
+)
+async def test_http_200_invalid_json_is_safe_invalid_response(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+    payload,
+) -> None:
+    credential = tmp_path / "credentials.json"
+    credential.write_text(
+        '{"claudeAiOauth": {"accessToken": "secret-json-token"}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        claude_usage.httpx,
+        "AsyncClient",
+        lambda **kwargs: _Client(_Response(200, payload=payload)),
+    )
+    caplog.set_level("WARNING", logger=claude_usage.__name__)
+
+    snapshot = await claude_usage.ClaudeUsageMonitor(
+        credentials_path=credential
+    ).refresh(force=True)
+
+    assert snapshot.last_error == "invalid_response"
+    assert "secret-json-detail" not in caplog.text
+    assert "secret-json-token" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_monitor_start_timeout_does_not_block_and_stop_cleans_task() -> None:
+    blocker = asyncio.Event()
+
+    async def fetcher() -> dict:
+        await blocker.wait()
+        return {"five_hour": {"utilization": 0.1}, "seven_day": {"utilization": 0.2}}
+
+    monitor = claude_usage.ClaudeUsageMonitor(
+        fetcher=fetcher,
+        startup_timeout_seconds=0.01,
+        refresh_interval_seconds=3600,
+    )
+
+    await monitor.start()
+    assert monitor.is_running
+    assert monitor.snapshot().last_error == "startup_timeout"
+
+    await monitor.start()
+    await asyncio.sleep(0)
+
+    await monitor.stop()
+    assert not monitor.is_running
+    await monitor.stop()

--- a/backend/tests/test_codex_acp_compat.py
+++ b/backend/tests/test_codex_acp_compat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -19,7 +20,11 @@ from acp.schema import (
     ToolCallUpdate,
 )
 
-from ching_tech_os.services.codex_acp import CodexAcpClient, to_acp_mcp_server
+from ching_tech_os.services.codex_acp import (
+    CodexAcpClient,
+    _redact_diagnostics,
+    to_acp_mcp_server,
+)
 
 
 def test_runtime_versions_are_exactly_pinned() -> None:
@@ -41,6 +46,36 @@ def test_runtime_versions_are_exactly_pinned() -> None:
     assert fixture["versions"]["codex_acp"] == "1.1.9"
     assert fixture["versions"]["codex_cli"] == "0.146.0"
     assert all(fixture["validated"].values())
+
+
+def test_stderr_diagnostics_are_bounded_and_redacted() -> None:
+    client = CodexAcpClient()
+    client.stderr_max_bytes = 24
+    client._stderr_tail.extend(b"prefix Bearer very-secret")
+    overflow = len(client._stderr_tail) - client.stderr_max_bytes
+    del client._stderr_tail[:max(0, overflow)]
+
+    assert len(client._stderr_tail) <= 24
+    assert "very-secret" not in client.stderr_tail
+    assert "[REDACTED]" in client.stderr_tail
+    assert "token-value" not in _redact_diagnostics("access_token=token-value")
+
+
+@pytest.mark.asyncio
+async def test_stderr_reader_keeps_only_bounded_tail() -> None:
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"old-data " + b"x" * 30)
+    reader.feed_data(b" Bearer newest-secret")
+    reader.feed_eof()
+    client = CodexAcpClient()
+    client.stderr_max_bytes = 32
+    client._process = SimpleNamespace(stderr=reader)
+
+    await client._drain_stderr()
+
+    assert len(client._stderr_tail) == 32
+    assert "old-data" not in client.stderr_tail
+    assert "newest-secret" not in client.stderr_tail
 
 
 def test_mcp_conversion_preserves_stdio_and_http_fields() -> None:

--- a/backend/tests/test_codex_acp_compat.py
+++ b/backend/tests/test_codex_acp_compat.py
@@ -1,0 +1,260 @@
+"""Codex ACP compatibility layer 的協定 fixture 測試。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from acp.schema import (
+    AgentMessageChunk,
+    HttpMcpServer,
+    McpServerStdio,
+    PermissionOption,
+    TextContentBlock,
+    ToolCallProgress,
+    ToolCallStart,
+    ToolCallUpdate,
+)
+
+from ching_tech_os.services.codex_acp import CodexAcpClient, to_acp_mcp_server
+
+
+def test_runtime_versions_are_exactly_pinned() -> None:
+    project_root = Path(__file__).parents[2]
+    package = json.loads((project_root / "package.json").read_text(encoding="utf-8"))
+    lock = json.loads((project_root / "package-lock.json").read_text(encoding="utf-8"))
+
+    assert package["dependencies"]["@agentclientprotocol/codex-acp"] == "1.1.9"
+    assert package["dependencies"]["@openai/codex"] == "0.146.0"
+    assert lock["packages"]["node_modules/@agentclientprotocol/codex-acp"]["version"] == "1.1.9"
+    assert lock["packages"]["node_modules/@openai/codex"]["version"] == "0.146.0"
+
+    fixture = json.loads(
+        (
+            Path(__file__).parent
+            / "fixtures/codex_acp_compatibility_1_1_9.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert fixture["versions"]["codex_acp"] == "1.1.9"
+    assert fixture["versions"]["codex_cli"] == "0.146.0"
+    assert all(fixture["validated"].values())
+
+
+def test_mcp_conversion_preserves_stdio_and_http_fields() -> None:
+    stdio = to_acp_mcp_server(
+        {
+            "name": "ching-tech-os",
+            "type": "stdio",
+            "command": "uv",
+            "args": ["run", "python", "-m", "ching_tech_os.mcp_cli"],
+            "env": {"CTOS_USER_ID": "42"},
+        }
+    )
+    http = to_acp_mcp_server(
+        {
+            "name": "github",
+            "type": "http",
+            "url": "https://api.githubcopilot.com/mcp/",
+            "headers": {"Authorization": "Bearer secret-placeholder"},
+        }
+    )
+
+    assert isinstance(stdio, McpServerStdio)
+    assert stdio.command == "uv"
+    assert stdio.args[-1] == "ching_tech_os.mcp_cli"
+    assert [(item.name, item.value) for item in stdio.env] == [("CTOS_USER_ID", "42")]
+    assert isinstance(http, HttpMcpServer)
+    assert http.url == "https://api.githubcopilot.com/mcp/"
+    assert [(item.name, item.value) for item in http.headers] == [
+        ("Authorization", "Bearer secret-placeholder")
+    ]
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {},
+        {"name": "x", "type": "sse"},
+        {"name": "x", "type": "http", "headers": "invalid"},
+        {"name": "x", "type": "stdio", "env": "invalid"},
+    ],
+)
+def test_mcp_conversion_fails_closed_for_invalid_config(config: dict) -> None:
+    with pytest.raises(ValueError):
+        to_acp_mcp_server(config)
+
+
+@pytest.mark.asyncio
+async def test_message_chunks_preserve_repeated_text() -> None:
+    client = CodexAcpClient()
+    received: list[str] = []
+
+    @client.on_text
+    async def on_text(text: str) -> None:
+        received.append(text)
+
+    handler = client._create_client_handler()
+    for text in ("echo ", "echo ", "done"):
+        await handler.session_update(
+            "session-1",
+            AgentMessageChunk(
+                sessionUpdate="agent_message_chunk",
+                content=TextContentBlock(type="text", text=text),
+            ),
+        )
+
+    assert client._text_buffer == "echo echo done"
+    assert received == ["echo ", "echo ", "done"]
+
+
+@pytest.mark.asyncio
+async def test_tool_progress_is_deduplicated_and_permission_keeps_identity() -> None:
+    client = CodexAcpClient()
+    starts: list[tuple] = []
+    ends: list[tuple] = []
+    permissions: list[tuple] = []
+
+    @client.on_tool_start
+    async def on_start(*args) -> None:
+        starts.append(args)
+
+    @client.on_tool_end
+    async def on_end(*args) -> None:
+        ends.append(args)
+
+    @client.on_permission
+    async def on_permission(title: str, raw_input: dict, options: list[dict]) -> str:
+        permissions.append((title, raw_input, options))
+        return "reject_once"
+
+    handler = client._create_client_handler()
+    await handler.session_update(
+        "session-1",
+        ToolCallStart(
+            sessionUpdate="tool_call",
+            toolCallId="tool-1",
+            title="mcp.ching-tech-os.search_knowledge",
+            kind="execute",
+            status="in_progress",
+            rawInput={
+                "server": "ching-tech-os",
+                "tool": "search_knowledge",
+                "arguments": {"query": "安全測試"},
+            },
+        ),
+    )
+    response = await handler.request_permission(
+        options=[
+            PermissionOption(optionId="allow_once", name="Allow", kind="allow_once"),
+            PermissionOption(optionId="reject_once", name="Reject", kind="reject_once"),
+        ],
+        session_id="session-1",
+        tool_call=ToolCallUpdate(
+            toolCallId="tool-1",
+            status="pending",
+        ),
+    )
+    for status in ("in_progress", "completed", "completed"):
+        await handler.session_update(
+            "session-1",
+            ToolCallProgress(
+                sessionUpdate="tool_call_update",
+                toolCallId="tool-1",
+                status=status,
+                rawOutput={"ok": True} if status == "completed" else None,
+            ),
+        )
+
+    assert starts == [
+        (
+            "tool-1",
+            "mcp.ching-tech-os.search_knowledge",
+            {
+                "server": "ching-tech-os",
+                "tool": "search_knowledge",
+                "arguments": {"query": "安全測試"},
+            },
+        )
+    ]
+    assert permissions[0][0] == "mcp.ching-tech-os.search_knowledge"
+    assert permissions[0][1]["server"] == "ching-tech-os"
+    assert permissions[0][1]["tool"] == "search_knowledge"
+    assert permissions[0][1]["_acp_tool_call_id"] == "tool-1"
+    assert response.outcome.option_id == "reject_once"
+    assert ends == [("tool-1", "completed", {"ok": True})]
+
+
+@pytest.mark.asyncio
+async def test_permission_defaults_to_reject_without_handler() -> None:
+    client = CodexAcpClient()
+    handler = client._create_client_handler()
+
+    response = await handler.request_permission(
+        options=[
+            PermissionOption(optionId="allow_once", name="Allow", kind="allow_once"),
+            PermissionOption(optionId="deny", name="Deny", kind="reject_once"),
+        ],
+        session_id="session-1",
+        tool_call=ToolCallUpdate(toolCallId="unknown", status="pending"),
+    )
+
+    assert response.outcome.option_id == "deny"
+
+
+@pytest.mark.asyncio
+async def test_new_session_passes_both_mcp_transports_and_pending_model() -> None:
+    connection = SimpleNamespace(
+        new_session=AsyncMock(return_value=SimpleNamespace(session_id="session-1")),
+        set_session_model=AsyncMock(),
+    )
+    client = CodexAcpClient(
+        cwd="/tmp/safe-workspace",
+        mcp_servers=[
+            {"name": "local", "command": "python", "args": ["server.py"]},
+            {"name": "remote", "type": "http", "url": "https://example.test/mcp", "headers": {}},
+        ],
+    )
+    client._connection = connection
+    await client.set_model("gpt-test")
+
+    session_id = await client.new_session()
+
+    assert session_id == "session-1"
+    passed = connection.new_session.await_args.kwargs["mcp_servers"]
+    assert isinstance(passed[0], McpServerStdio)
+    assert isinstance(passed[1], HttpMcpServer)
+    connection.set_session_model.assert_awaited_once_with(
+        model_id="gpt-test",
+        session_id="session-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_prompt_retains_token_model_metadata_and_cancel() -> None:
+    client = CodexAcpClient()
+
+    async def prompt(**_kwargs):
+        client._text_buffer = "repeat repeat"
+        return SimpleNamespace(
+            usage=SimpleNamespace(input_tokens=12, output_tokens=5),
+            field_meta={"quota": {"model_usage": [{"model": "gpt-test"}]}},
+        )
+
+    connection = SimpleNamespace(
+        prompt=AsyncMock(side_effect=prompt),
+        cancel=AsyncMock(),
+    )
+    client._connection = connection
+    client._session_id = "session-1"
+
+    result = await client.prompt("只讀測試")
+    await client.cancel()
+
+    assert result == "repeat repeat"
+    assert client.input_tokens == 12
+    assert client.output_tokens == 5
+    assert client.model_name == "gpt-test"
+    connection.cancel.assert_awaited_once_with(session_id="session-1")

--- a/backend/tests/test_codex_acp_smoke.py
+++ b/backend/tests/test_codex_acp_smoke.py
@@ -1,0 +1,211 @@
+"""真實 Codex ACP 唯讀 smoke；預設跳過，需明確設定環境變數。"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+from pathlib import Path
+
+import pytest
+
+from ching_tech_os.services.codex_acp import CodexAcpClient
+
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("RUN_CODEX_ACP_SMOKE") != "1",
+    reason="需明確設定 RUN_CODEX_ACP_SMOKE=1 才執行真實 Codex ACP smoke",
+)
+
+PROJECT_ROOT = Path(__file__).parents[2]
+BACKEND_ROOT = Path(__file__).parents[1]
+ADAPTER_BIN = PROJECT_ROOT / "node_modules/.bin/codex-acp"
+CODEX_BIN = PROJECT_ROOT / "node_modules/.bin/codex"
+MCP_FIXTURE = Path(__file__).parent / "fixtures/codex_readonly_mcp_server.py"
+
+
+def _client_env(*, approval_policy: str = "never") -> dict[str, str]:
+    env = dict(os.environ)
+    env.update(
+        {
+            "CODEX_PATH": str(CODEX_BIN),
+            "INITIAL_AGENT_MODE": "read-only",
+            "NO_BROWSER": "1",
+            "CODEX_CONFIG": json.dumps(
+                {
+                    "features": {"multi_agent": False},
+                    "sandbox_mode": "read-only",
+                    "approval_policy": approval_policy,
+                }
+            ),
+        }
+    )
+    return env
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+async def _wait_for_port(port: int) -> None:
+    for _ in range(100):
+        try:
+            _reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        except OSError:
+            await asyncio.sleep(0.05)
+            continue
+        writer.close()
+        await writer.wait_closed()
+        return
+    raise TimeoutError("本機 smoke HTTP MCP 未在期限內啟動")
+
+
+@pytest.mark.asyncio
+async def test_real_codex_acp_text_repeat_and_readonly_stdio_tool(tmp_path) -> None:
+    client = CodexAcpClient(
+        command=str(ADAPTER_BIN),
+        cwd=str(tmp_path),
+        env=_client_env(approval_policy="on-request"),
+        mcp_servers=[
+            {
+                "name": "ctos-readonly-smoke",
+                "type": "stdio",
+                "command": str(BACKEND_ROOT / ".venv/bin/python"),
+                "args": [str(MCP_FIXTURE)],
+                "env": {},
+            }
+        ],
+    )
+    permission_identities: list[tuple[str, str]] = []
+    tool_identities: list[tuple[str, str, str]] = []
+
+    @client.on_tool_start
+    async def on_tool_start(_tool_id: str, title: str, raw_input: dict) -> None:
+        if title.startswith("mcp."):
+            tool_identities.append(
+                (
+                    title,
+                    str(raw_input.get("server", "")),
+                    str(raw_input.get("tool", "")),
+                )
+            )
+
+    @client.on_permission
+    async def on_permission(_title: str, raw_input: dict, options: list[dict]) -> str:
+        identity = (str(raw_input.get("server", "")), str(raw_input.get("tool", "")))
+        permission_identities.append(identity)
+        if identity == ("ctos-readonly-smoke", "read_only_marker"):
+            for option in options:
+                if str(option.get("kind", "")).startswith("allow"):
+                    return str(option["id"])
+        for option in options:
+            if str(option.get("kind", "")).startswith("reject"):
+                return str(option["id"])
+        return "reject"
+
+    try:
+        await client.connect()
+        await client.new_session()
+        plain = await asyncio.wait_for(
+            client.prompt("Reply with exactly: ACP_SMOKE_OK"),
+            timeout=90,
+        )
+        repeated = await asyncio.wait_for(
+            client.prompt("Reply with exactly: repeat repeat repeat"),
+            timeout=90,
+        )
+        tool_result = await asyncio.wait_for(
+            client.prompt(
+                "Call read_only_marker exactly once with value ACP_TOOL_OK, "
+                "then reply with the returned text only."
+            ),
+            timeout=120,
+        )
+    finally:
+        await client.disconnect()
+
+    assert "ACP_SMOKE_OK" in plain
+    assert "repeat repeat repeat" in repeated
+    assert "ACP_TOOL_OK" in tool_result
+    assert tool_identities == [
+        (
+            "mcp.ctos-readonly-smoke.read_only_marker",
+            "ctos-readonly-smoke",
+            "read_only_marker",
+        )
+    ]
+    assert permission_identities == [
+        ("ctos-readonly-smoke", "read_only_marker")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_real_codex_acp_http_mcp_handshake(tmp_path) -> None:
+    port = _free_port()
+    server_env = dict(os.environ)
+    server_env.update(
+        {
+            "CTOS_SMOKE_MCP_TRANSPORT": "streamable-http",
+            "CTOS_SMOKE_MCP_PORT": str(port),
+        }
+    )
+    server = await asyncio.create_subprocess_exec(
+        str(BACKEND_ROOT / ".venv/bin/python"),
+        str(MCP_FIXTURE),
+        env=server_env,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    client = CodexAcpClient(
+        command=str(ADAPTER_BIN),
+        cwd=str(tmp_path),
+        env=_client_env(),
+        mcp_servers=[
+            {
+                "name": "ctos-http-smoke",
+                "type": "http",
+                "url": f"http://127.0.0.1:{port}/mcp",
+                "headers": {"X-CTOS-Smoke": "safe-marker"},
+            }
+        ],
+    )
+    try:
+        await _wait_for_port(port)
+        await client.connect()
+        session_id = await asyncio.wait_for(client.new_session(), timeout=30)
+        assert session_id
+    finally:
+        await client.disconnect()
+        server.terminate()
+        try:
+            await asyncio.wait_for(server.wait(), timeout=5)
+        except TimeoutError:
+            server.kill()
+            await server.wait()
+
+
+@pytest.mark.asyncio
+async def test_real_codex_acp_timeout_cancel_and_cleanup(tmp_path) -> None:
+    client = CodexAcpClient(
+        command=str(ADAPTER_BIN),
+        cwd=str(tmp_path),
+        env=_client_env(),
+    )
+    try:
+        await client.connect()
+        await client.new_session()
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(
+                client.prompt("Analyze this empty workspace in detail."),
+                timeout=0.001,
+            )
+        await client.cancel()
+    finally:
+        process = client._process
+        await client.disconnect()
+
+    assert process is not None
+    assert process.returncode is not None

--- a/backend/tests/test_codex_agent.py
+++ b/backend/tests/test_codex_agent.py
@@ -1,0 +1,439 @@
+"""Codex Provider 契約、安全邊界與資源治理測試。"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from acp.schema import HttpMcpServer
+
+from ching_tech_os.services import ai_provider, codex_agent
+
+
+class FakeCodexClient:
+    def __init__(self, *, scenario: str = "success", **kwargs: Any) -> None:
+        self.scenario = scenario
+        self.kwargs = kwargs
+        self.events: dict[str, Any] = {}
+        self._text_buffer = ""
+        self.input_tokens = 12
+        self.output_tokens = 7
+        self.model_name = "gpt-test"
+        self.stderr_max_bytes = 0
+        self.disconnected = False
+        self.cancelled = False
+        self.permission_results: list[str] = []
+        self.model: str | None = None
+
+    def _decorator(self, name: str):
+        def register(func):
+            self.events[name] = func
+            return func
+        return register
+
+    @property
+    def on_tool_start(self):
+        return self._decorator("tool_start")
+
+    @property
+    def on_tool_end(self):
+        return self._decorator("tool_end")
+
+    @property
+    def on_permission(self):
+        return self._decorator("permission")
+
+    @property
+    def on_terminal_create(self):
+        return self._decorator("terminal")
+
+    @property
+    def on_file_write(self):
+        return self._decorator("file_write")
+
+    async def connect(self) -> None:
+        if self.scenario == "auth_error":
+            raise RuntimeError("authentication token secret-value expired")
+        if self.scenario == "protocol_error":
+            raise RuntimeError("protocol initialize invalid secret-value")
+
+    async def set_model(self, model: str) -> None:
+        self.model = model
+
+    async def new_session(self) -> str:
+        if self.scenario == "mcp_error":
+            raise RuntimeError("MCP startup connection failed secret-value")
+        return "session-1"
+
+    async def prompt(self, text: str) -> str:
+        self.prompt_text = text
+        if self.scenario == "timeout":
+            self._text_buffer = "部分結果"
+            await asyncio.Future()
+        if self.scenario == "overload":
+            raise RuntimeError("429 rate limit secret-value")
+        if self.scenario == "native":
+            await self.events["tool_start"]("native-1", "Image generation", {})
+            await self.events["tool_end"]("native-1", "completed", "image")
+        if self.scenario.startswith("tool"):
+            await self._emit_tools()
+        self._text_buffer = "完成"
+        return "完成"
+
+    async def _emit_tools(self) -> None:
+        if self.scenario == "tool_short":
+            title = "search_knowledge"
+            raw = {"tool": "search_knowledge"}
+        elif self.scenario == "tool_mismatch":
+            title = "mcp.other.search_knowledge"
+            raw = {"server": "ching-tech-os", "tool": "search_knowledge"}
+        else:
+            title = "mcp.ching-tech-os.search_knowledge"
+            raw = {
+                "server": "ching-tech-os",
+                "tool": "search_knowledge",
+                "arguments": {"query": "test"},
+            }
+        repeats = 2 if self.scenario == "tool_twice" else 1
+        for index in range(repeats):
+            tool_id = f"tool-{index}"
+            await self.events["tool_start"](tool_id, title, dict(raw))
+            permission_input = {**raw, "_acp_tool_call_id": tool_id}
+            result = await self.events["permission"](
+                title,
+                permission_input,
+                [
+                    {"id": "allow_once", "kind": "allow_once"},
+                    {"id": "reject_once", "kind": "reject_once"},
+                ],
+            )
+            self.permission_results.append(result)
+            status = "completed" if result == "allow_once" else "failed"
+            await self.events["tool_end"](tool_id, status, {"ok": True})
+
+    async def cancel(self) -> None:
+        self.cancelled = True
+
+    async def disconnect(self) -> None:
+        self.disconnected = True
+
+
+class FakeFactory:
+    def __init__(self, scenario: str = "success") -> None:
+        self.scenario = scenario
+        self.clients: list[FakeCodexClient] = []
+
+    def __call__(self, **kwargs: Any) -> FakeCodexClient:
+        client = FakeCodexClient(scenario=self.scenario, **kwargs)
+        self.clients.append(client)
+        return client
+
+
+def make_provider(factory: FakeFactory, **kwargs: Any) -> codex_agent.CodexProvider:
+    return codex_agent.CodexProvider(
+        client_factory=factory,
+        adapter_path="/bin/true",
+        codex_path="/bin/true",
+        model="gpt-test",
+        **kwargs,
+    )
+
+
+def test_codex_provider_matches_complete_request_contract(provider_contract_spec) -> None:
+    fields = set(inspect.signature(codex_agent.CodexProvider.call).parameters) - {"self"}
+    assert fields == provider_contract_spec.claude_request_fields
+    assert isinstance(make_provider(FakeFactory()), ai_provider.AIProvider)
+
+
+@pytest.mark.asyncio
+async def test_success_preserves_history_system_usage_model_and_cleanup() -> None:
+    factory = FakeFactory()
+    provider = make_provider(factory)
+    result = await provider.call(
+        prompt="新問題",
+        history=[{"role": "user", "content": "舊問題"}],
+        system_prompt="只回答事實",
+    )
+
+    client = factory.clients[0]
+    assert result.success is True
+    assert result.message == "完成"
+    assert (result.input_tokens, result.output_tokens) == (12, 7)
+    assert result.actual_model == "gpt-test"
+    assert result.provider_started is True
+    assert "舊問題" in client.prompt_text and "只回答事實" in client.prompt_text
+    assert "禁止 terminal" in client.prompt_text
+    assert client.disconnected is True
+    assert not Path(client.kwargs["cwd"]).exists()
+    config = json.loads(client.kwargs["env"]["CODEX_CONFIG"])
+    assert config["sandbox_mode"] == "read-only"
+    assert config["approval_policy"] == "on-request"
+    assert config["features"]["multi_agent"] is False
+
+
+@pytest.mark.asyncio
+async def test_mcp_filter_and_framework_identity_env_are_preserved() -> None:
+    factory = FakeFactory()
+    provider = make_provider(factory)
+    await provider.call(
+        prompt="查詢",
+        tools=["mcp__ching-tech-os__search_knowledge"],
+        required_mcp_servers=set(),
+        ctos_user_id=42,
+        extra_mcp_env={"CTOS_GROUP_ID": "group-1"},
+    )
+
+    servers = factory.clients[0].kwargs["mcp_servers"]
+    ctos = next(server for server in servers if server.name == "ching-tech-os")
+    env = {item.name: item.value for item in ctos.env}
+    assert env["CTOS_USER_ID"] == "42"
+    assert env["CTOS_GROUP_ID"] == "group-1"
+    assert {server.name for server in servers} == {"ching-tech-os"}
+
+
+@pytest.mark.asyncio
+async def test_http_mcp_is_preserved_and_unrequired_servers_are_filtered() -> None:
+    factory = FakeFactory()
+    await make_provider(factory).call(
+        prompt="唯讀 GitHub 查詢",
+        tools=[
+            "mcp__github__search_repositories",
+            "mcp__nanobanana__generate_image",
+        ],
+        required_mcp_servers={"github"},
+    )
+
+    servers = factory.clients[0].kwargs["mcp_servers"]
+    assert {server.name for server in servers} == {"ching-tech-os", "github"}
+    github = next(server for server in servers if server.name == "github")
+    assert isinstance(github, HttpMcpServer)
+    assert github.url == "https://api.githubcopilot.com/mcp/"
+    assert all(server.name != "nanobanana" for server in servers)
+
+
+@pytest.mark.asyncio
+async def test_canonical_tool_permission_and_callbacks_are_exact() -> None:
+    factory = FakeFactory("tool")
+    provider = make_provider(factory)
+    on_start = AsyncMock(side_effect=RuntimeError("caller callback failure"))
+    on_end = AsyncMock()
+    result = await provider.call(
+        prompt="查詢",
+        tools=["mcp__ching-tech-os__search_knowledge"],
+        on_tool_start=on_start,
+        on_tool_end=on_end,
+    )
+
+    assert result.success is True
+    assert factory.clients[0].permission_results == ["allow_once"]
+    assert [item.name for item in result.tool_calls] == [
+        "mcp__ching-tech-os__search_knowledge"
+    ]
+    assert result.tool_timings[0]["name"] == "mcp__ching-tech-os__search_knowledge"
+    on_start.assert_awaited_once()
+    on_end.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scenario", ["tool_short", "tool_mismatch"])
+async def test_missing_namespace_and_mismatched_identity_fail_closed(scenario: str) -> None:
+    factory = FakeFactory(scenario)
+    result = await make_provider(factory).call(
+        prompt="不可執行",
+        tools=["mcp__ching-tech-os__search_knowledge"],
+    )
+    assert result.success is False
+    assert result.error == "Codex 請求失敗（security_violation）"
+    assert factory.clients[0].permission_results == ["reject_once"]
+    assert result.tool_calls == []
+
+
+@pytest.mark.asyncio
+async def test_same_tool_on_other_server_and_short_allowlist_are_denied() -> None:
+    factory = FakeFactory("tool")
+    result = await make_provider(factory).call(
+        prompt="不可猜測 namespace",
+        tools=["search_knowledge", "mcp__other__search_knowledge"],
+    )
+    assert result.success is False
+    assert factory.clients[0].permission_results == ["reject_once"]
+
+
+@pytest.mark.asyncio
+async def test_tool_limit_and_global_image_limits() -> None:
+    factory = FakeFactory("tool_twice")
+    result = await make_provider(factory).call(
+        prompt="最多一次",
+        tools=["mcp__ching-tech-os__search_knowledge"],
+        tool_call_limits={"mcp__ching-tech-os__search_knowledge": 1},
+    )
+    assert result.success is True
+    assert factory.clients[0].permission_results == ["allow_once", "reject_once"]
+    assert len(result.tool_calls) == 1
+
+    limits = codex_agent.CodexProvider._build_tool_limits(
+        {
+            ("nanobanana", "generate_image"),
+            ("ching-tech-os", "codex_image_tool"),
+        },
+        None,
+    )
+    assert limits["mcp__nanobanana__generate_image"] >= 1
+    assert limits["mcp__ching-tech-os__codex_image_tool"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_native_image_terminal_and_file_write_are_denied() -> None:
+    factory = FakeFactory("native")
+    result = await make_provider(factory).call(prompt="產圖")
+    client = factory.clients[0]
+    assert result.success is False
+    assert await client.events["terminal"]("ls", "/tmp") is False
+    assert await client.events["file_write"]("x", "data") is False
+
+
+@pytest.mark.asyncio
+async def test_timeout_keeps_partial_result_cancels_and_cleans_up() -> None:
+    factory = FakeFactory("timeout")
+    result = await make_provider(factory).call(prompt="慢請求", timeout=0.01)
+    client = factory.clients[0]
+    assert result.success is False
+    assert result.message == "部分結果"
+    assert result.error == "Codex 請求失敗（timeout）"
+    assert client.cancelled is True and client.disconnected is True
+    assert not Path(client.kwargs["cwd"]).exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("scenario", "category"),
+    [
+        ("auth_error", "auth_error"),
+        ("protocol_error", "protocol_error"),
+        ("mcp_error", "mcp_startup_error"),
+        ("overload", "overload"),
+    ],
+)
+async def test_failures_are_categorized_without_leaking_raw_errors(
+    scenario: str, category: str
+) -> None:
+    result = await make_provider(FakeFactory(scenario)).call(prompt="測試")
+    assert result.success is False
+    assert category in (result.error or "")
+    assert "secret-value" not in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_binary_missing_is_pre_start_failure() -> None:
+    provider = codex_agent.CodexProvider(
+        client_factory=FakeFactory(),
+        adapter_path="/definitely/missing/codex-acp",
+        codex_path="/bin/true",
+    )
+    assert await provider.is_ready() is False
+    result = await provider.call(prompt="測試")
+    assert result.provider_started is False
+    assert "binary_missing" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_client_factory_failure_cleans_pre_start_session(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    monkeypatch.setattr(
+        codex_agent, "_create_session_workdir", lambda: str(session_dir)
+    )
+
+    def broken_factory(**_kwargs):
+        raise RuntimeError("constructor secret-value")
+
+    provider = codex_agent.CodexProvider(
+        client_factory=broken_factory,
+        adapter_path="/bin/true",
+        codex_path="/bin/true",
+    )
+    result = await provider.call(prompt="測試")
+
+    assert result.provider_started is False
+    assert result.error == "Codex 請求失敗（execution_error）"
+    assert not session_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_external_cancellation_still_disconnects_and_cleans_session() -> None:
+    factory = FakeFactory("timeout")
+    provider = make_provider(factory)
+    task = asyncio.create_task(provider.call(prompt="取消測試", timeout=30))
+    while not factory.clients:
+        await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    client = factory.clients[0]
+    assert client.disconnected is True
+    assert not Path(client.kwargs["cwd"]).exists()
+
+
+@pytest.mark.asyncio
+async def test_concurrency_queue_timeout_rejects_without_spawning_second_client() -> None:
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    class BlockingClient(FakeCodexClient):
+        async def prompt(self, text: str) -> str:
+            entered.set()
+            await release.wait()
+            return await super().prompt(text)
+
+    clients: list[BlockingClient] = []
+
+    def factory(**kwargs):
+        client = BlockingClient(**kwargs)
+        clients.append(client)
+        return client
+
+    provider = codex_agent.CodexProvider(
+        client_factory=factory,
+        adapter_path="/bin/true",
+        codex_path="/bin/true",
+        max_concurrency=1,
+        queue_timeout=0.01,
+    )
+    first = asyncio.create_task(provider.call(prompt="first"))
+    await entered.wait()
+    second = await provider.call(prompt="second")
+    release.set()
+    await first
+    assert second.provider_started is False
+    assert "queue_timeout" in (second.error or "")
+    assert len(clients) == 1
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_opens_and_recovers_after_cooldown() -> None:
+    now = [10.0]
+    breaker = codex_agent.CodexCircuitBreaker(2, 5, clock=lambda: now[0])
+    provider = make_provider(FakeFactory("protocol_error"), circuit_breaker=breaker)
+    await provider.call(prompt="one")
+    assert await provider.is_ready() is True
+    await provider.call(prompt="two")
+    assert await provider.is_ready() is False
+    now[0] = 15.1
+    assert await provider.is_ready() is True
+
+
+def test_canonical_parser_rejects_unknown_and_conflicting_names() -> None:
+    assert codex_agent._canonical_identity("Unknown", {}) is None
+    assert codex_agent._canonical_identity(
+        "mcp.a.tool", {"server": "b", "tool": "tool"}
+    ) is None
+    assert codex_agent._allowed_identities(["tool", "mcp__a__tool"]) == {("a", "tool")}

--- a/backend/tests/test_log_filters.py
+++ b/backend/tests/test_log_filters.py
@@ -1,0 +1,89 @@
+"""httpx 日誌過濾器測試。
+
+為什麼要有這支:bot token 會跟著 httpx 的 request log 明文進 /var/log/syslog
+與 systemd journal。過濾器一旦壞掉是「安靜地壞」——log 看起來正常,token 卻在外面,
+所以遮蔽行為必須有測試釘住。
+"""
+
+import logging
+
+import pytest
+
+from ching_tech_os.utils.log_filters import (
+    TelegramTokenFilter,
+    install_log_filters,
+)
+
+TOKEN = "8294724422:AAFpygE0ijqqpdzhz5TGPvUf8HdJsN6Xxh8"
+
+
+def _record(msg: str, *args) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="httpx", level=logging.INFO, pathname=__file__,
+        lineno=1, msg=msg, args=args, exc_info=None,
+    )
+
+
+class TestTelegramTokenFilter:
+    def test_丟掉_getUpdates_輪詢雜訊(self):
+        """長輪詢每 30 秒一筆、內容重複,佔 log 量 95%,直接丟。"""
+        rec = _record(
+            f'HTTP Request: POST https://api.telegram.org/bot{TOKEN}/getUpdates "HTTP/1.1 200 OK"'
+        )
+        assert TelegramTokenFilter().filter(rec) is False
+
+    def test_其他_telegram_請求保留但遮蔽_token(self):
+        """sendMessage 這類是有診斷價值的,要留下來,但 token 得遮掉。"""
+        rec = _record(
+            f'HTTP Request: POST https://api.telegram.org/bot{TOKEN}/sendMessage "HTTP/1.1 200 OK"'
+        )
+        assert TelegramTokenFilter().filter(rec) is True
+        out = rec.getMessage()
+        assert TOKEN not in out
+        assert "bot***" in out
+        # 其餘資訊(打去哪、回什麼碼)必須完整保留,否則就失去除錯價值
+        assert "sendMessage" in out
+        assert "200 OK" in out
+
+    def test_無關的請求原封不動(self):
+        """clawhub / skillhub / codex_image 等模組的紀錄不能被動到。"""
+        msg = 'HTTP Request: GET https://clawhub.example/api/v1/items "HTTP/1.1 200 OK"'
+        rec = _record(msg)
+        assert TelegramTokenFilter().filter(rec) is True
+        assert rec.getMessage() == msg
+
+    def test_token_夾在_args_裡也要遮掉(self):
+        """logger.info("%s", url) 這種寫法,token 在 args 不在 msg。"""
+        rec = _record("HTTP Request: %s", f"https://api.telegram.org/bot{TOKEN}/sendPhoto")
+        assert TelegramTokenFilter().filter(rec) is True
+        assert TOKEN not in rec.getMessage()
+        assert "bot***" in rec.getMessage()
+
+    def test_遮蔽後仍可安全格式化(self):
+        """遮蔽時若沒清掉 args,後續 getMessage() 會炸 TypeError。"""
+        rec = _record("HTTP Request: %s", f"https://api.telegram.org/bot{TOKEN}/sendPhoto")
+        TelegramTokenFilter().filter(rec)
+        rec.getMessage()  # 再叫一次不能爆
+        rec.getMessage()
+
+
+class TestInstall:
+    @pytest.fixture(autouse=True)
+    def _清掉_httpx_logger_上的_filter(self):
+        logger = logging.getLogger("httpx")
+        before = list(logger.filters)
+        logger.filters.clear()
+        yield
+        logger.filters[:] = before
+
+    def test_掛上去之後_httpx_logger_有過濾器(self):
+        install_log_filters()
+        logger = logging.getLogger("httpx")
+        assert any(isinstance(f, TelegramTokenFilter) for f in logger.filters)
+
+    def test_重複呼叫不會重複掛(self):
+        """uvicorn --reload 會重複 import,掛兩次會讓每筆紀錄被過濾兩輪。"""
+        install_log_filters()
+        install_log_filters()
+        logger = logging.getLogger("httpx")
+        assert sum(isinstance(f, TelegramTokenFilter) for f in logger.filters) == 1

--- a/backend/tests/test_main_module.py
+++ b/backend/tests/test_main_module.py
@@ -97,6 +97,7 @@ async def test_lifespan_startup_shutdown(monkeypatch: pytest.MonkeyPatch, tmp_pa
     app = FastAPI()
 
     monkeypatch.setattr(main.settings, "bot_secret_key", "")
+    monkeypatch.setattr(main.settings, "ai_provider_mode", "auto")
     monkeypatch.setattr(main, "ensure_directories", Mock())
     monkeypatch.setattr(main, "init_db_pool", AsyncMock())
     monkeypatch.setattr(main, "close_db_pool", AsyncMock())
@@ -138,6 +139,9 @@ async def test_lifespan_startup_shutdown(monkeypatch: pytest.MonkeyPatch, tmp_pa
     monkeypatch.setattr(line_client_module, "close_line_client", AsyncMock())
     import ching_tech_os.services.claude_agent as claude_agent_module
     monkeypatch.setattr(claude_agent_module, "_WORKING_DIR_BASE", tmp_path / "claude-work")
+    import ching_tech_os.services.claude_usage as claude_usage_module
+    usage_monitor = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
+    monkeypatch.setattr(claude_usage_module, "claude_usage_monitor", usage_monitor)
 
     async with main.lifespan(app):
         assert hasattr(app.state, "clawhub_client")
@@ -147,6 +151,8 @@ async def test_lifespan_startup_shutdown(monkeypatch: pytest.MonkeyPatch, tmp_pa
     main.close_db_pool.assert_awaited_once()
     claw_client.close.assert_awaited_once()
     skill_client.close.assert_awaited_once()
+    usage_monitor.start.assert_awaited_once()
+    usage_monitor.stop.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/docs/ai-agent-design.md
+++ b/docs/ai-agent-design.md
@@ -63,7 +63,13 @@ ChingTech OS 的 AI 助手透過 `claude-code-acp`（ClaudeClient in-process）�
 | `AI_PROVIDER_CANARY_CONTEXTS` | `internal_admin,internal_test` | context exact-match allowlist |
 | `AI_PROVIDER_CANARY_AGENTS` | `test-agent` | Agent exact-match allowlist |
 
-在 Codex provider 與 usage monitor 尚未通過後續 gate 前，`codex` 會記錄 `codex_unready`，`auto` 會依 scope 記錄 `canary_not_allowed` 或 `usage_unknown`，實際 provider 仍為 Claude。`RoutingContext` 只供 router 判斷，不會傳入 prompt 或 provider。fake provider tests 已鎖住 readiness false/error/missing、fallback unavailable 與執行後禁止跨 provider retry。
+在 Codex provider 尚未通過後續 gate 前，`codex` 會在 pre-start fallback 記錄 `codex_unready`；`auto` 會依 scope 與 usage snapshot 產生 route reason，但實際 provider 仍為 Claude。`RoutingContext` 只供 router 判斷，不會傳入 prompt 或 provider。fake provider tests 已鎖住 readiness false/error/missing、fallback unavailable 與執行後禁止跨 provider retry。
+
+### Claude Usage Monitor
+
+`services/claude_usage.py` 以背景 single-flight request 更新記憶體快照，Router 不會在使用者請求路徑等待外部 Usage API。快照分為 unknown、fresh、stale、error；預設 TTL 60 秒、max-stale 300 秒。只有 `AI_PROVIDER_MODE=auto` 會在 FastAPI lifespan 啟動，forced Claude 不讀取 credentials。
+
+自動路由採 hysteresis：fresh utilization `>=90%` 選 Codex、已在 Codex 時必須 `<85%` 才切回 Claude；85%–90% 或 max-stale 內的 stale 快照維持前一個穩定 provider。unknown、error 或超過 max-stale 一律回 Claude。Codex provider 尚未註冊時，所有 Codex 決策仍在 pre-start readiness 階段回到 Claude。
 
 ## Agent 系統
 

--- a/docs/ai-agent-design.md
+++ b/docs/ai-agent-design.md
@@ -4,6 +4,8 @@
 
 ChingTech OS 的 AI 助手透過 `claude-code-acp`（ClaudeClient in-process）與 Claude API 溝通，支援 Line Bot、Telegram Bot 和 Web 前端三個平台。系統包含完整的 Agent 管理、動態工具分配、身份分流、頻率限制和對話壓縮機制。
 
+> Codex ACP provider 與用量路由尚未實作或啟用。目前已完成 provider-neutral `AIResponse`/`AIProvider` 契約、provider mode 驗證與 canary scope 判斷；尚無 caller 使用的 `call_ai()` 旁路仍會安全回到 Claude。評估、風險與後續 gate 見 [Codex ACP 備援評估報告](codex-acp-failover-evaluation.md) 與 `openspec/changes/add-codex-acp-failover/`。
+
 ## 架構
 
 ```
@@ -50,6 +52,18 @@ ChingTech OS 的 AI 助手透過 `claude-code-acp`（ClaudeClient in-process）�
 │  In-process Claude 呼叫，支援 MCP 工具、權限控制、token 統計   │
 └─────────────────────────────────────────────────────────────┘
 ```
+
+### Provider Router 安全骨架
+
+`services/ai_router.py::call_ai()` 目前尚未被正式入口使用，也不會啟動 Codex。`ProviderRouter` 以 registry 與 `is_ready()` 建立可測試的 pre-start fallback 邊界：只有尚未進入 `provider.call()` 前可改選明確 fallback；進入 call 後，不論回應失敗或拋錯都保持 provider sticky，避免重複副作用。預設 registry 仍只有 Claude。已加入的設定只用來驗證未來路由政策：
+
+| 環境變數 | 預設值 | 目前行為 |
+|---------|--------|----------|
+| `AI_PROVIDER_MODE` | `claude` | 接受 `claude`、`codex`、`auto`；非法值明確告警並回到 Claude |
+| `AI_PROVIDER_CANARY_CONTEXTS` | `internal_admin,internal_test` | context exact-match allowlist |
+| `AI_PROVIDER_CANARY_AGENTS` | `test-agent` | Agent exact-match allowlist |
+
+在 Codex provider 與 usage monitor 尚未通過後續 gate 前，`codex` 會記錄 `codex_unready`，`auto` 會依 scope 記錄 `canary_not_allowed` 或 `usage_unknown`，實際 provider 仍為 Claude。`RoutingContext` 只供 router 判斷，不會傳入 prompt 或 provider。fake provider tests 已鎖住 readiness false/error/missing、fallback unavailable 與執行後禁止跨 provider retry。
 
 ## Agent 系統
 

--- a/docs/ai-agent-design.md
+++ b/docs/ai-agent-design.md
@@ -71,6 +71,12 @@ ChingTech OS 的 AI 助手透過 `claude-code-acp`（ClaudeClient in-process）�
 
 自動路由採 hysteresis：fresh utilization `>=90%` 選 Codex、已在 Codex 時必須 `<85%` 才切回 Claude；85%–90% 或 max-stale 內的 stale 快照維持前一個穩定 provider。unknown、error 或超過 max-stale 一律回 Claude。Codex provider 尚未註冊時，所有 Codex 決策仍在 pre-start readiness 階段回到 Claude。
 
+### Codex ACP Compatibility Layer
+
+`services/codex_acp.py` 固定搭配 `@agentclientprotocol/codex-acp` 1.1.9、`@openai/codex` 0.146.0 與 Python ACP 0.8.0。此層只處理協定差異：ordered message delta、tool terminal event 去重、token/model metadata、stdio/HTTP MCP schema 與 tool-call-id permission identity correlation；provider 的工作目錄、權限、callback、timeout 與資源限制由 `codex_agent.py` 負責。
+
+真實 smoke 使用本機單一唯讀 MCP fixture，已驗證 stdio tool、Streamable HTTP handshake、canonical server/tool identity、timeout/cancel 與 subprocess cleanup。若 pin 組合升級後任一契約失敗，Codex readiness 必須 fail closed，不可退回模糊工具名稱判斷。
+
 ## Agent 系統
 
 ### Agent 定義與儲存

--- a/docs/ai-agent-design.md
+++ b/docs/ai-agent-design.md
@@ -4,7 +4,7 @@
 
 ChingTech OS 的 AI 助手透過 `claude-code-acp`（ClaudeClient in-process）與 Claude API 溝通，支援 Line Bot、Telegram Bot 和 Web 前端三個平台。系統包含完整的 Agent 管理、動態工具分配、身份分流、頻率限制和對話壓縮機制。
 
-> Codex ACP provider 與用量路由尚未實作或啟用。目前已完成 provider-neutral `AIResponse`/`AIProvider` 契約、provider mode 驗證與 canary scope 判斷；尚無 caller 使用的 `call_ai()` 旁路仍會安全回到 Claude。評估、風險與後續 gate 見 [Codex ACP 備援評估報告](codex-acp-failover-evaluation.md) 與 `openspec/changes/add-codex-acp-failover/`。
+> Codex ACP provider、用量監測與安全路由核心已實作，但預設仍為固定 Claude，且尚無正式入口改用 `call_ai()`。部署 readiness、可觀測性與 canary gate 尚未完成，因此目前不得開啟正式流量。評估、風險與後續 gate 見 [Codex ACP 備援評估報告](codex-acp-failover-evaluation.md) 與 `openspec/changes/add-codex-acp-failover/`。
 
 ## 架構
 
@@ -55,7 +55,7 @@ ChingTech OS 的 AI 助手透過 `claude-code-acp`（ClaudeClient in-process）�
 
 ### Provider Router 安全骨架
 
-`services/ai_router.py::call_ai()` 目前尚未被正式入口使用，也不會啟動 Codex。`ProviderRouter` 以 registry 與 `is_ready()` 建立可測試的 pre-start fallback 邊界：只有尚未進入 `provider.call()` 前可改選明確 fallback；進入 call 後，不論回應失敗或拋錯都保持 provider sticky，避免重複副作用。預設 registry 仍只有 Claude。已加入的設定只用來驗證未來路由政策：
+`services/ai_router.py::call_ai()` 目前尚未被正式入口使用。`ProviderRouter` 以 Claude/Codex registry 與 `is_ready()` 建立可測試的 pre-start fallback 邊界：只有尚未進入 `provider.call()` 前可改選明確 fallback；進入 call 後，不論回應失敗或拋錯都保持 provider sticky，避免重複副作用。預設 mode 仍固定 Claude：
 
 | 環境變數 | 預設值 | 目前行為 |
 |---------|--------|----------|
@@ -63,19 +63,25 @@ ChingTech OS 的 AI 助手透過 `claude-code-acp`（ClaudeClient in-process）�
 | `AI_PROVIDER_CANARY_CONTEXTS` | `internal_admin,internal_test` | context exact-match allowlist |
 | `AI_PROVIDER_CANARY_AGENTS` | `test-agent` | Agent exact-match allowlist |
 
-在 Codex provider 尚未通過後續 gate 前，`codex` 會在 pre-start fallback 記錄 `codex_unready`；`auto` 會依 scope 與 usage snapshot 產生 route reason，但實際 provider 仍為 Claude。`RoutingContext` 只供 router 判斷，不會傳入 prompt 或 provider。fake provider tests 已鎖住 readiness false/error/missing、fallback unavailable 與執行後禁止跨 provider retry。
+`codex` 或符合 canary 的 `auto` 決策可以選到已註冊的 Codex provider；binary/circuit readiness 失敗才會在 session 前回 Claude並記錄 `codex_unready`。`RoutingContext` 只供 router 判斷，不會傳入 prompt 或 provider。fake provider tests 已鎖住 readiness false/error/missing、fallback unavailable 與執行後禁止跨 provider retry。由於目前沒有正式 caller 使用 `call_ai()`，既有 Line、Telegram、Web 與特殊 pipeline 完全不受影響。
 
 ### Claude Usage Monitor
 
 `services/claude_usage.py` 以背景 single-flight request 更新記憶體快照，Router 不會在使用者請求路徑等待外部 Usage API。快照分為 unknown、fresh、stale、error；預設 TTL 60 秒、max-stale 300 秒。只有 `AI_PROVIDER_MODE=auto` 會在 FastAPI lifespan 啟動，forced Claude 不讀取 credentials。
 
-自動路由採 hysteresis：fresh utilization `>=90%` 選 Codex、已在 Codex 時必須 `<85%` 才切回 Claude；85%–90% 或 max-stale 內的 stale 快照維持前一個穩定 provider。unknown、error 或超過 max-stale 一律回 Claude。Codex provider 尚未註冊時，所有 Codex 決策仍在 pre-start readiness 階段回到 Claude。
+自動路由採 hysteresis：fresh utilization `>=90%` 選 Codex、已在 Codex 時必須 `<85%` 才切回 Claude；85%–90% 或 max-stale 內的 stale 快照維持前一個穩定 provider。unknown、error 或超過 max-stale 一律回 Claude。
 
 ### Codex ACP Compatibility Layer
 
 `services/codex_acp.py` 固定搭配 `@agentclientprotocol/codex-acp` 1.1.9、`@openai/codex` 0.146.0 與 Python ACP 0.8.0。此層只處理協定差異：ordered message delta、tool terminal event 去重、token/model metadata、stdio/HTTP MCP schema 與 tool-call-id permission identity correlation；provider 的工作目錄、權限、callback、timeout 與資源限制由 `codex_agent.py` 負責。
 
 真實 smoke 使用本機單一唯讀 MCP fixture，已驗證 stdio tool、Streamable HTTP handshake、canonical server/tool identity、timeout/cancel 與 subprocess cleanup。若 pin 組合升級後任一契約失敗，Codex readiness 必須 fail closed，不可退回模糊工具名稱判斷。
+
+### Codex Provider 安全邊界
+
+`services/codex_agent.py` 沿用 Claude 的 per-request session workdir、MCP merge 與 framework identity/env injection，但只載入 allowlist canonical name 實際引用且同時位於 required set 的 server。permission 必須同時具有完全一致的 `mcp.server.tool` title、結構化 server/tool 與 `mcp__server__tool` allowlist；Unknown、短名稱、同名 server 衝突或 event correlation 不一致全部拒絕。
+
+Provider 強制 read-only、`on-request` approval、停用 multi-agent，並拒絕 terminal、file-write 與 Codex 原生圖片工具。允許的圖片需求只能走既有 MCP 工具，且仍受 nanobanana/codex-image 全域上限。每次呼叫也受 semaphore、queue timeout 與 circuit breaker 控制；timeout 會 cancel、保留 partial result，再 disconnect 並清除 session 目錄。stderr 只保留有界尾端且遮罩 credential-like 內容。
 
 ## Agent 系統
 

--- a/docs/codex-acp-failover-evaluation.md
+++ b/docs/codex-acp-failover-evaluation.md
@@ -1,7 +1,7 @@
 # Codex ACP 備援評估報告
 
 > 評估日期：2026-08-04
-> 狀態：Phase 0/1/2 完成；固定 Claude 的安全旁路與 sticky router 已受測，Codex 與自動路由尚未實作或啟用
+> 狀態：Phase 0–4 完成；安全旁路、usage monitor 與 Codex ACP 相容層已受測，Codex Provider 尚未註冊，正式流量仍固定 Claude
 > 後續計畫：`openspec/changes/add-codex-acp-failover/`
 
 ## 1. 結論
@@ -14,7 +14,7 @@
 
 ## 2. 評估範圍
 
-本次完成以下唯讀檢查與測試，未修改功能程式：
+初始評估完成以下唯讀檢查與測試；後續 Phase checkpoint 則依測試先行逐步加入預設不啟用的隔離元件：
 
 - 查閱 `docs/module-index.md` 定位 AI、Bot、MCP 與部署模組。
 - 還原 `ctos-lite` 的 Claude/Codex provider router、Claude 用量快取與 Codex ACP adapter。
@@ -25,7 +25,7 @@
 - 對照目前官方 Codex App Server、認證與 rate-limit 能力文件。
 - 執行主系統相關測試、完整後端測試與 `ctos-lite` provider 測試。
 
-本次沒有執行真實 Claude/Codex 推論，也沒有用正式 MCP 寫入工具做端到端驗證。這些驗證被列為後續啟用 gate，而不是在評估階段直接碰正式資料。
+初始評估沒有執行真實 Claude/Codex 推論，也沒有用正式 MCP 寫入工具做端到端驗證。Phase 4 已補上真實 Codex 唯讀 smoke 與隔離 MCP fixture；正式 MCP 寫入、正式資料及正式流量仍未觸碰，並保留為後續啟用 gate。
 
 ## 3. `ctos-lite` 參考實作
 
@@ -286,6 +286,23 @@ Codex ACP 每個請求啟動 Node/Codex subprocess。需要：
 - 完整 `npm run ci:check`：`1335 passed, 10 skipped, 1 warning in 180.15s`，整體 coverage 85.95%。
 
 此 checkpoint 完成 Phase 3。尚未註冊 Codex provider、啟動 Codex subprocess 或遷移任何 caller；下一步只進行 ACP protocol compatibility spike 與唯讀 smoke。
+
+### 6.9 Codex ACP compatibility spike checkpoint（2026-08-04）
+
+結論為 **Go**，正式 provider 可建立在 pin 版 ACP compatibility layer，不需改走直接 App Server。
+
+- npm lock 固定 `@agentclientprotocol/codex-acp` 1.1.9 與 `@openai/codex` 0.146.0；Python 使用既有 `claude-code-acp` 0.5.1 / ACP 0.8.0。
+- 上游 adapter 1.1.9 會啟動 Codex App Server，並原生映射 stdio/HTTP MCP、tool events、usage、permission 與 cancel。官方 App Server 的 initialize/thread/turn lifecycle 因此由 adapter 承擔。
+- Generic Python client 的已知缺口已集中修正在 `services/codex_acp.py`：合法重複 chunk 不再被 substring 去重、tool terminal update 只完成一次、PromptResponse token/model metadata 不遺失、stdio/HTTP schema 完整保留。
+- HTTP MCP 的 URL/headers 已以 fake connection 驗證，並以本機 Streamable HTTP fixture 完成真實 session handshake。
+- 真實 `on-request` permission event 已取得 canonical title `mcp.ctos-readonly-smoke.read_only_marker` 與 raw input 的 `server=ctos-readonly-smoke`、`tool=read_only_marker`；不需要 suffix 或 display-name 模糊比對。
+- 真實 read-only smoke：純文字、`repeat repeat repeat`、單一無副作用 stdio MCP tool、HTTP MCP handshake、timeout/cancel 與 subprocess cleanup 全部通過（`3 passed in 28.73s`；canonical permission 強化後單項重跑 `1 passed in 16.95s`）。
+- protocol 證據保存在 `backend/tests/fixtures/codex_acp_compatibility_1_1_9.json`；真實 smoke 預設 skip，只有 `RUN_CODEX_ACP_SMOKE=1` 才執行。
+- 預設 CI：compatibility `11 passed, 3 skipped`；完整 `npm run ci:check`：`1348 passed, 13 skipped, 1 warning in 181.26s`，coverage 85.88%。
+
+ACP 與直接 App Server 的差異：App Server 提供原生 initialize/thread/start/turn/start/turn/completed 事件與更完整控制；ACP 多一層翻譯，但已提供 ching-tech-os 需要的 client-facing session、MCP 與 permission 事件，且 ctos-lite 與本次真實 smoke 都已驗證。為降低自製 JSON-RPC client 的維護面積，Phase 5 繼續採 ACP；若未來 pin 升級破壞 canonical identity 或 HTTP MCP，則 fail closed 並回到 App Server spike，而不是模糊放行。
+
+此 checkpoint 尚未把 Codex 註冊到 Router；Phase 5 將在相同 compatibility layer 上實作完整 provider contract、權限與資源治理。
 
 ## 7. 補完測試後的信心邊界
 

--- a/docs/codex-acp-failover-evaluation.md
+++ b/docs/codex-acp-failover-evaluation.md
@@ -274,6 +274,19 @@ Codex ACP 每個請求啟動 Node/Codex subprocess。需要：
 
 此 checkpoint 完成 Phase 2。關閉/預設 Claude 模式下，既有入口仍全部直呼 `call_claude()`，完整測試與既有 AI log 路徑無回歸。下一步進入 Phase 3 時，先只新增 usage payload 與 snapshot model 測試，不讀 credentials、不呼叫 HTTP，也不啟動 background task。
 
+### 6.8 Claude Usage Monitor checkpoint（2026-08-04）
+
+- 新增 `services/claude_usage.py`，將 5 小時與 7 天 utilization 正規化為 0–1 並取最大值；0–1、0–100、malformed、NaN/Inf 與 out-of-range 均有測試。
+- `UsageSnapshot` 明確區分 unknown、fresh、stale、error，保存 fetched/attempt time、安全錯誤分類與連續失敗次數；短期失敗保留最後有效值，超過 max-stale 則 fail closed 回 Claude。
+- refresh 使用 single-flight lock、60 秒 TTL、300 秒 max-stale 與週期 background task；Router 只讀記憶體，不在請求路徑等待 usage HTTP。
+- 只有 `AI_PROVIDER_MODE=auto` 才在 FastAPI lifespan 啟動 monitor；初次刷新受短 timeout 保護，missing credentials 或外部服務失敗不阻止系統啟動。
+- 401、429、5xx、network timeout、missing/invalid/unreadable credentials、invalid JSON、cache recovery 與 startup/cleanup 均有測試；log 不含 token、完整 response body 或原始 exception 內容。
+- `UsageRoutingPolicy` 已鎖定 `>=90%` 切 Codex、`<85%` 切回 Claude、85%–90% 維持穩定 provider；unknown/error 回 Claude，max-stale 內 stale 維持前一狀態。
+- focused：`67 passed`；`claude_usage.py` 98%、`ai_router.py` 100%。
+- 完整 `npm run ci:check`：`1335 passed, 10 skipped, 1 warning in 180.15s`，整體 coverage 85.95%。
+
+此 checkpoint 完成 Phase 3。尚未註冊 Codex provider、啟動 Codex subprocess 或遷移任何 caller；下一步只進行 ACP protocol compatibility spike 與唯讀 smoke。
+
 ## 7. 補完測試後的信心邊界
 
 補完測試可以讓團隊有把握「陸續開發」，但不能把所有階段視為同一種完成度：

--- a/docs/codex-acp-failover-evaluation.md
+++ b/docs/codex-acp-failover-evaluation.md
@@ -1,0 +1,328 @@
+# Codex ACP 備援評估報告
+
+> 評估日期：2026-08-04
+> 狀態：Phase 0/1/2 完成；固定 Claude 的安全旁路與 sticky router 已受測，Codex 與自動路由尚未實作或啟用
+> 後續計畫：`openspec/changes/add-codex-acp-failover/`
+
+## 1. 結論
+
+在 `ching-tech-os` 加入「Claude OAuth 用量達 90% 時，將新請求切換至 Codex」技術上可行，但不能直接移植 `ctos-lite` 的實作。
+
+目前判定為「有條件 No-Go」：可以開始測試先行的架構與 adapter 開發，但在完成 provider 契約、MCP 權限、真實唯讀 smoke、canary、監控與 kill switch 前，不得開啟正式流量的自動切換。
+
+主要原因不是模型文字輸出，而是 `ching-tech-os` 的 `call_claude()` 已同時承擔工具安全、身份注入、MCP server 動態載入、部分結果保存、進度通知與多入口整合。任何 provider 替換都必須先證明這些行為沒有退化。
+
+## 2. 評估範圍
+
+本次完成以下唯讀檢查與測試，未修改功能程式：
+
+- 查閱 `docs/module-index.md` 定位 AI、Bot、MCP 與部署模組。
+- 還原 `ctos-lite` 的 Claude/Codex provider router、Claude 用量快取與 Codex ACP adapter。
+- 盤點 `ching-tech-os` 所有直接使用 `call_claude()` 的入口與回應依賴。
+- 檢查主系統 `.mcp.json` 的 stdio/HTTP MCP 組成與動態 extends MCP。
+- 檢查 systemd 安裝腳本、PATH、執行使用者與 npm/uv 依賴管理方式。
+- 檢查已安裝的 Codex CLI、`codex-acp` adapter 與 Python Generic ACP client。
+- 對照目前官方 Codex App Server、認證與 rate-limit 能力文件。
+- 執行主系統相關測試、完整後端測試與 `ctos-lite` provider 測試。
+
+本次沒有執行真實 Claude/Codex 推論，也沒有用正式 MCP 寫入工具做端到端驗證。這些驗證被列為後續啟用 gate，而不是在評估階段直接碰正式資料。
+
+## 3. `ctos-lite` 參考實作
+
+### 3.1 路由流程
+
+`ctos-lite/backend/src/ctos_lite/services/ai_factory.py` 的行為如下：
+
+1. `AI_PROVIDER=claude`：固定 Claude。
+2. `AI_PROVIDER=codex`：固定 Codex ACP。
+3. `AI_PROVIDER=auto`：讀取記憶體內的 Claude OAuth 用量。
+4. 用量 `>= USAGE_THRESHOLD`（預設 `0.90`）：新請求直接送 Codex。
+5. 用量低於門檻：先送 Claude。
+6. Claude 回傳失敗且 `AUTO_FALLBACK_TO_CODEX=true`：將整個請求重新送 Codex。
+7. 每次呼叫結束後，以 background task 嘗試刷新 Claude 用量。
+
+### 3.2 用量來源
+
+`ctos-lite/backend/src/ctos_lite/services/claude_usage.py`：
+
+- 讀取 `~/.claude/.credentials.json` 的 OAuth access token。
+- 呼叫 Anthropic OAuth usage endpoint。
+- 同時讀取 5 小時與 7 天 utilization，取兩者最大值。
+- 相容 `0.90` 與 `90.0` 兩種百分比格式。
+- 記憶體 cache TTL 為 60 秒。
+
+### 3.3 Codex ACP adapter
+
+`ctos-lite/backend/src/ctos_lite/services/codex_agent.py`：
+
+- 每次請求啟動一個 `codex-acp` stdio subprocess。
+- 透過 `claude-code-acp` 內的 Generic ACP client 溝通。
+- 修正 Generic client 以 substring 去重 message chunk，可能吃掉重複文字的問題。
+- 收集工具開始/完成事件、文字、token usage 與實際模型資訊。
+- 設定 `INITIAL_AGENT_MODE=read-only`。
+- 阻擋 terminal 與 file-write callback。
+- 依工具白名單回答 ACP permission request。
+- 將 Claude 的 haiku/sonnet/opus 工作負載角色映射到 Codex 模型角色。
+
+### 3.4 成熟度判斷
+
+這套功能由 `ctos-lite` commit `21a2973 Add Codex ACP provider fallback` 於 2026-08-04 一次加入，修改 12 個檔案。它可以作為可行性參考，但尚不能視為已經過長期正式流量驗證的成熟元件。
+
+## 4. `ching-tech-os` 現行 AI 契約
+
+核心函式位於 `backend/src/ching_tech_os/services/claude_agent.py`。除了推論之外，目前還提供：
+
+- 每次呼叫建立並清理隔離的 session 工作目錄。
+- 合併專案 `.mcp.json` 與 enabled extends 的 MCP server。
+- 同時支援 stdio 與 HTTP MCP server。
+- 依 Agent 權限只載入需要的 MCP server。
+- 工具白名單與單回合工具呼叫次數上限。
+- `ctos_user_id` framework 級身份注入，避免 LLM 偽造使用者。
+- `extra_mcp_env` 注入群組、Agent、NAS 存取範圍等安全上下文。
+- `on_tool_start` / `on_tool_end` callback，供 Telegram 顯示進度。
+- timeout 時保留 partial text、已完成 tool calls 與 pending tool 摘要。
+- token usage、tool timings 與 session cleanup。
+
+直接或間接依賴這個契約的入口包含：
+
+- Line Bot 個人與群組對話。
+- Telegram Bot 對話與進度通知。
+- 未綁定使用者 restricted mode。
+- `/debug` 管理指令。
+- Web AI Chat 與 Agent 測試。
+- 排程 Agent。
+- 簡報 outline JSON 與圖片生成。
+- research-skill 的 WebSearch/WebFetch 與 fallback 統整。
+- Intent Guard 無 API key 時的 CLI fallback。
+- 對話摘要壓縮。
+
+因此 provider 導入必須逐入口遷移，不能一次改寫 `call_claude()` 的語意。
+
+## 5. 主要風險
+
+### 5.1 跨 provider 重送造成重複副作用
+
+`ctos-lite` 在 Claude 失敗時，會將完整 prompt 重新送 Codex。Claude 可能已經執行過 MCP 工具，只是在取得最終文字前 timeout 或失敗。若 Codex 再執行一次，可能重複：
+
+- 建立或修改知識庫資料。
+- 建立分享連結。
+- 發送 Line/Telegram 訊息。
+- 建立排程或背景工作。
+- 上傳、移動或處理 NAS 檔案。
+- 呼叫需付費的生圖或外部服務。
+
+第一版禁止 provider 執行後的通用 fallback。provider 必須在請求開始前選定，同一請求內保持不變。只有經明確證明「尚未啟動工具及副作用」的錯誤類別，未來才可另案考慮安全重試。
+
+### 5.2 HTTP MCP 不相容
+
+目前 Python Generic ACP client 的 `new_session()` 只將設定轉成 `McpServerStdio`。主系統 `.mcp.json` 包含 HTTP GitHub MCP，直接套用 `ctos-lite` converter 會得到空 command，造成 server 無法啟動或靜默缺少工具。
+
+Codex adapter 必須有 stdio 與 HTTP MCP 的契約測試，不能把 server config 當成同一種 dict 處理。
+
+### 5.3 工具權限比對過寬
+
+`ctos-lite` 的白名單允許用 normalized suffix 匹配工具名稱。不同 MCP server 若存在同名工具，可能把某 server 的授權套到另一個 server。
+
+主系統必須以完整 canonical identity 比對：
+
+- 內建工具使用明確名稱表。
+- MCP 工具使用 server + tool 完整名稱。
+- `Unknown` permission 只有在事件能唯一、可靠地對應已開始工具時才允許。
+- 任何模糊或衝突一律 fail closed。
+
+### 5.4 現行工具限制未被 Codex 實作
+
+Codex adapter 尚未具備：
+
+- `tool_call_limits`。
+- nanobanana/codex-image 全域單回合限制。
+- 完整 `ctos_user_id` 與 `extra_mcp_env` 行為。
+- Telegram callbacks 與 callback error isolation。
+- 與 Claude 相同的 tool timings。
+
+這些不是可選優化，而是 provider 契約的一部分。
+
+### 5.5 用量 cache 狀態不完整
+
+`ctos-lite` cache 的初始 utilization 是 0，造成服務剛啟動或 credentials 不可用時，系統無法區分「確定為 0%」與「尚未取得資料」。此外還有：
+
+- 沒有 refresh lock，多個 stale request 可能同時打 usage endpoint。
+- 沒有 freshness、last error 或 consecutive failure 狀態。
+- API 失敗時可能長期沿用過高或過低的 stale 值。
+- 90% 附近沒有 hysteresis，可能反覆切換。
+- 每次 AI request 都排 background refresh，不利於流量尖峰控制。
+
+主系統需要明確的 `unknown / fresh / stale / error` 狀態、single-flight refresh、週期更新與切換遲滯。
+
+### 5.6 部署與版本漂移
+
+目前開發機環境：
+
+- Codex CLI：`0.146.0`
+- `@agentclientprotocol/codex-acp`：`1.1.9`
+
+但 `codex-acp` 是全域 npm 安裝，不在 repo 的 package lock 中。正式機安裝腳本也沒有安裝或驗證它。systemd 服務還需確認：
+
+- `ct` 使用者能找到正確 binary。
+- service 的 Codex auth storage 路徑正確。
+- headless 模式不會啟動 browser login。
+- auth 過期時能回傳可監控的 readiness error。
+- adapter 與 Codex CLI 版本相容。
+
+正式導入必須 pin runtime 版本並提供 preflight，不可依賴部署機曾手動全域安裝的版本。
+
+### 5.7 可觀測性不足
+
+主系統目前 `ai_logs.model` 主要記錄 Agent 所選 Claude alias，沒有獨立 provider 欄位。若發生切換，需要至少記錄：
+
+- requested provider/model role。
+- selected provider。
+- actual model。
+- route reason。
+- Claude usage ratio、資料時間與 freshness。
+- Codex readiness/circuit 狀態。
+- tool started/completed 狀態。
+- provider error category。
+
+第一階段可先將 metadata 放入 response、structured log 與 `parsed_response`，避免立即修改分區表 schema；是否新增正式 provider 欄位再依 canary 查詢需求決定。
+
+### 5.8 subprocess 併發與清理
+
+Codex ACP 每個請求啟動 Node/Codex subprocess。需要：
+
+- provider semaphore 與 queue timeout。
+- subprocess 啟動失敗分類。
+- timeout cancel 後的強制 cleanup。
+- bounded stderr tail，不能直接丟棄所有診斷。
+- circuit breaker，避免 adapter 壞掉時每個使用者都重複啟動失敗行程。
+- load test 驗證無 zombie process 與無限制記憶體成長。
+
+## 6. 測試結果
+
+### 6.1 `ching-tech-os`
+
+- AI 相關測試：`87 passed in 3.44s`
+- 完整後端：`1269 passed, 10 skipped, 1 warning in 115.02s`
+- 完整 coverage：`85.50%`；`claude_agent.py` 為 `82%`。
+- warning 為既有 `datetime.utcnow()` deprecation，與本功能無關。
+
+### 6.2 `ctos-lite`
+
+- provider 測試：`16 passed`
+- 三個相關模組 coverage：60%
+- `ai_factory.py`：94%
+- `claude_usage.py`：84%
+- `codex_agent.py`：51%
+
+現有 `ctos-lite` 測試證明基本路由與成功路徑，但不足以保護主系統需要的事件、HTTP MCP、permission、timeout、cleanup、callback、tool limit 與身份安全分支。
+
+### 6.3 Coverage gate 差異
+
+- 2026-08-04 實測整體 coverage 為 85.50%。
+- GitHub Actions `backend-tests.yml` 目前要求 85%。
+- 本機 `test:backend:cov` 與 GitHub Actions 先統一為 85% 防退步 gate，`test:backend:cov:next` 以 86% 作為下一階預檢。
+- 新增 `test:backend:cov:target` 保留 90% 目標；Codex auto mode 與 canary 必須等此 target 通過後才可啟用。
+
+後續依新增測試的實際 coverage 逐整數調高 CI gate，最終在進入 canary 前達到 90%。router、usage state machine 與 permission guard 的重要分支仍必須逐條測試，不能只依賴 aggregate line coverage。
+
+### 6.4 第一批 characterization tests 進度（2026-08-04）
+
+- `test_claude_agent.py`：`11 passed`。
+- `claude_agent.py` 完整測試 coverage：91%（基線 82%）。
+- 新增共用 provider contract fixture，固定 request kwargs、response/partial-result、routing metadata 與 tool event 欄位。
+- 新增保護：完整參數傳遞、history/system prompt、required MCP server、身份環境注入、`ctos_user_id` 不可由模型偽造、白名單拒絕、call-site limit、nanobanana/codex-image 全域上限，以及 callback error isolation。
+- 新增 MCP merge/filter 保護：enabled extends、base precedence、stdio/HTTP 設定與敏感 env/header 不進 log。
+- 新增 timeout/cancel 保護：partial text、已完成與執行中工具、token/timing、client close 與 workdir cleanup。
+- 完成後的 `npm run ci:check`：`1275 passed, 10 skipped, 1 warning in 180.98s`，整體 coverage 85.70%（基線 85.50%）。
+
+這批測試沒有修改正式 Claude 實作或任何 AI 路由。Phase 1 characterization gate 已完成；下一步可在 feature flag 預設關閉下，先建立向下相容的 provider-neutral response/protocol 與 `call_ai()` 旁路。
+
+### 6.5 Provider-neutral 安全旁路 checkpoint（2026-08-04）
+
+- 新增 `services/ai_provider.py`：`AIResponse`、`ToolCall`、callback 型別與 runtime-checkable `AIProvider` Protocol。
+- `claude_agent.ClaudeResponse` 與 `ToolCall` 保留為共用型別的向下相容 alias。
+- 新增 `services/ai_router.py::call_ai()`，完整接受既有 Claude kwargs 加上 `routing_context`，但目前永遠只呼叫 Claude 一次。
+- `routing_context` 不傳入 prompt 或 Claude provider；provider exception 不做 retry。
+- 尚未有任何既有 caller 遷移至 `call_ai()`，因此 Line、Telegram、Web、排程、簡報與 research 路徑仍直接使用純 Claude。
+- 尚未新增 provider mode、usage monitor、Codex adapter 或 subprocess。
+- 完成後 `npm run ci:check`：`1280 passed, 10 skipped, 1 warning in 180.28s`，整體 coverage 85.71%。
+- 新增模組 coverage：`ai_provider.py` 97%、`ai_router.py` 100%；`claude_agent.py` 維持 91%。
+
+此 checkpoint 只建立可測試的旁路接縫，不構成 Codex 備援可用或可進 canary 的證明。下一步應先加入安全設定驗證與 canary scope 判斷，預設仍為 forced Claude。
+
+### 6.6 Provider mode 與 canary scope checkpoint（2026-08-04）
+
+- 新增 `AI_PROVIDER_MODE` 驗證，只接受 `claude`、`codex`、`auto`；預設與非法值都安全使用 Claude，非法值會留下明確 error log。
+- 新增 `AI_PROVIDER_CANARY_CONTEXTS` 與 `AI_PROVIDER_CANARY_AGENTS`，預設只包含 internal admin/test 與 `test-agent`。
+- 新增 frozen `RoutingContext`，context/Agent 會正規化並以 exact match 判斷；空 context 直接拒絕。
+- `routing_context` 不會傳入 Claude kwargs、prompt 或 model context。
+- 因 Codex provider 與 usage monitor 尚未存在，所有 mode 目前仍只呼叫 Claude 一次：`claude` 為 `forced_claude`、`codex` 為 `codex_unready`、auto 非 canary 為 `canary_not_allowed`、auto canary 為 `usage_unknown`。
+- focused：`28 passed`；`ai_router.py` 100%。
+- 完整 `npm run ci:check`：`1292 passed, 10 skipped, 1 warning in 184.81s`，整體 coverage 85.75%。
+
+此步仍未探測 Codex binary、讀取 Claude usage、啟動 background task 或遷移 caller。下一步應以 fake providers 補齊 sticky selection、pre-start fallback 與執行後禁止跨 provider retry 的 router tests。
+
+### 6.7 Sticky Router 與 pre-start fallback checkpoint（2026-08-04）
+
+- 新增 `ProviderDecision` 與 registry-based `ProviderRouter`；registry key 與 provider identity 不一致時會在建立階段拒絕。
+- `AIProvider.is_ready()` 明確代表尚未建立 session 前的 readiness；只有 primary readiness 為 false、拋錯或 provider 未註冊時，才可改選決策中明確指定的 fallback。
+- 進入 `provider.call()` 即視為執行邊界；無論回應為成功、`provider_started=false` 的失敗、`provider_started=true` 的失敗或直接拋出 exception，都不會跨 provider 重送。
+- fallback 也 unavailable 時，router 在任何 provider call 前以 `ProviderUnavailableError` 結束，不會偷偷改走第三個 provider。
+- 預設 registry 仍只有 Claude adapter；fake Codex 只存在測試，沒有安裝套件、探測 binary、建立 session 或 subprocess。
+- focused router tests：`26 passed`，`ai_router.py` 100%。
+- 完整 `npm run ci:check`：`1301 passed, 10 skipped, 1 warning in 179.21s`，整體 coverage 85.80%。
+
+此 checkpoint 完成 Phase 2。關閉/預設 Claude 模式下，既有入口仍全部直呼 `call_claude()`，完整測試與既有 AI log 路徑無回歸。下一步進入 Phase 3 時，先只新增 usage payload 與 snapshot model 測試，不讀 credentials、不呼叫 HTTP，也不啟動 background task。
+
+## 7. 補完測試後的信心邊界
+
+補完測試可以讓團隊有把握「陸續開發」，但不能把所有階段視為同一種完成度：
+
+| 已完成條件 | 可以有把握進行的下一步 |
+|---|---|
+| Provider 契約、router、usage 與 permission 單元測試 | 開發 feature-flag 關閉的 router 與 Codex adapter |
+| stdio/HTTP MCP integration tests、真實唯讀 ACP smoke | 開啟內部 admin/test-agent canary |
+| Line/Telegram/Web 入口測試、工具副作用防重送測試 | 開啟 allowlist 使用者或 Agent canary |
+| systemd preflight、load test、監控與 kill switch | 小比例正式流量自動切換 |
+| 24–72 小時 canary 無安全與重複操作問題 | 逐步擴大支援入口 |
+
+換句話說，測試不是一次性保證，而是每一階段的進場門檻。只要嚴格遵守 gate，就能安全地開始開發；未通過 gate 的功能不能向下一階段擴張。
+
+## 8. 建議架構原則
+
+1. 保留 `call_claude()` 為純 Claude provider，不改變所有既有 caller 的語意。
+2. 新增 provider-neutral `call_ai()`，只有明確遷移的入口才使用 router。
+3. provider 在請求開始前選定，整個請求保持 sticky。
+4. 第一版只做 usage-based routing，不做 Claude 執行失敗後跨 provider 重送。
+5. 自動模式預設關閉；初始部署仍為固定 Claude。
+6. 90% 切到 Codex，低於 85% 才切回 Claude。
+7. usage refresh TTL 為 60 秒、max-stale 為 300 秒；超過 max-stale 時回到既有 Claude 行為並發出告警。
+8. Codex readiness 在請求開始前失敗時回到 Claude，並記錄 critical route reason；Codex 開始執行後不得跨 provider 重送。
+9. Codex 一旦已開始執行但失敗，不得再送 Claude。
+10. 逐入口 migration：internal test → Web canary → Bot canary → 一般 Bot → 特殊 pipeline。
+
+## 9. 啟用前必要 gate
+
+- [ ] OpenSpec proposal、design、requirements 經確認。
+- [ ] Provider 契約與 safety tests 先寫並確認會失敗。
+- [ ] `npm run test:backend:cov:target` 通過，整體 coverage 達 90% 以上。
+- [ ] `uv run pytest` 與 `npm run ci:check` 全數通過。
+- [ ] stdio 與 HTTP MCP parity 測試通過。
+- [ ] 真實 `codex-acp` 唯讀 smoke 通過。
+- [ ] side-effect tool 不會因 provider failure 重送。
+- [ ] systemd 使用者的 binary/auth/preflight 通過。
+- [ ] provider concurrency、timeout、cleanup 與 circuit breaker 通過。
+- [ ] provider、route reason、usage freshness 與 error category 可觀測。
+- [ ] 固定 Claude kill switch 經實際演練。
+- [ ] canary allowlist 與回復流程經實際演練。
+
+## 10. 外部能力邊界
+
+OpenAI 官方文件將 Codex App Server 定位為產品深度整合介面，提供認證、conversation、approval、streamed events、MCP 與 rate-limit 查詢。`codex-acp` 是外部 adapter，內部再將 ACP 轉成 Codex App Server 操作。
+
+第一個 architecture spike 應驗證 ACP adapter 是否能完整承載主系統契約；若 HTTP MCP、permission identity 或事件資料不足，應比較直接使用官方 App Server stdio，而不是為了沿用 `ctos-lite` 而放寬安全契約。
+
+參考：
+
+- https://learn.chatgpt.com/docs/app-server
+- https://learn.chatgpt.com/docs/auth

--- a/docs/codex-acp-failover-evaluation.md
+++ b/docs/codex-acp-failover-evaluation.md
@@ -1,7 +1,7 @@
 # Codex ACP 備援評估報告
 
 > 評估日期：2026-08-04
-> 狀態：Phase 0–4 完成；安全旁路、usage monitor 與 Codex ACP 相容層已受測，Codex Provider 尚未註冊，正式流量仍固定 Claude
+> 狀態：Phase 0–5 完成；安全旁路、usage monitor、ACP 相容層與 Codex Provider 已受測，正式流量仍固定 Claude且尚無 caller 遷移
 > 後續計畫：`openspec/changes/add-codex-acp-failover/`
 
 ## 1. 結論
@@ -304,6 +304,22 @@ ACP 與直接 App Server 的差異：App Server 提供原生 initialize/thread/s
 
 此 checkpoint 尚未把 Codex 註冊到 Router；Phase 5 將在相同 compatibility layer 上實作完整 provider contract、權限與資源治理。
 
+### 6.10 Codex Provider checkpoint（2026-08-04）
+
+Phase 5 已完成，Codex provider 已註冊至 `call_ai()` Router，但預設 `AI_PROVIDER_MODE=claude`，且所有正式入口仍直呼 `call_claude()`，所以現有流量不會啟動 Codex。
+
+- 完整 provider kwargs 與 `AIResponse` 契約已對齊；保留 history、system prompt、partial text、completed tool calls、token、actual model、tool timings 與 callback isolation。
+- 每請求使用隔離 session workdir；MCP 先依 canonical allowlist server 與 required set 取交集，再沿用主系統 merge/filter、stdio/HTTP transport 與 `CTOS_USER_ID`/Agent scope env injection。
+- permission 同時要求 ACP title、raw server/tool 與 allowlist canonical identity 精確一致；短名稱、Unknown、同名不同 server、缺少 namespace、tool-call-id correlation 不一致皆拒絕。
+- terminal、file-write 與 Codex native image fail closed；允許的圖片只能走既有 MCP，仍受 nanobanana/codex-image 全域及 call-site 次數上限。
+- subprocess 設為 read-only、on-request approval、multi-agent disabled、`NO_BROWSER=1`；並有 concurrency semaphore、獨立 queue timeout、circuit breaker、安全錯誤分類、有界且遮罩的 stderr tail。
+- timeout 會 cancel、保留 partial result，再 disconnect/terminate/kill 並清除 session 目錄；binary missing、auth、protocol、MCP startup、overload 與 callback failure 均有獨立測試。
+- Phase 5 focused：`64 passed`；`codex_agent.py` 94%，核心安全分支不是只依賴 aggregate coverage。
+- 完整後端：`1371 passed, 13 skipped, 1 warning in 114.60s`。
+- `npm run ci:check`：前端 build 通過；`1371 passed, 13 skipped, 1 warning in 180.43s`，整體 coverage 85.98%。
+
+這個 checkpoint 完成 adapter 本體，但不是正式啟用許可。Phase 6–9 的部署 preflight、service-user auth、可觀測性、caller canary、load test、kill-switch 演練與 24–72 小時觀察仍是 rollout gate。
+
 ## 7. 補完測試後的信心邊界
 
 補完測試可以讓團隊有把握「陸續開發」，但不能把所有階段視為同一種完成度：
@@ -311,7 +327,8 @@ ACP 與直接 App Server 的差異：App Server 提供原生 initialize/thread/s
 | 已完成條件 | 可以有把握進行的下一步 |
 |---|---|
 | Provider 契約、router、usage 與 permission 單元測試 | 開發 feature-flag 關閉的 router 與 Codex adapter |
-| stdio/HTTP MCP integration tests、真實唯讀 ACP smoke | 開啟內部 admin/test-agent canary |
+| stdio/HTTP MCP integration tests、真實唯讀 ACP smoke | 實作完整 Provider 與部署 readiness |
+| Provider、部署 preflight、可觀測性與 kill switch | 開啟內部 admin/test-agent canary |
 | Line/Telegram/Web 入口測試、工具副作用防重送測試 | 開啟 allowlist 使用者或 Agent canary |
 | systemd preflight、load test、監控與 kill switch | 小比例正式流量自動切換 |
 | 24–72 小時 canary 無安全與重複操作問題 | 逐步擴大支援入口 |

--- a/docs/module-index.md
+++ b/docs/module-index.md
@@ -63,9 +63,10 @@ services/bot/rate_limiter.py       ← 受限模式頻率限制（bot_usage_trac
 services/bot/media.py              ← 媒體處理
 services/bot/message.py            ← 訊息處理
 services/ai_provider.py            ← Provider-neutral 回應型別與 AIProvider Protocol
-services/ai_router.py              ← call_ai()、ProviderRouter、readiness/sticky 邊界與 canary 判斷（目前安全回到 Claude）
+services/ai_router.py              ← call_ai()、Claude/Codex registry、readiness/sticky 邊界與 canary 判斷
 services/claude_usage.py           ← Claude OAuth usage snapshot、single-flight refresh 與 hysteresis 資料來源
 services/codex_acp.py              ← Codex ACP compatibility layer（ordered delta、HTTP MCP、permission identity）
+services/codex_agent.py            ← Codex Provider（canonical permission、資源限制、timeout/cleanup）
 services/claude_agent.py           ← call_claude() AI 推論
 ```
 
@@ -80,6 +81,7 @@ services/ai_provider.py            ← AIResponse、ToolCall 與 provider Protoc
 services/ai_router.py              ← Provider-neutral call_ai()、ProviderDecision 與 pre-start fallback（目前無 caller）
 services/claude_usage.py           ← Usage Monitor（unknown/fresh/stale/error、TTL/max-stale）
 services/codex_acp.py              ← Pin 版 Codex ACP 協定轉接與真實唯讀 smoke 基礎
+services/codex_agent.py            ← 完整 Codex provider 契約、MCP 安全邊界與 circuit breaker
 services/claude_agent.py           ← Claude API 呼叫
 services/linebot_ai.py             ← AI 訊息處理流程
 services/ai_manager.py             ← AI 管理邏輯（859 行）

--- a/docs/module-index.md
+++ b/docs/module-index.md
@@ -65,6 +65,7 @@ services/bot/message.py            ← 訊息處理
 services/ai_provider.py            ← Provider-neutral 回應型別與 AIProvider Protocol
 services/ai_router.py              ← call_ai()、ProviderRouter、readiness/sticky 邊界與 canary 判斷（目前安全回到 Claude）
 services/claude_usage.py           ← Claude OAuth usage snapshot、single-flight refresh 與 hysteresis 資料來源
+services/codex_acp.py              ← Codex ACP compatibility layer（ordered delta、HTTP MCP、permission identity）
 services/claude_agent.py           ← call_claude() AI 推論
 ```
 
@@ -78,6 +79,7 @@ services/bot/agents.py             ← prompt 模板（按功能分類）
 services/ai_provider.py            ← AIResponse、ToolCall 與 provider Protocol
 services/ai_router.py              ← Provider-neutral call_ai()、ProviderDecision 與 pre-start fallback（目前無 caller）
 services/claude_usage.py           ← Usage Monitor（unknown/fresh/stale/error、TTL/max-stale）
+services/codex_acp.py              ← Pin 版 Codex ACP 協定轉接與真實唯讀 smoke 基礎
 services/claude_agent.py           ← Claude API 呼叫
 services/linebot_ai.py             ← AI 訊息處理流程
 services/ai_manager.py             ← AI 管理邏輯（859 行）

--- a/docs/module-index.md
+++ b/docs/module-index.md
@@ -64,6 +64,7 @@ services/bot/media.py              ← 媒體處理
 services/bot/message.py            ← 訊息處理
 services/ai_provider.py            ← Provider-neutral 回應型別與 AIProvider Protocol
 services/ai_router.py              ← call_ai()、ProviderRouter、readiness/sticky 邊界與 canary 判斷（目前安全回到 Claude）
+services/claude_usage.py           ← Claude OAuth usage snapshot、single-flight refresh 與 hysteresis 資料來源
 services/claude_agent.py           ← call_claude() AI 推論
 ```
 
@@ -76,6 +77,7 @@ services/linebot_agents.py         ← agent 定義、prompt 生成、工具分�
 services/bot/agents.py             ← prompt 模板（按功能分類）
 services/ai_provider.py            ← AIResponse、ToolCall 與 provider Protocol
 services/ai_router.py              ← Provider-neutral call_ai()、ProviderDecision 與 pre-start fallback（目前無 caller）
+services/claude_usage.py           ← Usage Monitor（unknown/fresh/stale/error、TTL/max-stale）
 services/claude_agent.py           ← Claude API 呼叫
 services/linebot_ai.py             ← AI 訊息處理流程
 services/ai_manager.py             ← AI 管理邏輯（859 行）

--- a/docs/module-index.md
+++ b/docs/module-index.md
@@ -11,7 +11,7 @@
 |------|------|
 | `main.py` | FastAPI 入口、路由註冊、lifespan（啟動 scheduler/MCP/Telegram） |
 | `modules.py` | 模組 registry、`ENABLED_MODULES` 條件啟停、Skill contributes 合併 |
-| `config.py` | 環境變數設定（Pydantic Settings） |
+| `config.py` | 環境變數設定（含 AI provider mode 與 canary allowlist） |
 | `database.py` | asyncpg 連線池 |
 | `__init__.py` | 版本號 `__version__` |
 | `middleware/cache_control.py` | 快取控制中介層 |
@@ -62,6 +62,8 @@ services/bot/intent_guard.py       ← Intent Guard 意圖守門員（Haiku 前�
 services/bot/rate_limiter.py       ← 受限模式頻率限制（bot_usage_tracking）
 services/bot/media.py              ← 媒體處理
 services/bot/message.py            ← 訊息處理
+services/ai_provider.py            ← Provider-neutral 回應型別與 AIProvider Protocol
+services/ai_router.py              ← call_ai()、ProviderRouter、readiness/sticky 邊界與 canary 判斷（目前安全回到 Claude）
 services/claude_agent.py           ← call_claude() AI 推論
 ```
 
@@ -72,6 +74,8 @@ api/ai_management.py               ← AI prompt/agent CRUD API
 api/ai_router.py                   ← AI 對話 API（chats）
 services/linebot_agents.py         ← agent 定義、prompt 生成、工具分配、Agent 偏好持久化
 services/bot/agents.py             ← prompt 模板（按功能分類）
+services/ai_provider.py            ← AIResponse、ToolCall 與 provider Protocol
+services/ai_router.py              ← Provider-neutral call_ai()、ProviderDecision 與 pre-start fallback（目前無 caller）
 services/claude_agent.py           ← Claude API 呼叫
 services/linebot_ai.py             ← AI 訊息處理流程
 services/ai_manager.py             ← AI 管理邏輯（859 行）

--- a/docs/testing-ci.md
+++ b/docs/testing-ci.md
@@ -44,11 +44,14 @@ npm run build
 # 後端全量測試
 npm run test:backend
 
-# 後端 coverage 測試（門檻 90%）
+# 後端 coverage 測試（現況防退步門檻 85%）
 npm run test:backend:cov
 
-# 下一階門檻預檢（91%，不作為目前 CI Gate）
+# 下一階門檻預檢（86%，不作為目前 CI Gate）
 npm run test:backend:cov:next
+
+# Codex ACP 自動切換等高風險功能的目標門檻（90%）
+npm run test:backend:cov:target
 ```
 
 ### 單一測試（快速迭代）
@@ -80,7 +83,7 @@ uv run pytest -k permissions -v
 2. `uv sync` 安裝後端依賴
 3. 執行 pytest + coverage：
    - `--cov=src/ching_tech_os`
-   - `--cov-fail-under=90`
+   - `--cov-fail-under=85`
    - 產生 `coverage.xml`、`htmlcov/`、`pytest-report.xml`
 4. 上傳測試報告 artifacts（供下載檢查）
 
@@ -89,9 +92,11 @@ uv run pytest -k permissions -v
 ## 4. 提高測試率的落地規則
 
 ### Coverage 門檻拉升節奏（Step-by-step）
-- **目前 CI Gate**：90%
-- **下一階預檢**：91%（使用 `npm run test:backend:cov:next`）
-- **建議拉升規則**：當 `cov:next` 在主分支連續穩定通過後，再把 CI Gate 提升到同等門檻（每次 +1%）。
+- **2026-08-04 實測基線**：85.50%（1269 passed、10 skipped）。
+- **目前 CI Gate**：85%，與 GitHub Actions 的 `COVERAGE_FAIL_UNDER` 一致，作為不可退步的最低門檻。
+- **下一階預檢**：86%（使用 `npm run test:backend:cov:next`）。
+- **高風險功能目標 Gate**：90%（使用 `npm run test:backend:cov:target`）；Codex ACP 自動模式與 canary 不得在此門檻通過前啟用。
+- **建議拉升規則**：新增測試讓下一個整數門檻穩定通過後，同步提高 GitHub Actions、`test:backend:cov` 與 `test:backend:cov:next`，逐步提升至 90%。
 
 ### 後端 API / Service 變更
 - 新增或修改 API 路由時，至少補對應 `backend/tests/` 測試（成功與錯誤情境）。

--- a/openspec/changes/add-codex-acp-failover/.openspec.yaml
+++ b/openspec/changes/add-codex-acp-failover/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/openspec/changes/add-codex-acp-failover/design.md
+++ b/openspec/changes/add-codex-acp-failover/design.md
@@ -147,6 +147,8 @@ spike 必須先證明：
 
 **Phase 4 checkpoint（2026-08-04）— Go**：正式 protocol 選定 pin 版 `@agentclientprotocol/codex-acp` 1.1.9 + `@openai/codex` 0.146.0 + Python ACP 0.8.0。上游 adapter 本身由 App Server 轉接並支援 stdio/HTTP MCP；缺口位於 `claude-code-acp` Generic client 只轉 stdio、會以 substring 移除合法重複文字，並在 permission callback 遺失 active tool identity。`services/codex_acp.py` compatibility layer 已以 exact schema 補齊 HTTP headers、ordered delta、terminal progress 去重與 tool-call-id identity correlation。真實 read-only smoke 已通過文字、重複文字、stdio 工具、HTTP handshake、canonical permission identity、timeout/cancel 與 process cleanup，因此不需改走直接 App Server；若 pin 組合日後回歸，直接 App Server 仍是保留方案。
 
+**Phase 5 checkpoint（2026-08-04）**：`services/codex_agent.py` 已完成共用 response/kwargs、隔離 session、filtered stdio/HTTP MCP、framework identity env、canonical permission、工具與生圖上限、callbacks、partial result、timeout cleanup、bounded/redacted stderr、semaphore/queue timeout 與 circuit breaker。Router 已註冊 Codex，但 mode 預設 Claude且尚無正式 caller 使用 `call_ai()`。完整 CI 為 1371 passed/13 skipped、coverage 85.98%；下一階段仍須完成部署與 service-user auth readiness，不得直接啟用 canary。
+
 ### 7. MCP 組裝沿用主系統安全上下文
 
 Codex provider 必須使用與 Claude 相同的 session workdir、enabled extends、required server filtering 與環境注入來源。

--- a/openspec/changes/add-codex-acp-failover/design.md
+++ b/openspec/changes/add-codex-acp-failover/design.md
@@ -1,0 +1,289 @@
+## Context
+
+目前所有核心 AI 工作都透過 `services/claude_agent.py::call_claude()`。這個函式不只是 provider client，也包含 session 隔離、MCP server 組裝、工具權限、使用者身份、進度 callback、token、partial result 與 cleanup。
+
+`ctos-lite` 的 provider factory 證明 Codex ACP 基本呼叫可行，但它的 Python Generic ACP client 只建立 stdio MCP，permission identity 也比主系統需求寬鬆。主系統還包含 Line、Telegram、Web、restricted mode、排程、簡報、研究與摘要等不同輸出契約。
+
+本設計採「新增旁路、逐入口遷移」而非「替換全域函式」。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Claude 用量達 90% 時，將尚未開始的新請求安全地路由至 Codex。
+- 保持現有 Claude caller 與 `ClaudeResponse` 行為相容。
+- Codex provider 遵守現有 MCP、權限、身份、callback、timeout 與 partial result 契約。
+- 以測試、feature flag、canary、監控和 kill switch 控制導入風險。
+- 每次請求可追查 provider、實際模型與路由原因。
+
+**Non-Goals:**
+
+- 不要求兩個模型輸出品質一對一相同。
+- 不重放已經開始工具執行的請求。
+- 不在第一階段遷移所有背景或結構化輸出 pipeline。
+- 不同時執行雙 provider 做 agentic shadow comparison。
+- 不在第一階段建立前端 provider 管理 UI。
+
+## Decisions
+
+### 1. 保留 `call_claude()`，新增 `call_ai()`
+
+**選擇**：`call_claude()` 繼續代表純 Claude provider；新增 provider-neutral `call_ai()`，caller 必須明確遷移。
+
+**理由**：
+
+- 避免 feature code 一合併就改變至少 11 個模組的語意。
+- 可讓未完成 parity 驗證的簡報、研究、排程等路徑繼續固定 Claude。
+- 測試與 canary 可按 context/Agent 分批進行。
+- kill switch 不需要回滾所有 caller import。
+
+**不選**：直接將 `call_claude()` 內部改成 router。這會造成一次性 blast radius，且難以判斷哪個入口已完成 Codex parity。
+
+### 2. Provider 契約保持 keyword-compatible
+
+`call_ai()` 第一階段接受與 `call_claude()` 相同的參數，另加選填 routing context：
+
+- `prompt`
+- `model`
+- `history`
+- `system_prompt`
+- `timeout`
+- `tools`
+- `tool_call_limits`
+- `on_tool_start` / `on_tool_end`
+- `required_mcp_servers`
+- `ctos_user_id`
+- `extra_mcp_env`
+- `routing_context`（新，供 canary/觀測，不交給模型）
+
+回應沿用相容 dataclass，新增有預設值的 metadata：
+
+- `provider`
+- `actual_model`
+- `route_reason`
+- `provider_started`
+- `usage_snapshot`
+
+既有 caller 不讀取新欄位時不受影響。
+
+**Phase 2 checkpoint（2026-08-04）**：已新增共用 `AIResponse`/`AIProvider`，並以 alias 保留 `ClaudeResponse`/`ToolCall`。`call_ai()` 已建立但固定委派 Claude，`routing_context` 不傳入 provider。provider mode 已驗證 `claude`/`codex`/`auto`，並以 context/Agent exact-match 限制 canary；因 usage 與 Codex provider 尚未實作，三種 mode 都安全回到 Claude。`ProviderRouter` 只允許 readiness 尚未進入 `provider.call()` 前改選明確 fallback；一旦進入 call，不論回應標記、失敗或 exception 都不跨 provider 重送。fake provider tests 已覆蓋 readiness false/error/missing、fallback unavailable 與 sticky boundary；預設 registry 仍只有 Claude，尚無既有 caller 使用此旁路。
+
+### 3. Provider 在執行前選定並保持 sticky
+
+router 只在任何 provider subprocess、session 或 tool 尚未開始前做一次選擇。選擇完成後，該請求直到成功、timeout 或失敗都使用同一 provider。
+
+第一版不提供 provider execution failure retry：
+
+- Claude 已開始後失敗，不送 Codex。
+- Codex 已開始後失敗，不送 Claude。
+- readiness/preflight 在 provider 尚未開始前失敗，才可依設定選擇替代 provider。
+
+這個規則比可用性優先，但能避免重複副作用。
+
+### 4. 路由狀態機使用 90% / 85% hysteresis
+
+狀態：
+
+- `forced_claude`
+- `forced_codex`
+- `auto_claude`
+- `auto_codex`
+- `usage_unknown`
+- `usage_stale`
+- `codex_unready`
+- `circuit_open`
+
+自動模式規則：
+
+1. 預設設定是 forced Claude；只有明確開啟 auto 才讀 usage 決策。
+2. fresh utilization `>= 0.90`：切到 Codex。
+3. 已在 Codex 狀態時，fresh utilization 必須 `< 0.85` 才切回 Claude。
+4. fresh utilization 位於 85%–90%：維持上一個穩定 provider。
+5. 啟動時 usage unknown：使用 Claude 並告警，保持既有行為。
+6. 短時間 stale：在設定的 max-stale 內維持上一個穩定 provider。
+7. 超過 max-stale：使用 Claude 並告警。
+8. Codex preflight unready 且尚未開始請求：依 `codex_unavailable_policy`，預設回到 Claude 並記錄 critical route reason。
+
+所有 threshold 與 TTL 都要做範圍驗證，非法設定不得靜默進 auto。
+
+Phase 0 固定的初始營運預設如下：
+
+- usage refresh TTL：60 秒。
+- usage max-stale：300 秒。
+- Codex preflight unavailable：回到 Claude，並記錄 critical route reason。
+- 首批 canary：僅 internal admin/test-agent，且只允許純文字與唯讀工具。
+- 首批 canary 禁止：建立、修改或刪除知識庫/圖書館資料，檔案寫入、移動或刪除，外部訊息發送，ERP 寫入，shell/terminal，以及圖片生成或編輯。
+
+這些值先作為可由環境設定覆寫的安全預設；任何覆寫都必須通過設定範圍驗證。正式擴大流量前可依 canary 數據另提調整，但不得在未留紀錄下改變。
+
+### 5. Usage monitor 使用週期刷新與 single-flight
+
+usage monitor 由 FastAPI lifespan 啟動與關閉：
+
+- 啟動時以短 timeout 嘗試一次 refresh，不阻止服務啟動。
+- 背景 task 依固定 interval 更新。
+- stale request 可觸發 single-flight refresh，但同時間只有一個 HTTP request。
+- cache 同時保存 utilization、5h、7d、fetched_at、last_attempt_at、last_error 與 consecutive_failures。
+- credentials、token、完整 response body 不得進 log。
+
+router 只讀記憶體 snapshot，不在使用者 request critical path 等待遠端 usage API。
+
+### 6. Codex adapter 先走 ACP compatibility spike
+
+第一候選為 pin 版 `@agentclientprotocol/codex-acp` stdio adapter，因為 `ctos-lite` 已驗證基本可行，且 adapter 會轉接 Codex App Server。
+
+spike 必須先證明：
+
+- repeated text delta 不遺失。
+- tool start/progress/end 可可靠去重。
+- stdio 與 HTTP MCP 都能建立。
+- permission request 能取得完整、唯一的 tool identity。
+- token、actual model、partial text 與 cancel 可取得。
+- subprocess 可完全清理。
+
+如果完整 tool identity、HTTP MCP 或事件契約無法安全實作，停止 ACP adapter 擴張，改比較直接使用官方 `codex app-server` stdio。不能以模糊 permission 或停用 HTTP 工具作為正式解法。
+
+### 7. MCP 組裝沿用主系統安全上下文
+
+Codex provider 必須使用與 Claude 相同的 session workdir、enabled extends、required server filtering 與環境注入來源。
+
+不得另外掃描全域 MCP 或讓 Codex 自行載入未經過主系統過濾的工具。
+
+HTTP MCP 必須保留 URL 與 headers；stdio MCP 必須保留 command、args 與 env。敏感 header/env 不得寫入一般 log。
+
+### 8. Permission 採 canonical identity，模糊時拒絕
+
+允許判斷順序：
+
+1. 從 ACP 結構化 metadata 取得 server/tool canonical identity。
+2. 若 adapter 只提供 display title，必須透過實際 event fixture 建立無歧義 mapping。
+3. `Unknown` 只有在同一時間恰有一個 active tool，且 active tool 已有 canonical identity 時才可歸因。
+4. 同名、多個 active tool、缺少 namespace 或格式未知全部拒絕。
+
+terminal、shell、file-write 與 Codex native image generation 預設拒絕；圖片需求必須使用主系統允許的 MCP 工具與既有檔案傳送路徑。
+
+tool-call limit 在 permission 核准前計數，provider 不能繞過 nanobanana/codex-image 全域上限。
+
+### 9. Codex subprocess 受 concurrency 與 circuit breaker 控制
+
+- 使用可設定 semaphore 限制同時 Codex session。
+- queue wait 有獨立 timeout，不消耗完整 AI timeout。
+- adapter 啟動、auth、protocol、MCP startup、provider overload 分類記錄。
+- 連續 readiness/啟動失敗達門檻後開啟短時間 circuit。
+- circuit open 時不再重複 spawn；provider 尚未開始，因此可依 preflight policy 選 Claude 或受控失敗。
+- stderr 僅保存 bounded tail，並清理 credential-like 字串。
+
+### 10. Adapter 與 Codex runtime 必須 pin
+
+不依賴部署機手動全域 npm 安裝：
+
+- 將選定 adapter 以 exact version 納入 repo lock，或提供同等可重現的安裝 artifact。
+- 明確設定實際執行的 binary path。
+- preflight 驗證 binary、version、auth、headless 環境與最小 session handshake。
+- systemd 使用 `ct` 使用者的明確 Codex auth storage，不讀 root credentials。
+- `NO_BROWSER=1`，服務中不得啟動互動 login。
+
+### 11. 第一階段不新增 `ai_logs` provider 欄位
+
+為降低分區表 migration 風險，先將 routing metadata 寫入：
+
+- structured service log。
+- response metadata。
+- 現有 `parsed_response` JSON。
+
+`model` 欄位是否改記 actual model，需先確認既有 AI 管理統計與前端篩選不會退化。若 canary 需要 provider index/query，再提出獨立 migration。
+
+### 12. 按入口逐步遷移
+
+建議順序：
+
+1. internal admin/test-agent，限定無副作用工具。
+2. Web Chat canary Agent。
+3. allowlist Line/Telegram 使用者或群組。
+4. 一般 Line/Telegram 對話。
+5. restricted mode。
+6. 簡報、research、scheduler、summary 等特殊 pipeline，逐一通過格式或工具 parity 後才遷移。
+
+任何階段都能把 router mode 改回 forced Claude。未列入 allowlist 的 caller 保持呼叫 `call_claude()`。
+
+## Test Strategy
+
+### Characterization tests
+
+在重構共用型別或 helper 前，先鎖住現有 Claude：
+
+- 完整參數傳遞。
+- MCP server filtering 與 env injection。
+- permission/tool-call limit。
+- callback success/failure isolation。
+- token/tool timings。
+- timeout partial result。
+- cleanup。
+
+### Contract tests
+
+用同一組 provider contract tests 驗證 Claude 與 Codex fake client：
+
+- success、empty response、provider exception、timeout、cancel。
+- repeated chunks。
+- tool progress 去重。
+- partial text/tool output。
+- actual model/token metadata。
+
+### Router/usage tests
+
+- forced/auto/provider allowlist。
+- 0%、89.9%、90%、90.1%、85%、84.9%。
+- unknown/fresh/stale/error。
+- 1.0 與 100.0 格式。
+- malformed/out-of-range payload。
+- 401、429、5xx、timeout、missing credentials。
+- concurrent refresh single-flight。
+- circuit open/half-open/close。
+- provider sticky 與 no cross-provider replay。
+
+### Security tests
+
+- stdio/HTTP MCP parity。
+- required server 與 disabled extends。
+- canonical identity、同名工具、Unknown、concurrent tools。
+- terminal/file-write/native image deny。
+- `ctos_user_id` 與 Agent scope 無法由 LLM 覆寫。
+- tool-call limit across aliases/events。
+
+### Integration and smoke tests
+
+- admin test-agent、Web、Line、Telegram、restricted mode。
+- 圖片/語音 marker 與工具結果解析。
+- 簡報 JSON、research WebSearch/WebFetch、scheduler side effect 等特殊契約。
+- 真實 ACP 只使用唯讀 MCP fixture。
+- systemd service user preflight。
+- bounded concurrency、timeout、zombie process 與 memory soak。
+
+## Rollback Strategy
+
+1. 將 router mode 設為 forced Claude。
+2. 清空 canary allowlist。
+3. 停止 usage monitor 與 Codex readiness task，不影響純 Claude caller。
+4. 若 adapter 造成 subprocess 問題，停用 Codex provider，不需回滾資料庫。
+5. 保留 routing/error logs 供事後分析。
+
+## Risks / Trade-offs
+
+**[用量 endpoint 變動]** → usage monitor 狀態轉 error，不得把缺值當 0；超過 max stale 後回到 Claude 並告警。
+
+**[Codex 與 Claude 工具選擇不同]** → 不宣稱等價；以入口 contract 與 canary 驗證，不一次遷移特殊 pipeline。
+
+**[Codex adapter 事件格式升級]** → pin exact version、保存 protocol fixtures、preflight handshake；升版視為相容性變更。
+
+**[Claude 已接近額度但 Codex 不可用]** → 預設選擇維持 Claude 可用性並發 critical alert；營運方可改為 fail closed。此政策必須在正式啟用前確認。
+
+**[90% 附近切換震盪]** → 使用 90%/85% hysteresis 和 stable provider state。
+
+**[測試全綠仍與真實 adapter 不同]** → 真實唯讀 smoke 與 canary 是獨立 gate，不能用 mock test 取代。
+
+## Open Questions Before Production Auto Mode
+
+- 需要將 provider 正式新增到 `ai_logs` schema，還是 `parsed_response` 足夠？
+- ACP compatibility spike 是否能提供可靠的 HTTP MCP 與 canonical tool identity？
+- canary 完成後，threshold/TTL 是否需要由環境設定遷移到資料庫設定管理？

--- a/openspec/changes/add-codex-acp-failover/design.md
+++ b/openspec/changes/add-codex-acp-failover/design.md
@@ -145,6 +145,8 @@ spike 必須先證明：
 
 如果完整 tool identity、HTTP MCP 或事件契約無法安全實作，停止 ACP adapter 擴張，改比較直接使用官方 `codex app-server` stdio。不能以模糊 permission 或停用 HTTP 工具作為正式解法。
 
+**Phase 4 checkpoint（2026-08-04）— Go**：正式 protocol 選定 pin 版 `@agentclientprotocol/codex-acp` 1.1.9 + `@openai/codex` 0.146.0 + Python ACP 0.8.0。上游 adapter 本身由 App Server 轉接並支援 stdio/HTTP MCP；缺口位於 `claude-code-acp` Generic client 只轉 stdio、會以 substring 移除合法重複文字，並在 permission callback 遺失 active tool identity。`services/codex_acp.py` compatibility layer 已以 exact schema 補齊 HTTP headers、ordered delta、terminal progress 去重與 tool-call-id identity correlation。真實 read-only smoke 已通過文字、重複文字、stdio 工具、HTTP handshake、canonical permission identity、timeout/cancel 與 process cleanup，因此不需改走直接 App Server；若 pin 組合日後回歸，直接 App Server 仍是保留方案。
+
 ### 7. MCP 組裝沿用主系統安全上下文
 
 Codex provider 必須使用與 Claude 相同的 session workdir、enabled extends、required server filtering 與環境注入來源。

--- a/openspec/changes/add-codex-acp-failover/design.md
+++ b/openspec/changes/add-codex-acp-failover/design.md
@@ -128,6 +128,8 @@ usage monitor 由 FastAPI lifespan 啟動與關閉：
 
 router 只讀記憶體 snapshot，不在使用者 request critical path 等待遠端 usage API。
 
+**Phase 3 checkpoint（2026-08-04）**：已完成 `UsageSnapshot` 的 unknown/fresh/stale/error 狀態、5h/7d payload 正規化、single-flight refresh、TTL/max-stale、週期 task 與 90%/85% hysteresis。只有 `AI_PROVIDER_MODE=auto` 會在 FastAPI lifespan 啟動 monitor；預設 Claude 不讀 credentials。HTTP/credentials 的錯誤只保留安全 category，不記 token、完整 response body 或原始 network exception。Codex provider 尚未註冊，因此 auto 決策即使選到 Codex也只會在 pre-start readiness 階段安全回到 Claude。
+
 ### 6. Codex adapter 先走 ACP compatibility spike
 
 第一候選為 pin 版 `@agentclientprotocol/codex-acp` stdio adapter，因為 `ctos-lite` 已驗證基本可行，且 adapter 會轉接 Codex App Server。

--- a/openspec/changes/add-codex-acp-failover/proposal.md
+++ b/openspec/changes/add-codex-acp-failover/proposal.md
@@ -1,0 +1,96 @@
+## Why
+
+`ching-tech-os` 的主要 AI 推論目前依賴 Claude Code OAuth 用量。當 5 小時或 7 天用量接近上限時，所有 Line、Telegram、Web 與背景 Agent 功能都可能同時失去服務能力。
+
+姐妹專案 `ctos-lite` 已加入 Codex ACP provider，可在 Claude 用量達 90% 時將新請求切至 Codex。但主系統的 AI 呼叫同時承擔動態 MCP、工具權限、身份注入、進度通知、partial result 與多入口工作流程，直接移植會有重複副作用、HTTP MCP 遺失及權限退化風險。
+
+需要先建立 provider-neutral 契約與測試，再以 feature flag、canary 與 kill switch 逐入口導入 Codex 備援。
+
+完整風險與測試基線見 `docs/codex-acp-failover-evaluation.md`。
+
+## What Changes
+
+### 1. Provider-neutral AI 契約
+
+- 保留現有 `call_claude()` 為純 Claude provider。
+- 新增 `call_ai()` router，只有明確遷移的 caller 才使用多 provider 路由。
+- 統一回應 metadata：provider、實際模型、route reason、token、tool calls、tool timings 與 partial result。
+- 以 characterization tests 保護現有 Claude 行為。
+
+### 2. Claude 用量狀態服務
+
+- 讀取 Claude OAuth 的 5 小時與 7 天 utilization，取最高值。
+- 使用週期背景刷新與 single-flight lock，不在每個 request 無限制建立 refresh task。
+- 區分 unknown、fresh、stale、error 狀態。
+- 預設 90% 切到 Codex，低於 85% 才切回 Claude。
+- usage 過舊或無法取得時保留既有 Claude 行為並告警。
+
+### 3. Codex provider adapter
+
+- 透過經驗證且 pin 版的 `codex-acp` stdio adapter 呼叫 Codex。
+- 若 architecture spike 證明 ACP 無法滿足完整契約，改評估直接使用官方 Codex App Server stdio。
+- 支援 stdio/HTTP MCP、完整工具 identity、tool-call limit、身份環境變數、callbacks、partial result、timeout 與 cleanup。
+- 限制 terminal/file-write，任何模糊 permission fail closed。
+- 加入 subprocess concurrency limit、queue timeout、readiness 與 circuit breaker。
+
+### 4. 安全路由規則
+
+- provider 在請求開始前選定，同一請求中不得切換。
+- 第一版不實作 Claude 執行失敗後的跨 provider retry。
+- Codex preflight 尚未開始執行就失敗時，依明確設定選擇 Claude 或受控失敗。
+- Codex 已開始執行後失敗，不得將相同請求重送 Claude。
+- 自動模式預設關閉，提供固定 Claude kill switch 與 context/Agent canary allowlist。
+
+### 5. 可觀測性與逐步導入
+
+- 記錄 selected provider、actual model、route reason、usage freshness、error category 與 tool execution state。
+- 先使用 structured log 與 `ai_logs.parsed_response`，第一階段不要求資料庫 schema 變更。
+- 依 internal test、Web canary、Bot canary、一般 Bot、特殊 pipeline 的順序遷移。
+
+## Capabilities
+
+### New Capabilities
+
+- `ai-provider-routing`: 依 Claude 用量、readiness、feature flag 與 canary scope 安全選擇 Claude 或 Codex provider。
+- `codex-acp-provider`: 符合主系統安全與事件契約的 Codex provider adapter。
+- `claude-usage-monitor`: 具 freshness、single-flight、hysteresis 與錯誤狀態的 Claude OAuth 用量監控。
+
+### Modified Capabilities
+
+- `ai-management`: AI log 可辨識實際 provider、模型與路由原因。
+- `line-bot`: 經 canary 驗證後，可選擇使用 provider router，現有訊息、圖片、語音與工具結果行為不變。
+- `bot-platform`: Telegram/restricted mode 經獨立驗證後逐步支援 provider router。
+
+## Impact
+
+- **新增後端模組（預估）**：
+  - provider-neutral contract/router
+  - Claude usage monitor
+  - Codex adapter
+- **可能修改**：
+  - `config.py`、`main.py` lifespan
+  - `claude_agent.py`（只抽共用型別或補 metadata，不改既有純 Claude 語意）
+  - 明確納入 canary 的 AI caller
+  - AI log 組裝與部署 preflight
+  - root npm runtime dependency/lock
+- **測試**：新增 provider contract、usage state machine、permission、MCP parity、入口 integration、deployment/load 測試。
+- **資料庫**：第一階段不新增欄位；若 canary 後需要高效率 provider 查詢，再另提 Alembic migration。
+- **部署**：需要 pin Codex adapter、確認 systemd 使用者 auth storage，並新增 preflight。
+
+## Constraints
+
+- 不得降低現有工具白名單、身份注入或單回合工具限制。
+- 不得將已開始執行的請求跨 provider 重送。
+- 不得一次切換所有 `call_claude()` caller。
+- 自動模式預設關閉，沒有 kill switch 不得進 canary。
+- 未通過 stdio/HTTP MCP 與真實唯讀 smoke，不得承接正式工具請求。
+- 所有新程式碼及整體測試 coverage 必須符合 90% gate；安全分支需明確測試。
+
+## Out of Scope
+
+- 同一對話中的跨 provider 原生 session 接續。
+- provider 執行失敗後自動重放有副作用的請求。
+- 以 shadow mode 同時執行 Claude 與 Codex agentic tools。
+- 第一階段新增 AI provider 管理前端。
+- 第一階段修改分區 `ai_logs` schema。
+- 宣稱 Claude 與 Codex 的模型品質、工具選擇或生成格式完全等價。

--- a/openspec/changes/add-codex-acp-failover/specs/ai-provider-routing/spec.md
+++ b/openspec/changes/add-codex-acp-failover/specs/ai-provider-routing/spec.md
@@ -1,0 +1,325 @@
+## ADDED Requirements
+
+### Requirement: 現有 Claude 呼叫保持向下相容
+
+系統 MUST 保留純 Claude provider 的 `call_claude()` 行為。新增多 provider 路由時，未明確遷移至 `call_ai()` 的 caller MUST 繼續固定使用 Claude，且參數、回應、工具權限、partial result 與 cleanup 行為不得改變。
+
+#### Scenario: Feature flag 關閉
+
+- **GIVEN** AI provider auto mode 未啟用
+- **WHEN** 任一既有 caller 呼叫 `call_claude()`
+- **THEN** 系統只使用 Claude provider
+- **AND** 不啟動 Codex subprocess
+
+#### Scenario: 未遷移的特殊 pipeline
+
+- **GIVEN** 簡報、研究或排程 pipeline 尚未完成 Codex parity 驗證
+- **WHEN** pipeline 執行 AI 呼叫
+- **THEN** pipeline MUST 維持使用 `call_claude()`
+
+### Requirement: Provider 在請求執行前選定並保持不變
+
+系統 MUST 在建立 provider session 或執行任何工具之前選定 provider。選定後，同一請求 MUST 保持使用該 provider，直到成功、timeout、取消或失敗。
+
+#### Scenario: Claude 執行後失敗
+
+- **GIVEN** router 已選定 Claude
+- **AND** Claude session 已開始執行
+- **WHEN** Claude timeout 或回傳失敗
+- **THEN** 系統 MUST 回傳 Claude 的失敗與 partial result
+- **AND** MUST NOT 將相同請求重送 Codex
+
+#### Scenario: Codex 執行後失敗
+
+- **GIVEN** router 已選定 Codex
+- **AND** Codex session 已開始執行
+- **WHEN** Codex timeout 或回傳失敗
+- **THEN** 系統 MUST 回傳 Codex 的失敗與 partial result
+- **AND** MUST NOT 將相同請求重送 Claude
+
+#### Scenario: Codex preflight 在執行前失敗
+
+- **GIVEN** auto router 原本要選 Codex
+- **AND** Codex readiness 在 session 建立前失敗
+- **WHEN** unavailable policy 設為 Claude
+- **THEN** 系統 MAY 在任何工具尚未開始前選擇 Claude
+- **AND** MUST 記錄 `codex_unready` route reason
+
+### Requirement: Claude 用量達 90% 時選擇 Codex
+
+在 auto mode 與 canary scope 內，系統 SHALL 以 Claude 5 小時與 7 天 utilization 的最高值作為 routing utilization。fresh utilization 大於或等於 90% 時，尚未開始的新請求 SHALL 選擇 Codex。
+
+#### Scenario: 用量低於切入門檻
+
+- **GIVEN** fresh routing utilization 為 89.9%
+- **AND** 上一個穩定 provider 為 Claude
+- **WHEN** 新請求進入 router
+- **THEN** 系統選擇 Claude
+
+#### Scenario: 用量等於切入門檻
+
+- **GIVEN** fresh routing utilization 為 90.0%
+- **WHEN** 新請求進入 router
+- **THEN** 系統選擇 Codex
+
+#### Scenario: 取 5 小時與 7 天最大值
+
+- **GIVEN** 5 小時 utilization 為 40%
+- **AND** 7 天 utilization 為 92%
+- **WHEN** usage monitor 建立 snapshot
+- **THEN** routing utilization MUST 為 92%
+
+### Requirement: Provider 切換具有 hysteresis
+
+系統 SHALL 使用不同的切入與切回門檻避免 90% 附近反覆切換。預設切入 Codex 門檻為 90%，切回 Claude 門檻為 85%。
+
+#### Scenario: 已在 Codex 且用量位於遲滯區間
+
+- **GIVEN** 上一個穩定 provider 為 Codex
+- **AND** fresh utilization 為 87%
+- **WHEN** 新請求進入 router
+- **THEN** 系統維持 Codex
+
+#### Scenario: 用量低於切回門檻
+
+- **GIVEN** 上一個穩定 provider 為 Codex
+- **AND** fresh utilization 為 84.9%
+- **WHEN** 新請求進入 router
+- **THEN** 系統切回 Claude
+
+### Requirement: Usage 狀態不得將未知值當成 0
+
+usage monitor MUST 區分 unknown、fresh、stale 與 error。系統 MUST NOT 因缺少 credentials、API 失敗或尚未完成首次 refresh 而將 utilization 記為已知的 0%。
+
+#### Scenario: 服務啟動時尚無 snapshot
+
+- **GIVEN** usage monitor 尚未完成首次 refresh
+- **WHEN** auto router 收到新請求
+- **THEN** 系統使用 Claude 以保持現行行為
+- **AND** 記錄 `usage_unknown`
+
+#### Scenario: 短時間 stale
+
+- **GIVEN** snapshot 已超過 refresh TTL
+- **AND** 尚未超過 max-stale
+- **WHEN** 新請求進入 router
+- **THEN** 系統維持上一個穩定 provider
+- **AND** snapshot MUST 標記為 stale
+
+#### Scenario: 超過 max-stale
+
+- **GIVEN** snapshot 已超過 max-stale
+- **WHEN** 新請求進入 router
+- **THEN** 系統使用 Claude
+- **AND** 發出可觀測告警
+
+#### Scenario: Usage payload 格式錯誤
+
+- **WHEN** usage endpoint 回傳缺少欄位、非數字或超出合法範圍的 utilization
+- **THEN** monitor MUST 將該次 refresh 標記為 error
+- **AND** MUST NOT 覆蓋最後一筆有效 snapshot
+
+### Requirement: Usage refresh 為 single-flight 且不阻塞使用者請求
+
+usage monitor SHALL 使用背景週期刷新與 single-flight lock。初始 refresh TTL SHALL 為 60 秒，max-stale SHALL 為 300 秒。router 讀取記憶體 snapshot 時 MUST NOT 等待遠端 usage API。
+
+#### Scenario: 多個請求同時發現 cache stale
+
+- **GIVEN** cache 已 stale
+- **WHEN** 多個 request 同時觸發 refresh
+- **THEN** 系統最多只執行一個遠端 usage request
+
+#### Scenario: Usage endpoint timeout
+
+- **WHEN** usage endpoint 超過設定 timeout
+- **THEN** 使用者 AI request MUST 依現有 snapshot 繼續路由
+- **AND** monitor MUST 記錄 refresh error 與 failure count
+
+#### Scenario: Snapshot 超過初始 max-stale
+
+- **GIVEN** 最後有效 snapshot 已超過 300 秒
+- **WHEN** 新請求進入 router
+- **THEN** 系統使用 Claude
+- **AND** 發出可觀測告警
+
+### Requirement: Auto mode 預設關閉並支援 canary
+
+系統 SHALL 預設固定使用 Claude。只有明確啟用 auto mode 且 routing context 符合 canary allowlist 的請求，才可依 usage 切至 Codex。第一批 canary SHALL 僅限 internal admin/test-agent，且只允許純文字與唯讀工具。
+
+#### Scenario: Auto mode 未啟用
+
+- **GIVEN** provider mode 為 Claude
+- **WHEN** utilization 超過 90%
+- **THEN** 系統仍選擇 Claude
+
+#### Scenario: 不在 canary scope
+
+- **GIVEN** provider mode 為 auto
+- **AND** utilization 超過 90%
+- **AND** request context 不在 canary allowlist
+- **WHEN** 新請求進入 router
+- **THEN** 系統選擇 Claude
+
+#### Scenario: Kill switch
+
+- **GIVEN** auto mode 已有 canary 流量
+- **WHEN** operator 將 provider mode 改為 Claude 並重新載入生效設定
+- **THEN** 所有後續新請求 MUST 停止選擇 Codex
+
+#### Scenario: 首批 canary 要求副作用工具
+
+- **GIVEN** request context 屬於第一批 internal admin/test-agent canary
+- **WHEN** 請求要求資料建立、修改或刪除、檔案寫入、外部訊息發送、ERP 寫入、shell/terminal 或圖片生成編輯
+- **THEN** 系統 MUST NOT 將該副作用工具暴露給 Codex
+
+### Requirement: Codex provider 必須符合共用回應契約
+
+Codex provider SHALL 回傳與現有 Claude caller 相容的成功狀態、文字、錯誤、tool calls、input/output tokens 與 tool timings，並附加 provider、actual model、route reason 與 provider started metadata。
+
+#### Scenario: Codex 正常完成
+
+- **WHEN** Codex 完成文字與工具呼叫
+- **THEN** response MUST 包含完整文字與去重後的 tool calls
+- **AND** provider MUST 為 Codex
+- **AND** 可取得時 MUST 記錄 actual model 與 token usage
+
+#### Scenario: 重複文字 chunk
+
+- **WHEN** Codex 依序送出內容相同的兩個合法 delta
+- **THEN** 系統 MUST 保留兩個 delta 的順序與內容
+- **AND** MUST NOT 以 substring 去重而遺失文字
+
+#### Scenario: Codex timeout
+
+- **WHEN** Codex 超過 request timeout
+- **THEN** 系統 MUST cancel session 並清理 subprocess
+- **AND** response MUST 保留已收到的 partial text 與 completed tool calls
+
+### Requirement: Codex provider 支援 stdio 與 HTTP MCP
+
+Codex provider MUST 保留主系統過濾後的 MCP server 類型與設定。stdio server MUST 保留 command、args、env；HTTP server MUST 保留 URL 與 headers。
+
+#### Scenario: 載入 stdio MCP
+
+- **WHEN** required MCP 包含 stdio server
+- **THEN** Codex session MUST 以原 command、args 與 env 建立該 server
+
+#### Scenario: 載入 HTTP MCP
+
+- **WHEN** required MCP 包含 HTTP server
+- **THEN** Codex session MUST 以原 URL 與 headers 建立該 server
+- **AND** MUST NOT 將它轉成空 command 的 stdio server
+
+#### Scenario: MCP 未在 required set
+
+- **WHEN** MCP server 不在該 Agent 的 required set
+- **THEN** Codex session MUST NOT 載入該 server
+
+### Requirement: Codex 工具 permission 必須 fail closed
+
+Codex provider MUST 使用 canonical server/tool identity 與完整 allowlist 比對。模糊、衝突、Unknown 或無法唯一歸因的 permission request MUST 被拒絕。
+
+#### Scenario: 完整名稱在 allowlist
+
+- **GIVEN** permission request 可辨識為 `mcp__ching-tech-os__search_knowledge`
+- **AND** 完整名稱在 allowlist
+- **WHEN** Codex 請求使用工具
+- **THEN** permission guard 可核准該工具
+
+#### Scenario: 不同 server 的同名工具
+
+- **GIVEN** allowlist 只允許 server A 的 `search`
+- **WHEN** server B 的 `search` 請求 permission
+- **THEN** permission guard MUST 拒絕
+
+#### Scenario: Unknown 且多個工具執行中
+
+- **GIVEN** permission title 為 Unknown
+- **AND** 同時有多個 active tools
+- **WHEN** permission guard 無法唯一歸因
+- **THEN** permission guard MUST 拒絕
+
+#### Scenario: Terminal 或 file-write
+
+- **WHEN** Codex 請求 terminal、shell command 或直接 file-write
+- **THEN** provider MUST 拒絕
+
+### Requirement: Codex 必須遵守身份注入與工具次數上限
+
+Codex provider MUST 使用 framework 控制的 `ctos_user_id` 與 Agent scope 環境變數，且 MUST 執行與 Claude 相同的單回合工具呼叫限制。
+
+#### Scenario: LLM 偽造使用者身份
+
+- **GIVEN** framework 注入 `ctos_user_id=123`
+- **WHEN** 模型工具輸入嘗試指定其他使用者 ID
+- **THEN** MCP server 接收到的有效身份 MUST 為 framework 指定值
+
+#### Scenario: 工具達到上限
+
+- **GIVEN** 某工具單回合上限為 1
+- **AND** 該工具已核准並執行一次
+- **WHEN** Codex 再次請求相同 canonical tool
+- **THEN** permission guard MUST 拒絕第二次呼叫
+
+### Requirement: Codex subprocess 受到資源與錯誤控制
+
+系統 SHALL 限制同時執行的 Codex sessions，為排隊設定 timeout，並在連續啟動或 readiness 失敗時開啟 circuit breaker。
+
+#### Scenario: 達到 concurrency 上限
+
+- **GIVEN** 所有 Codex session slots 已使用
+- **WHEN** 新請求等待超過 queue timeout
+- **THEN** provider MUST 回傳可分類的 queue timeout
+- **AND** MUST NOT 無限制建立新 subprocess
+
+#### Scenario: Circuit open
+
+- **GIVEN** Codex 連續失敗達 circuit threshold
+- **WHEN** 新請求原本要選 Codex
+- **THEN** 系統 MUST NOT 啟動新的 Codex subprocess
+- **AND** router MUST 依 unavailable policy 處理
+
+#### Scenario: Process cleanup
+
+- **WHEN** Codex 成功、失敗、timeout 或被取消
+- **THEN** stdin/stdout transport 與 subprocess MUST 被關閉
+- **AND** session workdir MUST 被清理
+
+### Requirement: Provider 路由必須可觀測且不洩漏秘密
+
+每個經過 `call_ai()` 的請求 SHALL 記錄 selected provider、actual model、route reason、usage freshness、latency、error category 與 tool execution state。記錄 MUST NOT 包含 OAuth token、Codex auth、MCP secret headers 或敏感 env values。
+
+#### Scenario: 自動切至 Codex
+
+- **WHEN** utilization 達 90% 且請求選擇 Codex
+- **THEN** structured log 與 AI log metadata MUST 能辨識 provider、actual model 與 usage threshold route reason
+
+#### Scenario: Usage refresh 失敗
+
+- **WHEN** usage endpoint 回傳含敏感內容的錯誤
+- **THEN** log MUST 只保存分類後的 error code/message
+- **AND** MUST NOT 保存 Authorization header、access token 或完整 response body
+
+### Requirement: 正式啟用前必須通過分階段 gate
+
+系統 SHALL 在 mock/unit tests、真實唯讀 smoke、入口 canary、部署/load 測試與 rollback 演練完成後，才可逐步擴大 auto mode scope。
+
+#### Scenario: 僅單元測試完成
+
+- **GIVEN** provider/router 單元測試已通過
+- **AND** 真實 ACP smoke 尚未通過
+- **WHEN** 準備部署
+- **THEN** Codex auto routing MUST 保持關閉
+
+#### Scenario: Canary 發現重複副作用
+
+- **WHEN** canary 發現任何工具操作被跨 provider 重複執行
+- **THEN** rollout MUST 立即停止
+- **AND** kill switch MUST 將後續請求切回 Claude
+
+#### Scenario: Canary gate 全數通過
+
+- **GIVEN** 完整測試、唯讀 smoke、systemd preflight、load test、監控與 rollback 演練皆通過
+- **AND** canary 觀察期無安全退化
+- **WHEN** operator 核准下一 rollout stage
+- **THEN** 系統 MAY 擴大明確指定的 context scope

--- a/openspec/changes/add-codex-acp-failover/tasks.md
+++ b/openspec/changes/add-codex-acp-failover/tasks.md
@@ -26,13 +26,13 @@
 
 ## 3. Claude Usage Monitor（TDD）
 
-- [ ] 3.1 先新增 usage payload tests：5h/7d max、0–1/0–100 格式、malformed、out-of-range
-- [ ] 3.2 新增 unknown/fresh/stale/error snapshot model，保存 fetched time、last error 與 failure count
-- [ ] 3.3 實作 credentials/HTTP 讀取，確保 token、credentials 與完整錯誤 body 不進 log
-- [ ] 3.4 實作 single-flight refresh lock、TTL、max-stale 與週期 background task
-- [ ] 3.5 在 FastAPI lifespan 啟動/關閉 monitor；初次 refresh 有短 timeout 且不阻止服務啟動
-- [ ] 3.6 先新增並通過 90%/85% hysteresis、unknown/stale 與 concurrency tests
-- [ ] 3.7 新增 401、429、5xx、network timeout、missing credentials 與 cache recovery tests
+- [x] 3.1 先新增 usage payload tests：5h/7d max、0–1/0–100 格式、malformed、out-of-range
+- [x] 3.2 新增 unknown/fresh/stale/error snapshot model，保存 fetched time、last error 與 failure count
+- [x] 3.3 實作 credentials/HTTP 讀取，確保 token、credentials 與完整錯誤 body 不進 log
+- [x] 3.4 實作 single-flight refresh lock、TTL、max-stale 與週期 background task
+- [x] 3.5 在 FastAPI lifespan 啟動/關閉 monitor；初次 refresh 有短 timeout 且不阻止服務啟動
+- [x] 3.6 先新增並通過 90%/85% hysteresis、unknown/stale 與 concurrency tests
+- [x] 3.7 新增 401、429、5xx、network timeout、missing credentials 與 cache recovery tests
 
 ## 4. Codex Protocol Compatibility Spike
 

--- a/openspec/changes/add-codex-acp-failover/tasks.md
+++ b/openspec/changes/add-codex-acp-failover/tasks.md
@@ -1,0 +1,102 @@
+## 0. 決策與基線 Gate
+
+- [x] 0.1 確認並記錄初始路由政策：切入 90%、切回 85%、refresh TTL 60 秒、max-stale 300 秒、Codex unavailable 時回到 Claude
+- [x] 0.2 固定第一批 canary 為 internal admin/test-agent，僅允許純文字與唯讀工具，並記錄禁止的副作用能力
+- [x] 0.3 對齊本機與 GitHub Actions 的現況防退步 gate 為 85%，新增 86% next 與 canary 前必達的 90% target gate
+- [x] 0.4 保存實作前基線：1269 passed、10 skipped、coverage 85.50%、`claude_agent.py` 82%，並盤點目前 AI 入口與 MCP server
+- [x] 0.5 確認本 change 的 proposal、design、spec 與 `docs/codex-acp-failover-evaluation.md`
+
+## 1. 測試先行：鎖住現有 Claude 契約
+
+- [x] 1.1 新增 provider contract test fixtures，定義 request kwargs、response metadata、tool event 與 partial result 的共同契約
+- [x] 1.2 擴充 Claude characterization tests：所有現行參數、history/system prompt、tool callbacks 與 callback error isolation
+- [x] 1.3 擴充 MCP tests：required server filtering、stdio/HTTP config、enabled extends 與敏感 env/header 不進 log
+- [x] 1.4 擴充 permission tests：完整白名單、tool-call limit、nanobanana/codex-image 全域限制、身份注入不可偽造
+- [x] 1.5 擴充 timeout/cancel tests：partial text、completed/pending tool calls、token/timings 與 workdir/client cleanup
+- [x] 1.6 執行完整後端測試並確認 characterization tests 未改變現行行為（1275 passed、10 skipped、coverage 85.70%）
+
+## 2. Provider-neutral 契約與旁路 Router
+
+- [x] 2.1 新增相容的 provider-neutral response/protocol；`ClaudeResponse` 保留向下相容 alias 或介面
+- [x] 2.2 新增 `call_ai()` 旁路，保留 `call_claude()` 為純 Claude，尚未遷移的 caller 不變
+- [x] 2.3 新增 `routing_context` 與 context/Agent canary allowlist，不將 routing metadata 傳入模型
+- [x] 2.4 新增 forced Claude、forced Codex、auto mode 設定驗證；預設 forced Claude（Codex 尚未接入時安全回到 Claude）
+- [x] 2.5 先撰寫並通過 router tests：provider sticky、pre-start fallback、執行後禁止跨 provider retry
+- [x] 2.6 驗證關閉 feature flag 時，所有既有 AI tests 與 log 行為完全相同
+
+## 3. Claude Usage Monitor（TDD）
+
+- [ ] 3.1 先新增 usage payload tests：5h/7d max、0–1/0–100 格式、malformed、out-of-range
+- [ ] 3.2 新增 unknown/fresh/stale/error snapshot model，保存 fetched time、last error 與 failure count
+- [ ] 3.3 實作 credentials/HTTP 讀取，確保 token、credentials 與完整錯誤 body 不進 log
+- [ ] 3.4 實作 single-flight refresh lock、TTL、max-stale 與週期 background task
+- [ ] 3.5 在 FastAPI lifespan 啟動/關閉 monitor；初次 refresh 有短 timeout 且不阻止服務啟動
+- [ ] 3.6 先新增並通過 90%/85% hysteresis、unknown/stale 與 concurrency tests
+- [ ] 3.7 新增 401、429、5xx、network timeout、missing credentials 與 cache recovery tests
+
+## 4. Codex Protocol Compatibility Spike
+
+- [ ] 4.1 Pin 一個 `codex-acp` + Codex runtime 組合，保存 adapter/version/protocol fixture
+- [ ] 4.2 以 fake ACP connection 測試 repeated message chunks、tool progress 去重、token/model metadata 與 cancel
+- [ ] 4.3 建立真實唯讀 smoke fixture：純文字、重複文字、單一唯讀 MCP 工具、timeout/cancel
+- [ ] 4.4 驗證 stdio MCP 能完整傳遞 command/args/env
+- [ ] 4.5 驗證 HTTP MCP 能完整傳遞 URL/headers；若 Generic client 不支援，實作安全 schema conversion 或改走 App Server spike
+- [ ] 4.6 驗證 permission event 可取得 canonical server/tool identity；若只能模糊比對則停止正式 adapter 開發
+- [ ] 4.7 記錄 ACP 與直接 Codex App Server stdio 的差異，確認正式 provider protocol
+
+## 5. Codex Provider Adapter（TDD）
+
+- [ ] 5.1 先新增 Codex provider contract tests，涵蓋完整 `call_ai()` kwargs
+- [ ] 5.2 實作 per-request session workdir，沿用主系統 MCP merge/filter 與 env injection 規則
+- [ ] 5.3 實作 canonical permission guard；同名、Unknown、concurrent 或缺少 namespace 時 fail closed
+- [ ] 5.4 實作 terminal/file-write/native image deny，圖片必須走允許的 CTOS MCP 工具
+- [ ] 5.5 實作 tool-call limit、全域生圖上限、callbacks、tool timings 與 callback error isolation
+- [ ] 5.6 實作 message/tool event 去重、partial result、token、actual model 與 bounded stderr diagnostics
+- [ ] 5.7 實作 timeout cancel、disconnect、process terminate/kill 與所有路徑 cleanup tests
+- [ ] 5.8 實作 concurrency semaphore、queue timeout 與 provider circuit breaker
+- [ ] 5.9 新增 binary missing、auth expired、protocol mismatch、MCP startup failure、overload tests
+- [ ] 5.10 確認 Codex provider 核心安全分支皆有明確測試，不能只依 aggregate coverage
+
+## 6. 部署與 Readiness
+
+- [ ] 6.1 將 adapter/runtime 以 exact version 納入可重現的 package lock 或部署 artifact
+- [ ] 6.2 更新部署 preflight：binary path、version、service user、auth storage、`NO_BROWSER=1`、最小 handshake
+- [ ] 6.3 確認 systemd 使用 `ct` credentials，不依賴 root 或互動 login
+- [ ] 6.4 實作 provider readiness 與 circuit 狀態輸出，錯誤不得包含 token
+- [ ] 6.5 在 staging 驗證服務重啟、登入過期、adapter 缺失與 forced Claude rollback
+
+## 7. 可觀測性
+
+- [ ] 7.1 將 requested role、selected provider、actual model、route reason 與 usage snapshot 加入 response metadata
+- [ ] 7.2 將 routing metadata 寫入 structured log 與 `ai_logs.parsed_response`，保留既有 `model` 統計相容性
+- [ ] 7.3 記錄 provider latency、queue latency、error category、tool started/completed 與 circuit 狀態
+- [ ] 7.4 新增 log tests，確認敏感 credentials、MCP headers/env 與 stderr token 不會被記錄
+- [ ] 7.5 建立 canary 查詢與人工檢查清單；確認無法辨識 provider 的請求視為驗收失敗
+
+## 8. 分階段 Caller 整合
+
+- [ ] 8.1 internal admin/test-agent 改用 `call_ai()`，限制唯讀/無副作用工具，完成第一階段 canary
+- [ ] 8.2 Web Chat allowlist Agent 改用 `call_ai()`，驗證 history、system prompt、tool results 與 AI log
+- [ ] 8.3 Line/Telegram allowlist 使用者或群組 canary，驗證文字、圖片、語音、progress callback 與 partial result
+- [ ] 8.4 驗證任何 provider failure 都不會重複執行 side-effect tool
+- [ ] 8.5 canary 穩定後才評估一般 Line/Telegram 對話啟用 auto mode
+- [ ] 8.6 restricted mode 通過身份、權限與成本測試後獨立遷移
+- [ ] 8.7 簡報 JSON、生圖、research、scheduler、summary 各自新增 parity tests 後才逐一遷移；未完成者維持 Claude
+
+## 9. 驗收與 Rollout Gate
+
+- [ ] 9.1 `uv run pytest` 全數通過，無既有測試回歸
+- [ ] 9.2 `npm run ci:check` 與 `npm run test:backend:cov:target` 通過，整體 coverage 不低於 90%
+- [ ] 9.3 `openspec validate add-codex-acp-failover --strict --no-interactive` 通過
+- [ ] 9.4 真實 ACP 唯讀 smoke matrix 全數通過，stdio/HTTP MCP 無缺漏
+- [ ] 9.5 bounded concurrency/load test 通過，無 zombie process、無無限制記憶體成長
+- [ ] 9.6 演練 forced Claude kill switch、清空 canary、Codex auth 過期與 circuit open
+- [ ] 9.7 canary 連續觀察至少 24–72 小時，無重複副作用、安全退化或不可追查請求
+- [ ] 9.8 記錄 Go/No-Go 結論；只有 Go 才能擴大 auto mode scope
+
+## 10. 文件與版本
+
+- [ ] 10.1 更新 `docs/ai-agent-design.md`、`docs/backend.md` 與 `.env.example`
+- [ ] 10.2 更新 `docs/module-index.md` 加入 provider router、usage monitor 與 Codex adapter
+- [ ] 10.3 更新部署文件，記錄 Codex 認證、pin 版本、preflight、監控與 rollback
+- [ ] 10.4 功能完成後依專案規則確認是否進行 MINOR version bump，並同步三個版本位置

--- a/openspec/changes/add-codex-acp-failover/tasks.md
+++ b/openspec/changes/add-codex-acp-failover/tasks.md
@@ -36,13 +36,13 @@
 
 ## 4. Codex Protocol Compatibility Spike
 
-- [ ] 4.1 Pin 一個 `codex-acp` + Codex runtime 組合，保存 adapter/version/protocol fixture
-- [ ] 4.2 以 fake ACP connection 測試 repeated message chunks、tool progress 去重、token/model metadata 與 cancel
-- [ ] 4.3 建立真實唯讀 smoke fixture：純文字、重複文字、單一唯讀 MCP 工具、timeout/cancel
-- [ ] 4.4 驗證 stdio MCP 能完整傳遞 command/args/env
-- [ ] 4.5 驗證 HTTP MCP 能完整傳遞 URL/headers；若 Generic client 不支援，實作安全 schema conversion 或改走 App Server spike
-- [ ] 4.6 驗證 permission event 可取得 canonical server/tool identity；若只能模糊比對則停止正式 adapter 開發
-- [ ] 4.7 記錄 ACP 與直接 Codex App Server stdio 的差異，確認正式 provider protocol
+- [x] 4.1 Pin 一個 `codex-acp` + Codex runtime 組合，保存 adapter/version/protocol fixture
+- [x] 4.2 以 fake ACP connection 測試 repeated message chunks、tool progress 去重、token/model metadata 與 cancel
+- [x] 4.3 建立真實唯讀 smoke fixture：純文字、重複文字、單一唯讀 MCP 工具、timeout/cancel
+- [x] 4.4 驗證 stdio MCP 能完整傳遞 command/args/env
+- [x] 4.5 驗證 HTTP MCP 能完整傳遞 URL/headers；若 Generic client 不支援，實作安全 schema conversion 或改走 App Server spike
+- [x] 4.6 驗證 permission event 可取得 canonical server/tool identity；若只能模糊比對則停止正式 adapter 開發
+- [x] 4.7 記錄 ACP 與直接 Codex App Server stdio 的差異，確認正式 provider protocol
 
 ## 5. Codex Provider Adapter（TDD）
 

--- a/openspec/changes/add-codex-acp-failover/tasks.md
+++ b/openspec/changes/add-codex-acp-failover/tasks.md
@@ -46,16 +46,16 @@
 
 ## 5. Codex Provider Adapter（TDD）
 
-- [ ] 5.1 先新增 Codex provider contract tests，涵蓋完整 `call_ai()` kwargs
-- [ ] 5.2 實作 per-request session workdir，沿用主系統 MCP merge/filter 與 env injection 規則
-- [ ] 5.3 實作 canonical permission guard；同名、Unknown、concurrent 或缺少 namespace 時 fail closed
-- [ ] 5.4 實作 terminal/file-write/native image deny，圖片必須走允許的 CTOS MCP 工具
-- [ ] 5.5 實作 tool-call limit、全域生圖上限、callbacks、tool timings 與 callback error isolation
-- [ ] 5.6 實作 message/tool event 去重、partial result、token、actual model 與 bounded stderr diagnostics
-- [ ] 5.7 實作 timeout cancel、disconnect、process terminate/kill 與所有路徑 cleanup tests
-- [ ] 5.8 實作 concurrency semaphore、queue timeout 與 provider circuit breaker
-- [ ] 5.9 新增 binary missing、auth expired、protocol mismatch、MCP startup failure、overload tests
-- [ ] 5.10 確認 Codex provider 核心安全分支皆有明確測試，不能只依 aggregate coverage
+- [x] 5.1 先新增 Codex provider contract tests，涵蓋完整 `call_ai()` kwargs
+- [x] 5.2 實作 per-request session workdir，沿用主系統 MCP merge/filter 與 env injection 規則
+- [x] 5.3 實作 canonical permission guard；同名、Unknown、concurrent 或缺少 namespace 時 fail closed
+- [x] 5.4 實作 terminal/file-write/native image deny，圖片必須走允許的 CTOS MCP 工具
+- [x] 5.5 實作 tool-call limit、全域生圖上限、callbacks、tool timings 與 callback error isolation
+- [x] 5.6 實作 message/tool event 去重、partial result、token、actual model 與 bounded stderr diagnostics
+- [x] 5.7 實作 timeout cancel、disconnect、process terminate/kill 與所有路徑 cleanup tests
+- [x] 5.8 實作 concurrency semaphore、queue timeout 與 provider circuit breaker
+- [x] 5.9 新增 binary missing、auth expired、protocol mismatch、MCP startup failure、overload tests
+- [x] 5.10 確認 Codex provider 核心安全分支皆有明確測試，不能只依 aggregate coverage
 
 ## 6. 部署與 Readiness
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,160 @@
     "": {
       "name": "ching-tech-os",
       "version": "1.0.0",
+      "dependencies": {
+        "@agentclientprotocol/codex-acp": "1.1.9",
+        "@openai/codex": "0.146.0"
+      },
       "devDependencies": {
         "esbuild": "^0.25.0"
+      }
+    },
+    "node_modules/@agentclientprotocol/codex-acp": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/codex-acp/-/codex-acp-1.1.9.tgz",
+      "integrity": "sha512-T78vetAQJ+XpP+0zT18ceEPTD10tqYvouDh0ht7mpCQjXuW3Vm5MzcuMRJMVBA2MwfCvGFXfOhGA7ogMSeOpFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "^1.3.0",
+        "@openai/codex": "^0.145.0",
+        "diff": "^9.0.0",
+        "open": "^11.0.0",
+        "vscode-jsonrpc": "^9.0.1",
+        "zod": "^4.0.0"
+      },
+      "bin": {
+        "codex-acp": "dist/index.js"
+      }
+    },
+    "node_modules/@agentclientprotocol/codex-acp/node_modules/@openai/codex": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0.tgz",
+      "integrity": "sha512-/PSPSFujjjmiyVFvG2yu/grOFhsWdokTH8t2KGWhXSo/M5n/dIDsnbsnO82/7bLtIoDuzQf7ATBUMWqPWQINlQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.145.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.145.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.145.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.145.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.145.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.145.0-win32-x64"
+      }
+    },
+    "node_modules/@agentclientprotocol/codex-acp/node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.145.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-darwin-arm64.tgz",
+      "integrity": "sha512-h6aQ0UxnaP8mIM/9/qPAH9MNkRliJo88toq1T36IxNM2L5JSU0TFamu+MZn7YkFgDsrp0RfiI+97Tm8AVVxqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@agentclientprotocol/codex-acp/node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.145.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-darwin-x64.tgz",
+      "integrity": "sha512-FCYzVKCa9VoLtg9gVyzKpqylonfgZrfcWZN6HsXAZPeuo8CukdMqdgTUOhDn2V6h3MbqS0z6VqQVKUllN/yKhA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@agentclientprotocol/codex-acp/node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.145.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-linux-arm64.tgz",
+      "integrity": "sha512-8OLcPXaAol/FOrRoDxWhIiHIFa73KRsM41EKocjRZOwiT4TcelzJWn3dHyiuSb7teWF25rrslvSPyvhULYRRCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@agentclientprotocol/codex-acp/node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.145.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-linux-x64.tgz",
+      "integrity": "sha512-u8w8LLv3DvsfrDCoswLIemZ0SoNEXyi511WsfFsSiYUazk9qMsB/NtU8N9vhAfN7mZAxLFoMex4v66JjHuZWwA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@agentclientprotocol/codex-acp/node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.145.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-win32-arm64.tgz",
+      "integrity": "sha512-sub61rjEFevi1i3Zx7nAd4JM5XxoNFqMqFc5LfTo2xSI8ixHjFvEYDFDXwXOftT04n3Ht1Wh271ioUZpDiEjEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@agentclientprotocol/codex-acp/node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.145.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-win32-x64.tgz",
+      "integrity": "sha512-u0h9lk094CaXRSqE34SBW2dRaQTPa6fASXqehczWH9QdsU62mBsiAgAdp6tCG4i+YzPmmhjD8FdXNnYGNmwuMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.3.0.tgz",
+      "integrity": "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -453,6 +605,192 @@
         "node": ">=18"
       }
     },
+    "node_modules/@openai/codex": {
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0.tgz",
+      "integrity": "sha512-yG3sPWNda/2YAIQIDq9MrrjoCTIQ7rxYM5IasrG3VBcuhCLTkgeg/JzqmJq1V98RE4MJ5jCxDXXQlOjrditFRw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.146.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.146.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.146.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.146.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.146.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.146.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-darwin-arm64.tgz",
+      "integrity": "sha512-nb61yX4r5L6Z0dlC4o3u0GAK1YCd4TUvjaB382bajDoh84V+uv2hTBIVZ++fgXWV9yoeuNrNnNcn7GoTGOe2Tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-darwin-x64.tgz",
+      "integrity": "sha512-hTQR5jy/ObfTf1MDnuJCZJAe+SljKE8DDwQWN6lDFgjsPhMQz852U2tILt8Ei+G5GkQSzemHYKl2AYPwW0Y5xw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-linux-arm64.tgz",
+      "integrity": "sha512-qiYDxkkEFnXG7joadJW6Q+XcgyDXCpGdpa9nk/c+i0gEomur1j7bHvx12NfWWCF/y8Tqri6ay+FLuC2MjdehtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-linux-x64.tgz",
+      "integrity": "sha512-fswvyGprAPCMiOEue/7MKMk7pCjh9kZIJfJX5i9atmfnmGYbYCcUhZsEH9LEP0+0t5xyPqDbfNXY7NSxIVuXxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-win32-arm64.tgz",
+      "integrity": "sha512-EW6zdjDe+SLX2Iw+xymJ5+Pz2+DGexdstfFHXh4Ub+TfJsQPiMjGfZfNaoWgdJ2FsqSIzVKu2+G0KCMGYz2W8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-win32-x64.tgz",
+      "integrity": "sha512-b3lxMYeR0+IhstNo4JjX1P9cPc1xwVcCVkPd1lD1wpWPJ0SBhpIkPczwbu3ZRkJcdyl342+rgyf4DUrbZLdrGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -493,6 +831,144 @@
         "@esbuild/win32-arm64": "0.25.12",
         "@esbuild/win32-ia32": "0.25.12",
         "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,9 @@
   },
   "devDependencies": {
     "esbuild": "^0.25.0"
+  },
+  "dependencies": {
+    "@agentclientprotocol/codex-acp": "1.1.9",
+    "@openai/codex": "0.146.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "build": "node scripts/build-frontend.mjs",
     "build:watch": "node scripts/build-frontend.mjs --watch",
     "test:backend": "cd backend && uv run pytest",
-    "test:backend:cov": "cd backend && uv run pytest --cov=src/ching_tech_os --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html --cov-fail-under=90",
-    "test:backend:cov:next": "cd backend && uv run pytest --cov=src/ching_tech_os --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html --cov-fail-under=91",
+    "test:backend:cov": "cd backend && uv run pytest --cov=src/ching_tech_os --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html --cov-fail-under=85",
+    "test:backend:cov:next": "cd backend && uv run pytest --cov=src/ching_tech_os --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html --cov-fail-under=86",
+    "test:backend:cov:target": "cd backend && uv run pytest --cov=src/ching_tech_os --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html --cov-fail-under=90",
     "ci:check": "npm run build && npm run test:backend:cov"
   },
   "devDependencies": {


### PR DESCRIPTION
## 問題

python-telegram-bot 透過 httpx 長輪詢 `getUpdates`,每 ~30 秒一筆,**每一筆都把 bot token 明文寫進 `/var/log/syslog` 與 systemd journal**。

實測近 24 小時:

| | 行數 | 占比 |
|---|---|---|
| 本服務 log 總計 | 2992 | |
| 其中 httpx `HTTP Request` | 2851 | 95.3% |
| 其中 telegram `getUpdates` | 2851 | 全部 |
| 其他 API 呼叫 | 0 | |

所以這些行同時是兩個問題:token 外洩,以及把真正有用的 141 行應用層 log 埋在雜訊底下。

## 為什麼是掛 filter,不是把 httpx 調成 WARNING

httpx 在專案裡有 12 個模組在用(clawhub、skillhub、presentation、claude_usage、codex_image、media_tools ...)。調等級會連帶失去那些模組「打去哪、回什麼碼」的紀錄,那是除錯時真正要看的東西。

掛 filter 可以只精準拿掉輪詢雜訊,其餘完整保留:

- 丟掉含 `getUpdates` 的紀錄
- 其餘把 `bot<數字>:<token>` 遮成 `bot***`,保留 INFO 等級與完整 URL、狀態碼

## 驗證

全套測試:**1378 passed, 13 skipped**(唯一 warning 是既有的 `datetime.utcnow()` deprecation,與本次無關)。

正式環境重啟後,新行程的 log:

```
總行數:              52
getUpdates 行:        0
含明文 token 的行:     0
```

診斷價值保留 —— 這些照樣看得到:

```
HTTP Request: POST https://api.telegram.org/bot***/getMe         "HTTP/1.1 200 OK"
HTTP Request: POST https://api.telegram.org/bot***/deleteWebhook "HTTP/1.1 200 OK"
HTTP Request: POST https://api.telegram.org/bot***/sendMessage   "HTTP/1.1 200 OK"
```

## 範圍限制

- filter 掛在 `httpx` logger 上,只涵蓋 httpx 發出的紀錄。若日後有別的函式庫也印出 token 需另外處理(logging 的 filter 不會沿著 propagate 套用到子 logger 的紀錄)。
- **只擋未來**。既有 log 裡的 token(當時 syslog 1352 筆、近 7 天 journal 19469 筆)未清理 —— 評估後認為只在內網、`adm` 群組僅 `ct`,風險可接受,等 logrotate 自然汰換。token 亦不撤換。

🤖 Generated with [Claude Code](https://claude.com/claude-code)